### PR TITLE
feat(tradeup): add basic TradeUp platform

### DIFF
--- a/include/optionx_cpp/data/trading/enums.hpp
+++ b/include/optionx_cpp/data/trading/enums.hpp
@@ -18,7 +18,8 @@ namespace optionx {
         UNKNOWN = 0,    ///< Unknown platform type
         SIMULATOR,      ///< Simulation platform
         CLICKER,        ///< Click-based trading platform
-        INTRADE_BAR     ///< Intrade Bar platform
+        INTRADE_BAR,    ///< Intrade Bar platform
+        TRADEUP         ///< TradeUp platform
     };
 
 	/// \brief Converts PlatformType to its string representation.
@@ -26,9 +27,9 @@ namespace optionx {
     /// \param mode Format mode (0-uppercase, 1-lowercase, 2-title case).
     /// \return Constant reference to the corresponding string.
 	inline const std::string &to_str(PlatformType value, int mode = 0) noexcept {
-        static const std::vector<std::string> str_data_0 = {"UNKNOWN", "SIMULATOR", "CLICKER", "INTRADE_BAR"};
-        static const std::vector<std::string> str_data_1 = {"unknown", "simulator", "clicker", "intrade.bar"};
-        static const std::vector<std::string> str_data_2 = {"Unknown", "Simulator", "Clicker", "Intrade Bar"};
+        static const std::vector<std::string> str_data_0 = {"UNKNOWN", "SIMULATOR", "CLICKER", "INTRADE_BAR", "TRADEUP"};
+        static const std::vector<std::string> str_data_1 = {"unknown", "simulator", "clicker", "intrade.bar", "tradeup"};
+        static const std::vector<std::string> str_data_2 = {"Unknown", "Simulator", "Clicker", "Intrade Bar", "TradeUp"};
 
         switch (mode) {
             case 0: return str_data_0[static_cast<size_t>(value)];
@@ -48,7 +49,8 @@ namespace optionx {
             {"UNKNOWN",                 PlatformType::UNKNOWN,     },
             {"SIMULATOR",               PlatformType::SIMULATOR,   },
             {"CLICKER",                 PlatformType::CLICKER,     },
-            {"INTRADE_BAR",             PlatformType::INTRADE_BAR, }
+            {"INTRADE_BAR",             PlatformType::INTRADE_BAR, },
+            {"TRADEUP",                 PlatformType::TRADEUP,     }
         };
         auto it = str_data.find(utils::to_upper_case(str));
         if (it != str_data.end()) {

--- a/include/optionx_cpp/platforms.hpp
+++ b/include/optionx_cpp/platforms.hpp
@@ -11,5 +11,6 @@
 #include "modules.hpp"
 #include "platforms/common/BaseTradingPlatform.hpp"
 #include "platforms/IntradeBarPlatform.hpp"
+#include "platforms/TradeUpPlatform.hpp"
 
 #endif // _OPTIONX_PLATFORMS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_PLATFORM_API_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_PLATFORM_API_HPP_INCLUDED
+
+/// \file TradeUpPlatform.hpp
+/// \brief Defines the TradeUpPlatform class implementing TradeUp broker API.
+
+#include "platforms/common/BaseTradingPlatform.hpp"
+#include "TradeUpPlatform/AuthData.hpp"
+#include "TradeUpPlatform/AccountInfoData.hpp"
+#include "TradeUpPlatform/http_utils.hpp"
+#include "TradeUpPlatform/http_parsers.hpp"
+#include "TradeUpPlatform/HttpClientModule.hpp"
+#include "TradeUpPlatform/AuthManager.hpp"
+#include "TradeUpPlatform/BalanceManager.hpp"
+
+namespace optionx::platforms {
+
+    /// \class TradeUpPlatform
+    /// \brief Minimal platform implementation for TradeUp broker.
+    class TradeUpPlatform final : public BaseTradingPlatform {
+    public:
+        TradeUpPlatform()
+            : BaseTradingPlatform(std::make_shared<tradeup::AccountInfoData>()),
+              m_http_client(*this),
+              m_auth_manager(*this, m_http_client, m_account_info),
+              m_balance_manager(*this, m_http_client, m_account_info) {
+        }
+
+        virtual ~TradeUpPlatform() = default;
+
+        bool place_trade(std::unique_ptr<TradeRequest> trade_request) override {
+            (void)trade_request;
+            return false;
+        }
+
+        PlatformType platform_type() const override {
+            return PlatformType::TRADEUP;
+        }
+
+    private:
+        tradeup::HttpClientModule m_http_client;
+        tradeup::AuthManager      m_auth_manager;
+        tradeup::BalanceManager   m_balance_manager;
+    };
+
+} // namespace optionx::platforms
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_PLATFORM_API_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/AccountInfoData.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/AccountInfoData.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_ACCOUNT_INFO_DATA_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_ACCOUNT_INFO_DATA_HPP_INCLUDED
+
+/// \file AccountInfoData.hpp
+/// \brief Contains the AccountInfoData class for TradeUp platform account information.
+
+#include "optionx_cpp/data/account/BaseAccountInfoData.hpp"
+#include "optionx_cpp/data/trading/enums.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    /// \class AccountInfoData
+    /// \brief Account information data for TradeUp platform.
+    class AccountInfoData : public BaseAccountInfoData {
+    public:
+        std::string   user_id;                      ///< User identifier
+        double        balance      = 0.0;           ///< Account balance
+        CurrencyType  currency     = CurrencyType::UNKNOWN; ///< Account currency
+        AccountType   account_type = AccountType::UNKNOWN;  ///< Account type
+        bool          connect      = false;         ///< Connection status flag
+
+        const PlatformType platform_type() const override { return PlatformType::TRADEUP; }
+
+        std::unique_ptr<BaseAccountInfoData> clone_unique() const override {
+            return std::make_unique<AccountInfoData>(*this);
+        }
+
+        std::shared_ptr<BaseAccountInfoData> clone_shared() const override {
+            return std::make_shared<AccountInfoData>(*this);
+        }
+
+    protected:
+        bool get_info_bool(const AccountInfoRequest& request) const override {
+            if (request.type == AccountInfoType::CONNECTION_STATUS) return connect;
+            return false;
+        }
+
+        int64_t get_info_int64(const AccountInfoRequest& request) const override {
+            switch (request.type) {
+                case AccountInfoType::BALANCE: return static_cast<int64_t>(balance);
+                case AccountInfoType::PLATFORM_TYPE: return static_cast<int64_t>(platform_type());
+                case AccountInfoType::ACCOUNT_TYPE: return static_cast<int64_t>(account_type);
+                case AccountInfoType::CURRENCY: return static_cast<int64_t>(currency);
+                default: break;
+            }
+            return 0;
+        }
+
+        double get_info_f64(const AccountInfoRequest& request) const override {
+            if (request.type == AccountInfoType::BALANCE) return balance;
+            return 0.0;
+        }
+
+        std::string get_info_str(const AccountInfoRequest& request) const override {
+            switch (request.type) {
+                case AccountInfoType::USER_ID: return user_id;
+                case AccountInfoType::BALANCE: return std::to_string(balance);
+                case AccountInfoType::PLATFORM_TYPE: return to_str(platform_type());
+                case AccountInfoType::ACCOUNT_TYPE: return to_str(account_type);
+                case AccountInfoType::CURRENCY: return to_str(currency);
+                default: break;
+            }
+            return {};
+        }
+    };
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_ACCOUNT_INFO_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/AuthData.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/AuthData.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_AUTH_DATA_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_AUTH_DATA_HPP_INCLUDED
+
+/// \file AuthData.hpp
+/// \brief Contains the AuthData class for TradeUp platform authorization.
+
+#include <nlohmann/json.hpp>
+#include "optionx_cpp/data/account/IAuthData.hpp"
+#include "optionx_cpp/data/trading/enums.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    /// \class AuthData
+    /// \brief Represents authorization data for the TradeUp platform.
+    class AuthData : public IAuthData {
+    public:
+        std::string login;               ///< User login (email)
+        std::string password;            ///< Account password
+        bool        stay_logged = true;  ///< Flag to keep session logged in
+        std::string user_agent;          ///< User agent string
+        std::string accept_language;     ///< Accept-Language header
+        std::string host;                ///< API host
+
+        AuthData()
+            : user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"),
+              accept_language("ru,ru-RU;q=0.9,en;q=0.8,en-US;q=0.7"),
+              host("https://tradeup.net") {}
+
+        /// \brief Sets login and password for authorization.
+        void set_login_password(const std::string& l, const std::string& p) {
+            login = l;
+            password = p;
+        }
+
+        void to_json(nlohmann::json& j) const override {
+            j = nlohmann::json{
+                {"login", login},
+                {"password", password},
+                {"stay_logged", stay_logged},
+                {"host", host},
+                {"user_agent", user_agent},
+                {"accept_language", accept_language}
+            };
+        }
+
+        void from_json(const nlohmann::json& j) override {
+            login = j.value("login", "");
+            password = j.value("password", "");
+            stay_logged = j.value("stay_logged", true);
+            host = j.value("host", host);
+            user_agent = j.value("user_agent", user_agent);
+            accept_language = j.value("accept_language", accept_language);
+        }
+
+        std::pair<bool, std::string> validate() const override {
+            if (login.empty()) return {false, "Login is empty"};
+            if (password.empty()) return {false, "Password is empty"};
+            return {true, std::string()};
+        }
+
+        std::unique_ptr<IAuthData> clone_unique() const override {
+            return std::make_unique<AuthData>(*this);
+        }
+
+        std::shared_ptr<IAuthData> clone_shared() const override {
+            return std::make_shared<AuthData>(*this);
+        }
+
+        PlatformType platform_type() const override {
+            return PlatformType::TRADEUP;
+        }
+    };
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_AUTH_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/AuthManager.hpp
@@ -1,0 +1,137 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_AUTH_MANAGER_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_AUTH_MANAGER_HPP_INCLUDED
+
+/// \file AuthManager.hpp
+/// \brief Handles authentication for the TradeUp platform.
+
+#include "optionx_cpp/platforms/TradeUpPlatform/AuthData.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/HttpClientModule.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/AccountInfoData.hpp"
+#include "optionx_cpp/data/events/AuthDataEvent.hpp"
+#include "optionx_cpp/data/events/ConnectRequestEvent.hpp"
+#include "optionx_cpp/data/events/DisconnectRequestEvent.hpp"
+#include "optionx_cpp/data/events/BalanceRequestEvent.hpp"
+#include "optionx_cpp/data/events/AccountInfoUpdateEvent.hpp"
+#include "optionx_cpp/platforms/common/BaseTradingPlatform.hpp"
+#include "optionx_cpp/modules/BaseModule.hpp"
+#include "optionx_cpp/utils/tasks/TaskManager.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    /// \class AuthManager
+    class AuthManager final : public modules::BaseModule {
+    public:
+        AuthManager(BaseTradingPlatform& platform,
+                    HttpClientModule& http_client,
+                    std::shared_ptr<BaseAccountInfoData> account_info)
+            : BaseModule(platform.event_bus()),
+              m_http_client(http_client),
+              m_account_info(std::move(account_info)) {
+            subscribe<events::AuthDataEvent>();
+            subscribe<events::ConnectRequestEvent>();
+            subscribe<events::DisconnectRequestEvent>();
+            platform.register_module(this);
+        }
+
+        void on_event(const utils::Event* const event) override;
+        void process() override {}
+        void shutdown() override {}
+
+    private:
+        HttpClientModule& m_http_client;
+        std::shared_ptr<BaseAccountInfoData> m_account_info;
+        std::shared_ptr<AuthData> m_auth_data;
+
+        void handle_event(const events::AuthDataEvent& event);
+        void handle_event(const events::ConnectRequestEvent& event);
+        void handle_event(const events::DisconnectRequestEvent& event);
+
+        void perform_login(connection_callback_t callback);
+        std::shared_ptr<AccountInfoData> get_account_info();
+    };
+
+    inline void AuthManager::on_event(const utils::Event* const event) {
+        if (const auto* msg = dynamic_cast<const events::AuthDataEvent*>(event)) {
+            handle_event(*msg);
+        } else if (const auto* msg = dynamic_cast<const events::ConnectRequestEvent*>(event)) {
+            handle_event(*msg);
+        } else if (const auto* msg = dynamic_cast<const events::DisconnectRequestEvent*>(event)) {
+            handle_event(*msg);
+        }
+    }
+
+    inline void AuthManager::handle_event(const events::AuthDataEvent& event) {
+        if (auto data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
+            auto [ok, msg] = data->validate();
+            if (ok) m_auth_data = std::move(data);
+            if (m_auth_data) m_auth_data->dispatch_callbacks(ok, msg);
+        }
+    }
+
+    inline std::shared_ptr<AccountInfoData> AuthManager::get_account_info() {
+        return std::dynamic_pointer_cast<AccountInfoData>(m_account_info);
+    }
+
+    inline void AuthManager::perform_login(connection_callback_t callback) {
+        if (!m_auth_data) {
+            if (callback) callback({false, "Auth data not set", nullptr});
+            return;
+        }
+
+        kurlyk::Headers headers = {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"}
+        };
+        nlohmann::json body = {
+            {"password", m_auth_data->password},
+            {"stayLogged", m_auth_data->stay_logged},
+            {"login", m_auth_data->login}
+        };
+        auto future = m_http_client.get_http_client().post(
+            "/trade-api/api/signin",
+            kurlyk::QueryParams(),
+            headers,
+            body.dump(),
+            m_http_client.get_rate_limit(RateLimitType::AUTH)
+        );
+        m_http_client.add_http_request_task(std::move(future), [this, callback](kurlyk::HttpResponsePtr response){
+            if (!validate_response(response)) {
+                if (callback) callback({false, "HTTP error", m_auth_data ? m_auth_data->clone_unique() : nullptr});
+                return;
+            }
+            std::string token, uid;
+            if (!parse_signin_response(response->content, token, uid)) {
+                if (callback) callback({false, "Parse error", m_auth_data ? m_auth_data->clone_unique() : nullptr});
+                return;
+            }
+            m_http_client.set_auth_token(token);
+            std::string cookies = "nip-auth-token=" + token;
+            std::string session = extract_cookie(response->headers, "multibrand_session");
+            if (!session.empty()) cookies += "; multibrand_session=" + session;
+            m_http_client.set_session_cookie(cookies);
+
+            // Request balance after login
+            notify(events::BalanceRequestEvent());
+            if (callback) callback({true, std::string(), m_auth_data ? m_auth_data->clone_unique() : nullptr});
+        });
+    }
+
+    inline void AuthManager::handle_event(const events::ConnectRequestEvent& event) {
+        perform_login(event.callback);
+    }
+
+    inline void AuthManager::handle_event(const events::DisconnectRequestEvent& event) {
+        auto info = get_account_info();
+        if (info && info->connect) {
+            info->connect = false;
+            notify(events::AccountInfoUpdateEvent(info, events::AccountInfoUpdateEvent::Status::DISCONNECTED));
+        }
+        if (event.callback) event.callback({true, std::string(), m_auth_data ? m_auth_data->clone_unique() : nullptr});
+    }
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_AUTH_MANAGER_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/BalanceManager.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/BalanceManager.hpp
@@ -1,0 +1,99 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_BALANCE_MANAGER_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_BALANCE_MANAGER_HPP_INCLUDED
+
+/// \file BalanceManager.hpp
+/// \brief Handles balance updates for the TradeUp platform.
+
+#include "optionx_cpp/platforms/TradeUpPlatform/HttpClientModule.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp"
+#include "optionx_cpp/platforms/TradeUpPlatform/AccountInfoData.hpp"
+#include "optionx_cpp/data/events/BalanceRequestEvent.hpp"
+#include "optionx_cpp/data/events/AccountInfoUpdateEvent.hpp"
+#include "optionx_cpp/modules/BaseModule.hpp"
+#include "optionx_cpp/platforms/common/BaseTradingPlatform.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    /// \class BalanceManager
+    class BalanceManager final : public modules::BaseModule {
+    public:
+        BalanceManager(BaseTradingPlatform& platform,
+                       HttpClientModule& http_client,
+                       std::shared_ptr<BaseAccountInfoData> account_info)
+            : BaseModule(platform.event_bus()),
+              m_http_client(http_client),
+              m_account_info(std::move(account_info)) {
+            subscribe<events::BalanceRequestEvent>();
+            platform.register_module(this);
+        }
+
+        void on_event(const utils::Event* const event) override;
+        void process() override {}
+        void shutdown() override {}
+
+    private:
+        HttpClientModule& m_http_client;
+        std::shared_ptr<BaseAccountInfoData> m_account_info;
+
+        void handle_event(const events::BalanceRequestEvent& event);
+        void request_balance();
+        std::shared_ptr<AccountInfoData> get_account_info();
+    };
+
+    inline void BalanceManager::on_event(const utils::Event* const event) {
+        if (const auto* msg = dynamic_cast<const events::BalanceRequestEvent*>(event)) {
+            handle_event(*msg);
+        }
+    }
+
+    inline std::shared_ptr<AccountInfoData> BalanceManager::get_account_info() {
+        return std::dynamic_pointer_cast<AccountInfoData>(m_account_info);
+    }
+
+    inline void BalanceManager::handle_event(const events::BalanceRequestEvent& event) {
+        (void)event;
+        request_balance();
+    }
+
+    inline void BalanceManager::request_balance() {
+        if (m_http_client.auth_token().empty()) return;
+        kurlyk::Headers headers = {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"Cookie", m_http_client.session_cookie()},
+            {"X-API-TOKEN", m_http_client.auth_token()}
+        };
+        auto future = m_http_client.get_http_client().post(
+            "/api/v1/info",
+            kurlyk::QueryParams(),
+            headers,
+            "{}",
+            m_http_client.get_rate_limit(RateLimitType::BALANCE)
+        );
+        m_http_client.add_http_request_task(std::move(future), [this](kurlyk::HttpResponsePtr response){
+            if (!validate_response(response)) return;
+            double bal = 0.0; CurrencyType cur = CurrencyType::UNKNOWN;
+            if (parse_info_response(response->content, bal, cur)) {
+                auto info = get_account_info();
+                if (!info) return;
+                bool was_connected = info->connect;
+                info->balance = bal;
+                info->currency = cur;
+                info->connect = true;
+                auto status = was_connected ?
+                    events::AccountInfoUpdateEvent::Status::BALANCE_UPDATED :
+                    events::AccountInfoUpdateEvent::Status::CONNECTED;
+                notify(events::AccountInfoUpdateEvent(info, status));
+                std::string session = extract_cookie(response->headers, "multibrand_session");
+                if (!session.empty()) {
+                    m_http_client.set_session_cookie("nip-auth-token=" + m_http_client.auth_token() + "; multibrand_session=" + session);
+                }
+            }
+        });
+    }
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_BALANCE_MANAGER_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/HttpClientModule.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/HttpClientModule.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_HTTP_CLIENT_MODULE_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_HTTP_CLIENT_MODULE_HPP_INCLUDED
+
+/// \file HttpClientModule.hpp
+/// \brief Defines the HTTP client module for the TradeUp platform.
+
+#include "optionx_cpp/modules/BaseHttpClientModule.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    enum class RateLimitType : uint32_t {
+        GENERAL,
+        AUTH,
+        BALANCE,
+        COUNT
+    };
+
+    /// \class HttpClientModule
+    class HttpClientModule final : public modules::BaseHttpClientModule {
+    public:
+        explicit HttpClientModule(BaseTradingPlatform& platform)
+            : modules::BaseHttpClientModule(platform.event_bus()) {
+            set_rate_limit_rpm(RateLimitType::GENERAL, 60);
+            set_rate_limit_rps(RateLimitType::AUTH, 1);
+            set_rate_limit_rps(RateLimitType::BALANCE, 1);
+            platform.register_module(this);
+        }
+
+        void set_auth_token(std::string token) { m_token = std::move(token); }
+        const std::string& auth_token() const { return m_token; }
+
+        void set_session_cookie(std::string cookie) { m_cookie = std::move(cookie); }
+        const std::string& session_cookie() const { return m_cookie; }
+
+    private:
+        std::string m_token;
+        std::string m_cookie;
+    };
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_HTTP_CLIENT_MODULE_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_HTTP_PARSERS_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_HTTP_PARSERS_HPP_INCLUDED
+
+/// \file http_parsers.hpp
+/// \brief JSON parsers for TradeUp HTTP responses.
+
+#include <nlohmann/json.hpp>
+#include "optionx_cpp/data/trading/enums.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    inline bool parse_signin_response(const std::string& content, std::string& token, std::string& user_id) {
+        try {
+            auto j = nlohmann::json::parse(content);
+            if (!j.value("success", false)) return false;
+            const auto& data = j.at("data");
+            token = data.value("token", std::string());
+            user_id = data.value("userId", std::string());
+            return !token.empty();
+        } catch (...) {
+            return false;
+        }
+    }
+
+    inline bool parse_info_response(const std::string& content, double& balance, CurrencyType& currency) {
+        try {
+            auto j = nlohmann::json::parse(content);
+            if (!j.value("success", false)) return false;
+            const auto& balances = j.at("data").at("balances");
+            if (balances.empty()) return false;
+            const auto& b = balances.at(0);
+            balance = b.value("amount", 0.0);
+            currency = optionx::to_enum<CurrencyType>(b.value("currency", "UNKNOWN"));
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_HTTP_PARSERS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_TRADEUP_HTTP_UTILS_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_TRADEUP_HTTP_UTILS_HPP_INCLUDED
+
+/// \file http_utils.hpp
+/// \brief Utility helpers for TradeUp HTTP responses.
+
+#include <string>
+#include <algorithm>
+#include "optionx_cpp/data/account/ConnectionResult.hpp"
+#include "optionx_cpp/utils/string_utils.hpp"
+
+namespace optionx::platforms::tradeup {
+
+    inline bool validate_status(const kurlyk::HttpResponsePtr& response) {
+        return response && response->status_code == 200;
+    }
+
+    inline bool validate_response(const kurlyk::HttpResponsePtr& response) {
+        return validate_status(response);
+    }
+
+    /// \brief Extracts a cookie value from HTTP headers.
+    inline std::string extract_cookie(const kurlyk::Headers& headers, const std::string& name) {
+        for (const auto& h : headers) {
+            std::string key = h.first;
+            std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c){ return std::tolower(c); });
+            if (key == "set-cookie") {
+                auto pos = h.second.find(name + "=");
+                if (pos != std::string::npos) {
+                    pos += name.size() + 1;
+                    auto end = h.second.find(';', pos);
+                    return h.second.substr(pos, end - pos);
+                }
+            }
+        }
+        return {};
+    }
+
+} // namespace optionx::platforms::tradeup
+
+#endif // _OPTIONX_PLATFORMS_TRADEUP_HTTP_UTILS_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- introduce TradeUpPlatform with HTTP client, auth and balance managers
- extend PlatformType enum for TradeUp broker

## Testing
- `cmake -DBUILD_DEPS=ON -DBUILD_TESTS=ON ..` (fails: The source directory /workspace/optionx_cpp/libs/AES does not contain a CMakeLists.txt file)


------
https://chatgpt.com/codex/tasks/task_e_6895fd1c7eb0832c8fb5177ca7bb32f7