### PR TITLE
[codex] Avoid duplicate test target names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,37 @@ if(BUILD_TESTS)
     )
     add_custom_target(project_headers SOURCES ${PROJECT_HEADERS})
 
-    file(GLOB_RECURSE TEST_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cpp)
+    file(GLOB_RECURSE TEST_SOURCES
+        CONFIGURE_DEPENDS
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+        tests/*.cpp
+    )
+    list(SORT TEST_SOURCES)
+
+    set(TEST_SOURCE_STEMS)
+    foreach(test_src ${TEST_SOURCES})
+        get_filename_component(test_stem "${test_src}" NAME_WE)
+        list(APPEND TEST_SOURCE_STEMS "${test_stem}")
+    endforeach()
 
     foreach(test_src ${TEST_SOURCES})
-        get_filename_component(test_name ${test_src} NAME_WE)
+        get_filename_component(test_name "${test_src}" NAME_WE)
+        set(test_name_count 0)
+        foreach(test_stem ${TEST_SOURCE_STEMS})
+            if(test_stem STREQUAL test_name)
+                math(EXPR test_name_count "${test_name_count} + 1")
+            endif()
+        endforeach()
+
+        if(test_name_count GREATER 1)
+            set(test_name "${test_src}")
+            string(REGEX REPLACE "\\.[^.]*$" "" test_name "${test_name}")
+            string(MAKE_C_IDENTIFIER "${test_name}" test_name)
+        endif()
+
+        if(TARGET ${test_name})
+            message(FATAL_ERROR "Duplicate test target name '${test_name}' from '${test_src}'")
+        endif()
 
         add_executable(${test_name} ${test_src})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ if(BUILD_TESTS)
         list(APPEND TEST_SOURCE_STEMS "${test_stem}")
     endforeach()
 
+    set(TEST_TARGET_NAMES)
+    set(TEST_TARGET_SOURCES)
+
+    # Keep existing basename targets while they are unique. If recursive
+    # discovery finds duplicate stems, use path-derived names for that stem.
     foreach(test_src ${TEST_SOURCES})
         get_filename_component(test_name "${test_src}" NAME_WE)
         set(test_name_count 0)
@@ -170,9 +175,18 @@ if(BUILD_TESTS)
             string(MAKE_C_IDENTIFIER "${test_name}" test_name)
         endif()
 
-        if(TARGET ${test_name})
-            message(FATAL_ERROR "Duplicate test target name '${test_name}' from '${test_src}'")
+        list(FIND TEST_TARGET_NAMES "${test_name}" existing_test_index)
+        if(NOT existing_test_index EQUAL -1)
+            list(GET TEST_TARGET_SOURCES ${existing_test_index} existing_test_src)
+            message(FATAL_ERROR "Duplicate test target name '${test_name}' from '${test_src}' conflicts with '${existing_test_src}'")
         endif()
+
+        if(TARGET ${test_name})
+            message(FATAL_ERROR "Test target name '${test_name}' from '${test_src}' conflicts with an existing CMake target")
+        endif()
+
+        list(APPEND TEST_TARGET_NAMES "${test_name}")
+        list(APPEND TEST_TARGET_SOURCES "${test_src}")
 
         add_executable(${test_name} ${test_src})
 


### PR DESCRIPTION
﻿## Summary

Fix recursive test discovery so CMake does not generate duplicate targets when different test files share the same basename.

## Details

- Keep the existing target name for tests whose basename is unique.
- Use a path-derived C identifier when duplicate basenames are detected.
- Sort discovered test sources for stable target generation.
- Add `CONFIGURE_DEPENDS` so CMake notices added or removed test sources.
- Fail configure explicitly if normalized test target names still collide, and show both conflicting source paths.
- Document the naming policy in the CMake block so basename preservation is clearly intentional.

## Validation

- Synthetic duplicate-basename check with temporary files:
  - `tests/cmake_collision_alpha/duplicate_name_test.cpp`
  - `tests/cmake_collision_beta/duplicate_name_test.cpp`
- `cmake -G "MinGW Makefiles" -S . -B build-codex-collision -DBUILD_DEPS=OFF -DBUILD_TESTS=ON -DDEPS_BUILD_DIR="$PWD/build-codex"`
- `cmake --build build-codex-collision --target help | Select-String -Pattern "tests_cmake_collision_(alpha|beta)_duplicate_name_test|duplicate_name_test"`
- `cmake --build build-codex-collision --target tests_cmake_collision_alpha_duplicate_name_test -- -j1`
- `cmake --build build-codex-collision --target tests_cmake_collision_beta_duplicate_name_test -- -j1`
- Removed the temporary collision files and `build-codex-collision` after the check.
- `cmake -G "MinGW Makefiles" -S . -B build-codex -DBUILD_DEPS=ON -DBUILD_TESTS=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"`
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1`

Notes: the final build still emits external MinGW/libmdbx warnings around `%zu` formatting; they are unrelated to this CMake target naming change.