### PR TITLE
refactor(trading): consolidate trade record close time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
   публичная поверхность, основные домены и поток выполнения.
 - [Platform API guide](guides/platform-api-guide.md) - практический справочник
   по платформам, модулям, событиям, DTO, storage и bridge API.
+- [API and header contracts](guides/api-and-header-contracts.md) - публичный
+  API, include-модель, typed broker results, trade result/history contracts.
 - [Codebase orientation](guides/codebase-orientation.md) - карта проекта,
   DDD-слои, зависимости, расширение и безопасные точки входа.
 - [Build and test](guides/build-and-test.md) - CMake options, зависимости,
@@ -20,16 +22,22 @@
   task scheduling, HTTP/WebSocket, trade queue, session DB и ограничения.
 - [Coding style](guides/coding-style.md) - naming, namespace, Doxygen,
   обработка ошибок, ownership и header-only правила.
+- [Git workflow](guides/git-workflow.md) - branch policy, PR-only workflow,
+  branch naming и проверки перед PR.
 - [Commit conventions](guides/commit-conventions.md) - формат коммитов, если
   пользователь просит создать commit.
 
 ## Critical Defaults
 
 - Перед правками проверь `git status --short` и не перетирай чужие изменения.
+- Не коммить напрямую в `main`; создай отдельную ветку и PR, если пользователь
+  явно не попросил прямой commit в `main`.
 - Для поиска по репозиторию используй `rg` / `rg --files`.
 - Держи библиотеку header-only, если задача явно не требует нового `.cpp`.
 - Для публичных data/module/platform domains используй ближайший aggregate
   include point вместо ручного восстановления порядка зависимостей в leaf headers.
+- Внутри `include/optionx_cpp` не подключай headers через `"optionx_cpp/..."`;
+  используй локальные пути от `include/optionx_cpp`, например `"data/..."`.
 - Проект ориентирован на C++17 и CMake `>= 3.18`.
 - Переиспользуй `utils::EventBus`, `utils::EventMediator`, `utils::TaskManager`
   и `Base*Module` вместо локальных аналогов pub-sub, loop и task queue.

--- a/examples/trade_record_db_example.cpp
+++ b/examples/trade_record_db_example.cpp
@@ -17,7 +17,7 @@ optionx::TradeRecord make_open_record(const optionx::TradeRequest& request, std:
     record.place_date = timestamp_ms - 25;
     record.send_date = timestamp_ms - 10;
     record.open_date = timestamp_ms;
-    record.expiry_date = timestamp_ms + request.duration * 1000;
+    record.close_date = timestamp_ms + request.duration * 1000;
     record.trade_state = optionx::TradeState::IN_PROGRESS;
     record.live_state = optionx::TradeState::IN_PROGRESS;
     record.option_id = 123456;

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -1,0 +1,222 @@
+# API And Header Contracts
+
+Этот документ фиксирует публичный контракт `optionx_cpp`: как подключаются
+заголовки, где проходит граница public API, как устроены typed broker responses
+и какие DTO использовать для проверки результата и выгрузки истории сделок.
+
+Открывай его перед изменениями в `include/optionx_cpp/*.hpp`,
+`platforms/common/BaseTradingPlatform.hpp`, `data/trading/*`,
+`platforms/*/RequestManager.hpp` и broker history/result flows.
+
+## Public Include Contract
+
+Для внешнего пользователя публичный include contract остается классическим:
+
+```cpp
+#include <optionx_cpp/optionx.hpp>
+#include <optionx_cpp/data.hpp>
+#include <optionx_cpp/platforms.hpp>
+#include <optionx_cpp/platforms/IntradeBarPlatform.hpp>
+```
+
+Внутри самого дерева `include/optionx_cpp` используется локальный путь от
+`include/optionx_cpp`, без публичного префикса `optionx_cpp/`:
+
+```cpp
+#include "data/trading.hpp"
+#include "utils/response_parse_utils.hpp"
+#include "storages/TradeRecordDB/TradeRecordFilterMatcher.hpp"
+```
+
+Правила:
+
+- Не используй `../` в `#include`.
+- Не используй `"optionx_cpp/..."` внутри `include/optionx_cpp`.
+- Public aggregate headers (`optionx.hpp`, `data.hpp`, `platforms.hpp`,
+  `storages.hpp`, `modules.hpp`, `utils.hpp`, `bridges.hpp`) задают публичные
+  точки подключения.
+- Domain aggregates, например `data/trading.hpp`, задают include context для
+  связанных leaf headers.
+- Leaf DTO headers не должны вручную восстанавливать весь порядок зависимостей
+  соседнего домена. Если зависимость общая для домена, держи ее в ближайшем
+  aggregate.
+- Direct leaf includes допустимы в white-box/internal tests, но они не должны
+  случайно становиться новым пользовательским include contract.
+
+Текущая CMake-сборка tests/examples добавляет два include-root:
+`include` и `include/optionx_cpp`. Первый нужен для внешнего стиля
+`<optionx_cpp/...>`, второй - для внутренних локальных путей.
+
+## Header-Only Ownership
+
+`optionx_cpp` - header-only C++17 библиотека. Большая часть публичной
+поверхности живет в headers и компилируется в translation units пользователя.
+
+Правила ownership:
+
+- Новый public header добавляй в ближайший aggregate header.
+- Internal helper не расширяет public surface без причины.
+- Template-visible implementation должна быть видна из header.
+- Свободные функции в headers должны быть `inline`, если header может
+  включаться в несколько translation units.
+- Не добавляй broad dependency в leaf header, если эта зависимость нужна только
+  implementation detail соседнего manager.
+- Публичные headers должны сохранять Doxygen `\file` и краткий `\brief`.
+
+## Public Platform API Contract
+
+`platforms::BaseTradingPlatform` - user-facing facade. Внешний код работает
+через facade и DTO, а не через platform managers.
+
+Основные public entry points:
+
+- `configure_auth(std::unique_ptr<IAuthData>)`
+- `connect(callback)` / `disconnect(callback)`
+- `place_trade(std::unique_ptr<TradeRequest>)`
+- `fetch_trade_result(TradeResultQuery, trade_result_callback_t)`
+- `fetch_trade_history(const TradeHistoryRequest&, trade_history_callback_t)`
+- `fetch_trade_history(trade_history_callback_t)`
+- `fetch_candle_data(...)`
+- `fetch_symbol_list(...)`
+- `on_trade_result()`, `on_candle_data()`, `on_tick_data()`
+- `get_info<T>(AccountInfoType)`
+
+Managers (`AuthManager`, `RequestManager`, `TradeManager`, `BalanceManager`,
+etc.) являются implementation detail конкретной платформы. Новый user-facing
+метод сначала должен появиться на facade/base contract, а затем делегироваться
+в manager.
+
+## Typed Broker Result Pattern
+
+Broker HTTP adapters используют typed result wrappers, чтобы не смешивать
+транспортную ошибку, parser failure и успешный payload.
+
+Общая форма: `platforms::ApiResult<T>`.
+
+Инварианты:
+
+- `success` говорит о результате операции.
+- `status_code` хранит HTTP status или один из sentinel values:
+  `NO_HTTP_STATUS`, `NO_RESPONSE_STATUS`.
+- `error_desc` хранит диагностический текст failure.
+- `value` хранит typed payload только для успешной операции.
+- Ошибка не должна маскироваться пустым payload, если caller должен отличать
+  "пустой успешный ответ" от "запрос не удался".
+
+Для Intrade Bar новые `RequestManager::*_result` methods оборачивают старые
+request/parser flows в typed results. Они не являются поводом менять parser
+literals или HTML constants без live evidence: broker API нестабилен, поэтому
+сохраняй то, что уже проверено.
+
+## Trade Result Query Contract
+
+`fetch_trade_result` проверяет результат одной сделки. Он предназначен для
+recovery-сценария: бот мог открыть сделку, сохранить промежуточное состояние,
+перезапуститься и позже восстановить финальный результат.
+
+DTO:
+
+- `TradeResultQuery` - входной запрос.
+- `TradeResult` - заполняемый результат одной сделки.
+
+Контракт:
+
+- Broker trade identity может быть числом, строкой или hash у разных брокеров.
+  Текущий Intrade Bar использует `broker_option_id`.
+- Не передавай весь `TradeRequest`, если для проверки результата достаточно
+  broker id и минимального контекста результата.
+- `TradeResult` сохраняет local `trade_id`, account/currency, amount и open
+  timing/price, если caller их знает.
+- Если платформе не хватает входных данных для корректной классификации
+  результата, она должна вернуть failure/diagnostic, а не молча угадать.
+
+## Trade History Contract
+
+`fetch_trade_history` выгружает историю закрытых сделок аккаунта как массив
+`TradeRecord`.
+
+DTO:
+
+- `TradeHistoryRequest` - time range, selected time field, range mode, optional
+  comment.
+- `TradeHistoryResult` - `success`, `status_code`, `error_desc`, `records`.
+- `TradeRecord` - нормализованная запись сделки для storage/statistics.
+
+Почему `TradeRecord`, а не `TradeResult`:
+
+- История аккаунта является экспортом/статистикой, а не callback-результатом
+  одной активной сделки.
+- История должна совпадать с моделью storage и аналитики.
+- `TradeRecord.comment` можно использовать, чтобы пометить происхождение
+  экспортированных сделок, например `account-history-export`.
+
+Range rules:
+
+- `TradeHistoryRequest::all()` отключает client-side filtering и означает
+  "выгрузить все доступное через broker source".
+- Ranged request по умолчанию использует `TradeRecordTimeField::CLOSE_DATE`,
+  потому что это ближе всего к closed-trade statistics.
+- Caller может выбрать другой `TradeRecordTimeField`, если нужна другая
+  временная ось.
+- Записи без выбранного timestamp исключаются из ranged results.
+- `TimeRangeMode::CLOSED` включает обе границы.
+- `TimeRangeMode::HALF_OPEN` включает start и исключает stop.
+
+`TradeRecord::close_date` хранит planned or known option close timestamp. Для
+classic options это фиксированное `TradeRequest::expiry_time`, известное до
+открытия сделки. Для sprint options close time зависит от фактического
+`open_date`, поэтому обычно становится известным после открытия как
+`open_date + duration`.
+
+## Intrade Bar History Sources
+
+Source выбирается через `platforms::intrade_bar::TradeHistorySource` в
+`AuthData::trade_history_source`.
+
+Режимы:
+
+- `CSV` - использует `/stat_trade_export.php`; обычно дает лучшее финансовое
+  покрытие и более дальнюю историю.
+- `HTML` - читает authenticated main page `trade_close`, затем пагинацию через
+  `/trade_load_more2.php`; ближе к UI и содержит broker row identity, но
+  покрытие ограничено доступной HTML-пагинацией.
+- `HTML_CSV` - требует успеха обоих источников и возвращает только записи,
+  найденные в обоих. Это осознанный strict режим, а не "максимальная история".
+
+Особенности Intrade Bar:
+
+- HTML load-more endpoint следует текущему account type в broker session; он
+  не принимает независимый `account_type` в request body.
+- Перед HTML/HTML_CSV history платформа должна быть подключена к нужному
+  account type.
+- Intrade Bar closed-history sources provide a close timestamp; the adapter
+  stores it in `TradeRecord::close_date`.
+
+## New HTTP Broker Checklist
+
+Когда добавляется брокер с похожей HTTP-механикой:
+
+1. Добавь concrete platform facade на базе `BaseTradingPlatform`.
+2. Раздели auth/request/trade/balance/history managers по ответственности,
+   ориентируясь на Intrade Bar, но не копируя broker-specific quirks.
+3. Parser literals держи в platform-specific parser файле.
+4. Broker-independent raw-response helpers выноси в `utils`.
+5. RequestManager должен возвращать typed results для новых workflows.
+6. Историю аккаунта возвращай как `TradeHistoryResult` с `TradeRecord`.
+7. Проверку одной сделки возвращай через `fetch_trade_result`.
+8. Для online smoke сделай отдельную подпапку в `tests/<broker>_api`.
+9. Credentials/proxy держи только в untracked `*.local.env`.
+10. Negative-auth tests оставляй manual, если broker может заблокировать
+    аккаунт после failed login attempts.
+
+## Documentation And Evidence Rules
+
+Для broker behavior отделяй факты от предположений:
+
+- Факт: подтвержден кодом, fixture-тестом, live smoke или broker response.
+- Предположение: разумная гипотеза, но без подтверждения.
+- Не меняй parser constants только потому, что HTML/API "должен" быть другим.
+- Если reviewer сообщает потенциальный edge case, сначала классифицируй:
+  regression, real bug, low-risk hardening, или false positive.
+- Документируй intentional trade-offs рядом с кодом и в guide, если они могут
+  выглядеть как ошибка при следующем review.

--- a/guides/build-and-test.md
+++ b/guides/build-and-test.md
@@ -43,22 +43,85 @@ cmake -G "CodeBlocks - MinGW Makefiles" -S . -B build-cb
 
 ## Tests
 
-Текущие test files:
+CMake берет `tests/**/*.cpp` через `GLOB_RECURSE CONFIGURE_DEPENDS` и создает
+отдельный executable для каждого test source.
 
-- `tests/intrade_bar_platform_test.cpp`
-- `tests/intrade_ping_sweep.cpp`
-- `tests/trade_manager_test.cpp`
-- `tests/tradeup_ws_invalid_token_probe.cpp`
+Target naming:
 
-CMake берет `tests/*.cpp` и создает executable с именем файла без расширения.
-Для нового теста достаточно добавить `.cpp` в `tests`, если он использует
-существующую схему include/link.
+- Если basename уникален, target name равен имени файла без расширения:
+  `tests/trade_result_query_test.cpp` -> `trade_result_query_test`.
+- Если в разных подпапках есть одинаковый basename, для этого basename
+  используется path-derived target:
+  `tests/platforms/intrade_bar/api_response_test.cpp` ->
+  `tests_platforms_intrade_bar_api_response_test`.
+- После нормализации `MAKE_C_IDENTIFIER` CMake дополнительно проверяет
+  target-name collisions и показывает оба конфликтующих source path.
+
+Для нового теста достаточно добавить `.cpp` в `tests` или подпапку `tests/*`,
+если он использует существующую схему include/link.
+
+Полезные текущие targets:
+
+- `intrade_bar_api_response_test` - parser/typed-result fixtures Intrade Bar.
+- `intrade_bar_auth_smoke_test` - guarded online auth smoke; требует proxy.
+- `intrade_bar_smoke_cli` - ручная CLI для broker workflows.
+- `trade_result_query_test` - DTO/query behavior.
+- `trade_record_storage_test`, `trade_record_db_test`,
+  `trade_record_stats_test` - storage/statistics behavior.
+- `trade_manager_test` - trade execution lifecycle.
+- `tradeup_ws_invalid_token_probe` - TradeUp WebSocket probe.
 
 Линкуемые libs для tests в `CMakeLists.txt`: `ws2_32`, `wsock32`, `crypt32`,
 `ssl`, `crypto`, `curl`, `mdbx`, `ntdll`, `bcrypt`, `AES`, `gtest`.
 
 Compile definition: `ASIO_STANDALONE`. Для tests также задается
 `LOGIT_BASE_PATH`.
+
+## Intrade Bar Smoke CLI
+
+Живые broker workflows вынесены в `tests/intrade_bar_api`.
+
+Документы:
+
+- `tests/intrade_bar_api/README.md` - обзор smoke-подхода.
+- `tests/intrade_bar_api/CLI.md` - команды `intrade_bar_smoke_cli`.
+- `tests/intrade_bar_api/WORKFLOWS.md` - фактические HTTP sequences.
+
+Правила:
+
+- Любой автоматический credentialed broker request должен идти через proxy.
+- Credentials/proxy хранятся только в untracked `*.local.env`.
+- `OPTIONX_INTRADE_BAR_CONFIG_FILE` указывает на локальный env-файл.
+- Negative-auth сценарии не автоматизировать: broker может заблокировать вход
+  на несколько часов после failed login attempts.
+- Guarded trade commands требуют `--confirm` или
+  `OPTIONX_INTRADE_BAR_ALLOW_TRADE=1`.
+
+Пример сборки CLI:
+
+```bash
+cmake --build build-codex --target intrade_bar_smoke_cli -- -j1
+```
+
+Пример запуска с локальным config file:
+
+```powershell
+$env:OPTIONX_INTRADE_BAR_CONFIG_FILE="tests\intrade_bar_api\intrade_bar_api.local.env"
+.\build-codex\intrade_bar_smoke_cli.exe show-account
+```
+
+## Include-Contract Checks
+
+При изменении публичных aggregate headers или include policy добавляй или
+обновляй тест, который подключает intended public entry point:
+
+```cpp
+#include <optionx_cpp/data.hpp>
+#include <optionx_cpp/platforms/IntradeBarPlatform.hpp>
+```
+
+Direct leaf includes допустимы для white-box tests, но они не должны заменять
+проверку публичного include contract.
 
 ## Examples
 

--- a/guides/coding-style.md
+++ b/guides/coding-style.md
@@ -10,6 +10,14 @@
 - Public headers используют `#pragma once` и macro guard:
   `_OPTIONX_<AREA>_<NAME>_HPP_INCLUDED`.
 - Public aggregate headers лежат в `include/optionx_cpp/*.hpp`.
+- External consumers include public headers with the installed prefix, for
+  example `<optionx_cpp/data.hpp>` or
+  `<optionx_cpp/platforms/IntradeBarPlatform.hpp>`.
+- Internal headers under `include/optionx_cpp` include other project headers
+  with local paths from `include/optionx_cpp`, for example
+  `"data/trading.hpp"`, `"utils/http_utils.hpp"`, and
+  `"platforms/common/ApiResult.hpp"`.
+- Do not use `"optionx_cpp/..."` inside `include/optionx_cpp`.
 - Prefer the nearest aggregate header for public-domain and cross-domain
   dependencies; do not rebuild aggregate include order inside leaf DTO headers.
 - Do not use `../` in `#include` directives.

--- a/guides/commit-conventions.md
+++ b/guides/commit-conventions.md
@@ -6,13 +6,24 @@ Operational rule for AI agents that create commits in this repository.
 
 - Commit messages must be in English and use Conventional Commits.
 - Use the form `type(scope): short summary`.
-- Every commit must include a descriptive body.
+- Use an imperative, concise summary.
+- Include a descriptive body when the change is not obvious from the summary.
+- Prefer a scope that names the touched subsystem: `docs(guides)`,
+  `feat(intrade-bar)`, `fix(storage)`, `test(history)`, `build(cmake)`.
 
 Use:
 
 ```bash
-git commit -a -m "type(scope): short summary" -m "Detailed description of changes."
+git commit -m "type(scope): short summary" -m "Detailed description of changes."
 ```
+
+Before committing:
+
+- Check `git status --short`.
+- Check `git diff` or staged diff.
+- Include only files related to the requested change.
+- Do not commit generated build output, local env files, credentials, broker
+  session databases, logs, or unrelated agent/tool folders.
 
 ## Allowed types
 

--- a/guides/git-workflow.md
+++ b/guides/git-workflow.md
@@ -1,0 +1,85 @@
+# Git Workflow
+
+Этот документ фиксирует рабочий процесс для изменений в `optionx_cpp`.
+
+## Branch Policy
+
+Все изменения кода и документации проходят через отдельную ветку и pull
+request. Не коммить напрямую в `main`, если пользователь явно не попросил
+именно это для конкретной задачи.
+
+## Перед Началом Работы
+
+1. Проверь состояние:
+
+   ```bash
+   git status --short
+   git branch --show-current
+   ```
+
+2. Если работа начинается с `main`, обнови его:
+
+   ```bash
+   git fetch origin
+   git switch main
+   git merge --ff-only origin/main
+   ```
+
+3. Создай ветку с подходящим prefix:
+
+   ```bash
+   git switch -c docs/api-contracts
+   ```
+
+## Branch Naming
+
+| Prefix | Когда использовать |
+|---|---|
+| `feat/` | Новая функциональность |
+| `fix/` | Исправление bug/regression |
+| `refactor/` | Изменение структуры без поведения |
+| `test/` | Только тесты |
+| `docs/` | Документация |
+| `build/` | CMake/dependency/build changes |
+| `ci/` | CI/CD |
+| `chore/` | Maintenance без production behavior changes |
+| `perf/` | Производительность |
+
+## Commit Rules
+
+- Делай focused commits: один понятный смысл на commit.
+- Используй Conventional Commits на английском.
+- Формат: `type(scope): short summary`.
+- Добавляй body, если commit не очевиден из одной строки.
+- Перед commit проверь `git status --short` и `git diff`.
+- Не добавляй unrelated generated output, local env files, credentials, logs,
+  build trees.
+
+Смотри подробности в `guides/commit-conventions.md`.
+
+## PR Checklist
+
+Перед push/PR:
+
+1. Убедись, что diff относится к задаче.
+2. Запусти релевантные проверки:
+   - docs-only: Markdown/link smoke-check;
+   - code: самые узкие test targets;
+   - public include changes: include-contract test/build.
+3. Зафиксируй в PR description:
+   - что изменено;
+   - какие проверки выполнены;
+   - что не проверялось и почему.
+
+## После Merge
+
+После принятия PR:
+
+```bash
+git fetch origin
+git switch main
+git merge --ff-only origin/main
+```
+
+Локальные build directories и untracked agent/tool folders не трогай, если они
+не относятся к задаче.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -15,6 +15,14 @@
 - Domain aggregates such as `data/trading.hpp` own common include context for
   their leaf DTO headers. Leaf DTO headers should not recreate sibling include
   order or pull broad dependencies unless that leaf truly owns the dependency.
+- External consumers include through `<optionx_cpp/...>`. Internal headers under
+  `include/optionx_cpp` include other project headers through local paths from
+  that root: `"data/..."`, `"utils/..."`, `"modules/..."`,
+  `"platforms/..."`, `"storages/..."`.
+- Do not use `"optionx_cpp/..."` inside `include/optionx_cpp`, and do not use
+  `../` include paths. The local test/example CMake setup exposes both
+  `include` and `include/optionx_cpp` so public and internal include contracts
+  can be checked together.
 - При добавлении public header обновляй ближайший aggregate header; при
   внутреннем helper не расширяй public surface.
 
@@ -128,6 +136,29 @@ overloads. `run()` запускает worker thread, `process()` выполня�
 - Exceptions из future ловятся и переводятся в error response.
 - Rate limit ids хранятся в `m_rate_limits`; используй enum class
   `RateLimitType` внутри конкретной платформы.
+
+## Broker HTTP Adapter Pattern
+
+Platform `RequestManager` classes should keep broker-specific HTTP and parser
+quirks inside the platform folder, but expose typed workflow results to higher
+managers.
+
+Current pattern:
+
+- Low-level request methods keep the broker request/response flow close to the
+  existing implementation.
+- New `*_result` methods wrap the same parser path into `ApiResult<T>` payloads.
+- `ApiResult<T>` separates `success`, `status_code`, `error_desc`, and typed
+  payload. Do not represent a failed request as an empty successful payload.
+- Parser literals and HTML markers are evidence-sensitive. Do not rewrite them
+  just because a normalized API would look cleaner; first prove the broker
+  response changed or add a fixture/live smoke case.
+- Broker-independent raw-response helpers belong in `utils`, not in a concrete
+  platform folder.
+
+For user-facing broker features, add facade methods on
+`BaseTradingPlatform`/concrete platform and delegate into managers. Do not make
+application code call platform managers directly.
 
 ### IntradeBar Settings Switch Acknowledgement
 

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -30,6 +30,9 @@
 |---|---|---|
 | `configure_auth(std::unique_ptr<IAuthData>)` | Отправить auth data через `AuthDataEvent` | Возвращает `false` для `nullptr`; auth применяют subscribed managers |
 | `place_trade(std::unique_ptr<TradeRequest>)` | User-facing вход для сделки | В base возвращает `false`; concrete platform должна override |
+| `fetch_trade_result(TradeResultQuery, callback)` | Проверить результат одной сделки | В base возвращает `false`; используется для recovery по broker trade id |
+| `fetch_trade_history(request, callback)` | Выгрузить историю закрытых сделок | Возвращает `TradeHistoryResult` с `TradeRecord` records |
+| `fetch_trade_history(callback)` | Выгрузить всю доступную историю | Делегирует в `TradeHistoryRequest::all()` |
 | `fetch_candle_data(...)` | История свечей | В base возвращает `false`; реализация platform-specific |
 | `fetch_symbol_list(...)` | Список symbols | В base возвращает `false`; реализация platform-specific |
 | `connect(callback)` | Публикует `ConnectRequestEvent` | Реальное подключение делает manager |
@@ -74,6 +77,8 @@
 Методы:
 
 - `place_trade()` делегирует в `m_trade_execution.place_trade(...)`.
+- `fetch_trade_result()` делегирует в `m_trade_manager.fetch_trade_result(...)`.
+- `fetch_trade_history()` делегирует в `m_trade_manager.fetch_trade_history(...)`.
 - `platform_type()` возвращает `PlatformType::INTRADE_BAR`.
 
 Используй эту платформу как основной working example для новой реализации.
@@ -259,6 +264,63 @@ Ownership:
 Смотри `include/optionx_cpp/data/trading/TradeResult.hpp`.
 Используется вместе с `TradeRequest`, `TradeState`, `TradeErrorCode` и
 callback/event flow.
+
+`TradeResult` описывает результат одной сделки в lifecycle/callback API. Его
+можно передать в `TradeResultQuery` как частично заполненный результат, если
+бот восстановился после перезапуска и знает только broker id, amount,
+account/currency и open timing/price.
+
+### `TradeResultQuery`
+
+Файл: `include/optionx_cpp/data/trading/TradeResultQuery.hpp`.
+
+Используется `BaseTradingPlatform::fetch_trade_result(...)` для проверки одной
+сделки по broker identity. У разных брокеров identity может быть числом,
+строкой или hash; текущий Intrade Bar использует `broker_option_id`.
+
+Это не замена `TradeRequest`: запрос на проверку результата не должен тащить
+полный request, если для broker API достаточно id и минимального контекста
+результата.
+
+### `TradeHistoryRequest` / `TradeHistoryResult`
+
+Файлы:
+
+- `include/optionx_cpp/data/trading/TradeHistoryRequest.hpp`
+- `include/optionx_cpp/data/trading/TradeHistoryResult.hpp`
+- `include/optionx_cpp/data/trading/TradeRecordTimeRange.hpp`
+
+`fetch_trade_history` возвращает историю аккаунта как `TradeRecord`, потому что
+это storage/statistics model, а не callback-результат одной активной сделки.
+
+`TradeHistoryRequest` задает:
+
+- `start_ms`, `stop_ms`;
+- `range_mode`;
+- `time_field`, по умолчанию `CLOSE_DATE`;
+- optional `comment`, который копируется в каждый returned `TradeRecord`.
+
+`TradeHistoryRequest::all()` отключает client-side range filtering и означает
+"выгрузить все доступное через broker source". Для broker endpoints, которые
+требуют конечный date range, adapter может преобразовать это в практический
+широкий диапазон.
+
+`TradeHistoryResult` не маскирует ошибку пустым массивом: в нем отдельно есть
+`success`, `status_code`, `error_desc` и `records`.
+
+### `TradeRecord`
+
+Файл: `include/optionx_cpp/data/trading/TradeRecord.hpp`.
+
+`TradeRecord` - нормализованная запись сделки для storage, statistics и import
+history. Он может быть создан из `TradeRequest` + `TradeResult`, а также из
+broker history export.
+
+`TradeRecord::close_date` означает planned or known option close timestamp. Для
+classic options это фиксированное `TradeRequest::expiry_time`, известное до
+открытия сделки. Для sprint options close time зависит от фактического
+`open_date`, поэтому обычно становится известным после открытия как
+`open_date + duration`.
 
 ## Account/Auth Data
 

--- a/guides/project-overview.md
+++ b/guides/project-overview.md
@@ -8,8 +8,10 @@
 
 `optionx_cpp` - header-only C++17 библиотека для подключения торговых систем,
 broker API и bridges. Основной сценарий: пользователь создает платформу,
-настраивает auth data, подписывает callbacks, запускает lifecycle и отправляет
-`TradeRequest`.
+настраивает auth data, подписывает callbacks, запускает lifecycle, отправляет
+`TradeRequest`, восстанавливает результат одной сделки через
+`fetch_trade_result` или выгружает историю аккаунта через
+`fetch_trade_history`.
 
 Опорные файлы:
 
@@ -63,7 +65,9 @@ broker API и bridges. Основной сценарий: пользовател
 5. `place_trade()` у конкретной платформы делегирует в
    `BaseTradeExecutionModule`, который использует `TradeQueueManager` и
    `TradeStateManager`.
-6. `shutdown()` останавливает tasks, вызывает shutdown у modules, затем
+6. `fetch_trade_result()` и `fetch_trade_history()` у конкретной платформы
+   делегируются в platform managers и возвращают DTO через callbacks.
+7. `shutdown()` останавливает tasks, вызывает shutdown у modules, затем
    draining event bus.
 
 ## Реальные Платформы

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -389,7 +389,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 1;
+        static constexpr std::uint16_t kBinaryVersion = 4;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -54,8 +54,7 @@ namespace optionx {
         std::int64_t place_date = 0;                        ///< Request creation timestamp.
         std::int64_t send_date = 0;                         ///< Broker send timestamp.
         std::int64_t open_date = 0;                         ///< Trade open timestamp.
-        std::int64_t close_date = 0;                        ///< Trade close timestamp.
-        std::int64_t expiry_date = 0;                       ///< Expiration timestamp.
+        std::int64_t close_date = 0;                        ///< Planned or known close timestamp (classic expiry, sprint open + duration).
         std::int64_t duration = 0;                          ///< Requested duration in seconds.
 
         // Money management and extensibility
@@ -101,7 +100,9 @@ namespace optionx {
             refund = request.refund;
             min_payout = request.min_payout;
             duration = request.duration;
-            expiry_date = request.expiry_time > 0 ? request.expiry_time * 1000 : 0;
+            if (request.expiry_time > 0) {
+                close_date = request.expiry_time * 1000;
+            }
         }
 
         /// \brief Copies result-side fields into this record.
@@ -120,7 +121,9 @@ namespace optionx {
             place_date = result.place_date;
             send_date = result.send_date;
             open_date = result.open_date;
-            close_date = result.close_date;
+            if (result.close_date > 0 || close_date == 0) {
+                close_date = result.close_date;
+            }
             trade_state = result.trade_state;
             live_state = result.live_state;
             error_code = result.error_code;
@@ -242,7 +245,6 @@ namespace optionx {
             append_value(bytes, send_date);
             append_value(bytes, open_date);
             append_value(bytes, close_date);
-            append_value(bytes, expiry_date);
             append_value(bytes, duration);
 
             append_enum8(bytes, mm_type);
@@ -313,7 +315,6 @@ namespace optionx {
             record.send_date = reader.read<std::int64_t>();
             record.open_date = reader.read<std::int64_t>();
             record.close_date = reader.read<std::int64_t>();
-            record.expiry_date = reader.read<std::int64_t>();
             record.duration = reader.read<std::int64_t>();
 
             record.mm_type = reader.read_enum8<MmSystemType>();
@@ -368,7 +369,6 @@ namespace optionx {
                    send_date == other.send_date &&
                    open_date == other.open_date &&
                    close_date == other.close_date &&
-                   expiry_date == other.expiry_date &&
                    duration == other.duration &&
                    mm_type == other.mm_type &&
                    mm_step == other.mm_step &&
@@ -389,7 +389,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 3;
+        static constexpr std::uint16_t kBinaryVersion = 4;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -389,7 +389,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 4;
+        static constexpr std::uint16_t kBinaryVersion = 1;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -196,7 +196,7 @@ namespace optionx {
             return same_numeric_id || same_string_id;
         }
 
-        /// \brief Serializes the record using the Binary v2 storage format.
+        /// \brief Serializes the record using the current binary storage format.
         std::vector<std::uint8_t> to_bytes() const {
             std::vector<std::uint8_t> bytes;
             bytes.reserve(512 + request_unique_hash.size() + option_hash.size() +
@@ -263,7 +263,7 @@ namespace optionx {
             return bytes;
         }
 
-        /// \brief Deserializes a Binary v2 trade record.
+        /// \brief Deserializes a trade record serialized by the current binary storage format.
         static TradeRecord from_bytes(const void* data, std::size_t size) {
             BinaryReader reader(data, size);
 
@@ -389,7 +389,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 4;
+        static constexpr std::uint16_t kBinaryVersion = 1;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
@@ -31,15 +31,12 @@ namespace optionx {
                 return record.open_date;
             case TradeRecordTimeField::CLOSE_DATE:
                 return record.close_date;
-            case TradeRecordTimeField::EXPIRY_DATE:
-                return record.expiry_date;
             case TradeRecordTimeField::AUTO:
             default:
                 if (record.place_date > 0) return record.place_date;
                 if (record.send_date > 0) return record.send_date;
                 if (record.open_date > 0) return record.open_date;
                 if (record.close_date > 0) return record.close_date;
-                if (record.expiry_date > 0) return record.expiry_date;
                 return 0;
         }
     }

--- a/include/optionx_cpp/data/trading/TradeRecordTimeRange.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordTimeRange.hpp
@@ -14,8 +14,7 @@ namespace optionx {
         PLACE_DATE,  ///< Use place_date field.
         SEND_DATE,   ///< Use send_date field.
         OPEN_DATE,   ///< Use open_date field.
-        CLOSE_DATE,  ///< Use close_date field.
-        EXPIRY_DATE  ///< Use expiry_date field.
+        CLOSE_DATE   ///< Use close_date field.
     };
 
     /// \enum TimeRangeMode

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -995,18 +995,15 @@ namespace optionx::platforms::intrade_bar {
                 return record.open_date;
             case TradeRecordTimeField::CLOSE_DATE:
                 return record.close_date;
-            case TradeRecordTimeField::EXPIRY_DATE:
-                return record.expiry_date;
             case TradeRecordTimeField::AUTO:
             default:
                 if (record.place_date > 0) return record.place_date;
                 if (record.send_date > 0) return record.send_date;
                 if (record.open_date > 0) return record.open_date;
                 if (record.close_date > 0) return record.close_date;
-                if (record.expiry_date > 0) return record.expiry_date;
                 return 0;
-            }
         }
+    }
 
         std::vector<TradeRecord> filter_trade_history_range(
                 std::vector<TradeRecord> records,

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -605,7 +605,6 @@ namespace optionx::platforms::intrade_bar {
             }
             if (auto close_time = parse_history_row_close_time_ms(row)) {
                 record.close_date = *close_time;
-                record.expiry_date = record.close_date;
                 if (record.open_date > 0 && record.close_date >= record.open_date) {
                     record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
                 }
@@ -655,7 +654,6 @@ namespace optionx::platforms::intrade_bar {
             record.symbol = normalize_history_symbol(price_lines[0]);
             record.open_date = *open_time;
             record.close_date = *close_time;
-            record.expiry_date = record.close_date;
             if (record.close_date >= record.open_date) {
                 record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
             }
@@ -847,7 +845,6 @@ namespace optionx::platforms::intrade_bar {
 
             record.open_date = *open_time;
             record.close_date = *close_time;
-            record.expiry_date = record.close_date;
             if (record.close_date >= record.open_date) {
                 record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
             }

--- a/include/optionx_cpp/storages/TradeRecordDB.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB.hpp
@@ -75,7 +75,7 @@ namespace optionx::storage {
     ///
     /// For correct chronological ordering and range queries, callers should set
     /// TradeRecord::place_date before writing. The AUTO timestamp selector uses
-    /// place_date as the first priority (place -> send -> open -> close -> expiry).
+    /// place_date as the first priority (place -> send -> open -> close).
     ///
     /// Callbacks are delivered only by process(), flush(), or shutdown() on the
     /// calling thread. For broker execution, either call assign_trade_id() before
@@ -174,7 +174,7 @@ namespace optionx::storage {
         TradeRecordDBReadResult find_by_uid(std::int64_t request_unique_id) const;
 
         /// \brief Finds all records whose selected trade timestamp equals timestamp_ms.
-        /// \param timestamp_ms Millisecond timestamp matched against open/place/send/close/expiry date.
+        /// \param timestamp_ms Millisecond timestamp matched against open/place/send/close date.
         /// \return List result sorted by selected timestamp and trade_id.
         TradeRecordDBListResult find_by_timestamp(std::int64_t timestamp_ms) const;
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
@@ -12,7 +12,7 @@
 
 #include <time_shield.hpp>
 
-#include "optionx_cpp/utils.hpp"
+#include "utils.hpp"
 
 namespace optionx::storage {
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
@@ -70,8 +70,6 @@ namespace optionx::storage {
                 bool should_check_error = false;
                 if (rec.close_date > 0 && rec.close_date < stale_border) {
                     should_check_error = true;
-                } else if (rec.expiry_date > 0 && rec.expiry_date < stale_border) {
-                    should_check_error = true;
                 } else if (rec.open_date > 0 && rec.duration > 0 &&
                            (rec.open_date + rec.duration * 1000) < stale_border) {
                     should_check_error = true;

--- a/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
@@ -15,14 +15,13 @@ namespace optionx::storage::detail {
 
     /// \brief Selects canonical timestamp used by TradeRecordDB timestamp queries.
     ///
-    /// Order of precedence for AUTO mode: place_date -> send_date -> open_date -> close_date -> expiry_date.
+    /// Order of precedence for AUTO mode: place_date -> send_date -> open_date -> close_date.
     /// The backend must set place_date before writing a record; otherwise the record may not be found by range queries.
     inline std::int64_t selected_timestamp_ms(const TradeRecord& record) noexcept {
         if (record.place_date > 0) return record.place_date;
         if (record.send_date > 0) return record.send_date;
         if (record.open_date > 0) return record.open_date;
         if (record.close_date > 0) return record.close_date;
-        if (record.expiry_date > 0) return record.expiry_date;
         return 0;
     }
 

--- a/tests/intrade_bar_api/CLI.md
+++ b/tests/intrade_bar_api/CLI.md
@@ -216,8 +216,8 @@ time filtering and asks the broker for all available rows. For the CSV source,
 the adapter maps this to the broker-required date range starting at
 `2000-01-01`. `--comment` is copied to each returned `TradeRecord.comment`.
 Rows without the selected `--time-field` timestamp are excluded from ranged
-requests. Intrade Bar history currently provides `OPEN_DATE`, `CLOSE_DATE`, and
-`EXPIRY_DATE` (`EXPIRY_DATE` matches `CLOSE_DATE` for closed binary trades).
+requests. Intrade Bar history currently provides `OPEN_DATE` and `CLOSE_DATE`;
+the adapter stores the broker close timestamp in `TradeRecord::close_date`.
 
 The command prints a compact summary to stdout and writes every fetched record
 to the normal log files under `build-codex\data\logs\`.

--- a/tests/intrade_bar_api/WORKFLOWS.md
+++ b/tests/intrade_bar_api/WORKFLOWS.md
@@ -132,9 +132,9 @@ at `2000-01-01` because that endpoint requires dates. Ranged requests default
 to `CLOSE_DATE`, which matches the usual closed-trade DB query semantics;
 callers can choose another `TradeRecordTimeField` when they need a different
 time axis. Records missing the selected timestamp are excluded from ranged
-results. For Intrade Bar closed history, `EXPIRY_DATE` is populated from
-`CLOSE_DATE`. Optional `TradeHistoryRequest::comment` is copied to each returned
-`TradeRecord.comment`.
+results. Intrade Bar closed-history sources provide a close timestamp, which is
+stored in `TradeRecord::close_date`. Optional `TradeHistoryRequest::comment` is
+copied to each returned `TradeRecord.comment`.
 
 ## Manual Trade Result Recovery Check
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -220,7 +220,6 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryCsvExport) {
     EXPECT_EQ(trades[0].account_type, AccountType::DEMO);
     EXPECT_EQ(trades[0].platform_type, PlatformType::INTRADE_BAR);
     EXPECT_EQ(trades[0].duration, 180);
-    EXPECT_EQ(trades[0].expiry_date, trades[0].close_date);
 
     EXPECT_EQ(trades[1].option_id, 123);
     EXPECT_EQ(trades[1].symbol, "AUDNZD");
@@ -241,7 +240,6 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryCsvExport) {
     EXPECT_EQ(trades[4].currency, CurrencyType::RUB);
     EXPECT_EQ(trades[4].trade_state, TradeState::WIN);
     EXPECT_DOUBLE_EQ(trades[4].profit, 80.0);
-    EXPECT_EQ(trades[4].expiry_date, trades[4].close_date);
 }
 
 TEST(IntradeBarApiResponses, ParsesTradeHistoryHtmlSnapshotAndMergesWithCsv) {
@@ -262,7 +260,6 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryHtmlSnapshotAndMergesWithCsv) {
     EXPECT_EQ(html_trades[0].option_type, OptionType::SPRINT);
     EXPECT_EQ(html_trades[0].open_date, time_shield::sec_to_ms(1719146073));
     EXPECT_EQ(html_trades[0].close_date, time_shield::sec_to_ms(1719146373));
-    EXPECT_EQ(html_trades[0].expiry_date, html_trades[0].close_date);
     EXPECT_EQ(html_trades[0].duration, 300);
 
     std::vector<TradeRecord> csv_trades;
@@ -421,7 +418,6 @@ TEST(IntradeBarApiResponses, ParsesTradeCloseHtmlPageAndNextCursor) {
     EXPECT_EQ(page.records[0].order_type, OrderType::BUY);
     EXPECT_EQ(page.records[0].trade_state, TradeState::WIN);
     EXPECT_EQ(page.records[0].duration, 300);
-    EXPECT_EQ(page.records[0].expiry_date, page.records[0].close_date);
     EXPECT_DOUBLE_EQ(page.records[0].amount, 1.0);
     EXPECT_DOUBLE_EQ(page.records[0].profit, 0.79);
     EXPECT_DOUBLE_EQ(page.records[0].payout, 0.79);

--- a/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
+++ b/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
@@ -80,8 +80,6 @@ const char* trade_history_time_field_to_string(optionx::TradeRecordTimeField val
         return "OPEN_DATE";
     case optionx::TradeRecordTimeField::CLOSE_DATE:
         return "CLOSE_DATE";
-    case optionx::TradeRecordTimeField::EXPIRY_DATE:
-        return "EXPIRY_DATE";
     case optionx::TradeRecordTimeField::AUTO:
     default:
         return "AUTO";
@@ -98,7 +96,6 @@ optionx::TradeRecordTimeField parse_trade_history_time_field(
     if (normalized == "SEND_DATE" || normalized == "SEND") return optionx::TradeRecordTimeField::SEND_DATE;
     if (normalized == "OPEN_DATE" || normalized == "OPEN") return optionx::TradeRecordTimeField::OPEN_DATE;
     if (normalized == "CLOSE_DATE" || normalized == "CLOSE") return optionx::TradeRecordTimeField::CLOSE_DATE;
-    if (normalized == "EXPIRY_DATE" || normalized == "EXPIRY") return optionx::TradeRecordTimeField::EXPIRY_DATE;
     return fallback;
 }
 
@@ -477,7 +474,6 @@ void print_trade_record_line(
         << " balance=" << std::setprecision(12) << record.balance
         << " open_date=" << record.open_date
         << " close_date=" << record.close_date
-        << " expiry_date=" << record.expiry_date
         << " comment=" << record.comment
         << " error=" << record.error_desc
         << '\n';

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -69,7 +69,6 @@ TradeRecord make_record(
     record.send_date = open_date;
     record.open_date = open_date;
     record.close_date = open_date + 60000;
-    record.expiry_date = open_date + 60000;
     record.duration = 60;
     record.mm_type = optionx::MmSystemType::MARTINGALE_SIGNAL;
     record.mm_step = 2;

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -70,7 +70,6 @@ TradeRecord make_win_record(
     record.send_date = open_date;
     record.open_date = open_date;
     record.close_date = open_date + 60000;
-    record.expiry_date = open_date + 60000;
     record.duration = 60;
     record.mm_step = (uid == 1) ? 0 : 1;
     return record;
@@ -151,8 +150,7 @@ TEST(TradeRecordStatusFixerTest, MarksStaleAsCheckError) {
     // Stuck trade
     records.push_back(make_win_record(2, 0, 10.0, 0.0, "EURUSD", optionx::TradeState::OPEN_SUCCESS));
     records.back().open_date = 800000;
-    records.back().close_date = 0;
-    records.back().expiry_date = 850000;
+    records.back().close_date = 850000;
     records.back().duration = 60;
 
     // wait_status_ms = 100000 -> stale_border = 1000000 - 100000 = 900000
@@ -171,15 +169,14 @@ TEST(TradeRecordStatusFixerTest, CallbackResolvesStaleTrade) {
 
     records.push_back(make_win_record(2, 0, 10.0, 0.0, "EURUSD", optionx::TradeState::OPEN_SUCCESS));
     records.back().open_date = 800000;
-    records.back().close_date = 0;
-    records.back().expiry_date = 850000;
+    records.back().close_date = 850000;
     records.back().duration = 60;
 
     auto resolver = [](const TradeRecord& rec) -> optionx::TradeResult {
         optionx::TradeResult result;
         result.trade_state = optionx::TradeState::WIN;
         result.profit = 8.0;
-        result.close_date = rec.expiry_date;
+        result.close_date = rec.close_date;
         return result;
     };
 

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -152,10 +152,28 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.request_unique_hash, "request-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
-    EXPECT_EQ(record.expiry_date, 1712345700000);
+    EXPECT_EQ(record.close_date, 1712345700000);
     EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
     EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
     EXPECT_EQ(nlohmann::json::parse(record.decision_params_json).at("threshold"), 0.65);
+}
+
+TEST(TradeRecordFactoryTest, UsesCloseDateForPlannedAndKnownCloseTime) {
+    const auto request = make_request();
+
+    const auto request_record = optionx::TradeRecord::from_trade(request);
+    EXPECT_EQ(request_record.close_date, 1712345700000);
+
+    auto partial_result = make_result();
+    partial_result.close_date = 0;
+    const auto partial_record = optionx::TradeRecord::from_trade(request, partial_result);
+    EXPECT_EQ(partial_record.close_date, 1712345700000);
+
+    auto sprint_request = make_request();
+    sprint_request.option_type = optionx::OptionType::SPRINT;
+    sprint_request.expiry_time = 0;
+    const auto sprint_record = optionx::TradeRecord::from_trade(sprint_request);
+    EXPECT_EQ(sprint_record.close_date, 0);
 }
 
 TEST(TradeRecordIdentityTest, MatchesBrokerIdentityWithKnownContext) {


### PR DESCRIPTION
## Summary
- Add guides for API/header contracts, agent workflow expectations, Git/PR process, and platform API notes.
- Remove `TradeRecord::expiry_date` and `TradeRecordTimeField::EXPIRY_DATE`; `TradeRecord::close_date` is now the planned or known option close timestamp.
- Update Intrade Bar history parsing/CLI/tests and reset the revised TradeRecord binary format to version 1 because the previous storage layout was not a stable public contract.

## Validation
- `git diff --check`
- `cmake --build build-codex --target trade_record_storage_test -- -j1`
- `cmake --build build-codex --target trade_record_db_test -- -j1`
- `cmake --build build-codex --target trade_record_stats_test -- -j1`
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `cmake --build build-codex --target intrade_bar_smoke_cli -- -j1`
- `.\build-codex\trade_record_storage_test.exe --gtest_brief=1`
- `.\build-codex\trade_record_db_test.exe --gtest_brief=1`
- `.\build-codex\trade_record_stats_test.exe --gtest_brief=1`
- `.\build-codex\intrade_bar_api_response_test.exe --gtest_brief=1`
- Latest follow-up: `.\build-codex\trade_record_storage_test.exe --gtest_brief=1`