### PR TITLE
Fix core refactor audit findings

### DIFF
--- a/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
@@ -50,7 +50,7 @@ namespace optionx {
         std::int64_t time_zone_sec = 0;  ///< Time zone offset in seconds for local-time filtering.
 
         TradeRecordTimeField time_field = TradeRecordTimeField::AUTO; ///< Which timestamp to query on.
-        TimeRangeMode range_mode = TimeRangeMode::CLOSED;             ///< Range inclusion mode.
+        TimeRangeMode range_mode = TimeRangeMode::NONE;               ///< Range inclusion mode.
 
         std::size_t limit = 0;       ///< Maximum records to return (0 = unlimited).
         std::size_t offset = 0;      ///< Skip first N matched records.
@@ -61,6 +61,12 @@ namespace optionx {
         bool fix_stale_status = true;        ///< Apply stale-status correction to results.
         std::int64_t wait_status_sec = 30;   ///< Staleness threshold in seconds.
         std::int64_t coarse_expansion_ms = 86400000; ///< Scan expansion for non-AUTO time_field (default 24h).
+
+        /// \brief Creates a query that returns all records matching the field filters.
+        /// \return Query without a time range.
+        static TradeRecordQuery all() {
+            return TradeRecordQuery();
+        }
     };
 
 } // namespace optionx

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
@@ -131,7 +131,7 @@ namespace optionx::platforms::intrade_bar {
             }
             case AccountInfoType::PAYOUT_ABOVE_MIN:
                 if (request.min_payout == 0.0) return true;
-                return (request.min_payout >= get_payout(request));
+                return (get_payout(request) >= request.min_payout);
             case AccountInfoType::AMOUNT_BELOW_BALANCE:
                 return (request.amount <= balance);
             default:

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -499,7 +499,7 @@ namespace optionx::platforms::intrade_bar {
                 finalize_authentication(std::move(callback));
             });
         } else {
-            LOGIT_PRINT_ERROR("Failed to parse cookies: ", utils::redact_secret(cookies));
+            LOGIT_PRINT_ERROR("Failed to parse cookies: ", utils::redact_secret_value(cookies));
             execute_authentication_flow(std::move(callback));
         }
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -499,7 +499,7 @@ namespace optionx::platforms::intrade_bar {
                 finalize_authentication(std::move(callback));
             });
         } else {
-            LOGIT_PRINT_ERROR("Failed to parse cookies: ", cookies);
+            LOGIT_PRINT_ERROR("Failed to parse cookies: ", utils::redact_secret(cookies));
             execute_authentication_flow(std::move(callback));
         }
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
@@ -184,7 +184,6 @@ namespace optionx::platforms::intrade_bar {
         if (!account_info->connect) {
             account_info->connect = true;
             notify(events::AccountInfoUpdateEvent(account_info, Status::CONNECTED));
-            handle_connected();
         }
 
         int64_t elapsed = time_shield::ms_to_sec(OPTIONX_TIMESTAMP_MS) - m_last_trades_time;
@@ -211,7 +210,6 @@ namespace optionx::platforms::intrade_bar {
             const std::string error_text("Failed to retrieve balance.");
             LOGIT_ERROR(error_text);
             notify(events::AccountInfoUpdateEvent(account_info, Status::DISCONNECTED, error_text));
-            handle_disconnected();
         }
     }
 
@@ -278,6 +276,8 @@ namespace optionx::platforms::intrade_bar {
     /// \brief Handles account connection event.
     void BalanceManager::handle_connected() {
         LOGIT_TRACE0();
+
+        m_task_manager.shutdown();
         
         LOGIT_INFO(
             "Intrade Bar balance: starting connected balance polling. period_ms=",
@@ -313,7 +313,6 @@ namespace optionx::platforms::intrade_bar {
                         const std::string error_text("Ping to current host failed.");
                         LOGIT_ERROR(error_text);
                         notify(events::AccountInfoUpdateEvent(account_info, Status::DISCONNECTED, error_text));
-                        handle_disconnected();
                     }
                 }
             });

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -511,7 +511,7 @@ namespace optionx::platforms::intrade_bar {
                 const std::string& user_hash,
                 const std::string& cookies,
                 const std::string& reason)> result_callback) {
-        LOGIT_DEBUG(req_id, req_value, cookies);
+        LOGIT_DEBUG(req_id, req_value, utils::redact_secret(cookies));
 
         // Prepare query parameters
         kurlyk::QueryParams query = {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -511,7 +511,7 @@ namespace optionx::platforms::intrade_bar {
                 const std::string& user_hash,
                 const std::string& cookies,
                 const std::string& reason)> result_callback) {
-        LOGIT_DEBUG(req_id, req_value, utils::redact_secret(cookies));
+        LOGIT_DEBUG(req_id, req_value, utils::redact_secret_value(cookies));
 
         // Prepare query parameters
         kurlyk::QueryParams query = {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -59,10 +59,13 @@ namespace optionx::platforms::intrade_bar {
     std::optional<std::pair<double, CurrencyType>> parse_balance(const std::string& content) {
         try {
             const std::string STR_RUB = u8"₽";
+            const std::string STR_RUB_UTF8 = "\xE2\x82\xBD";
             const std::string STR_USD = u8"$";
 
             CurrencyType currency = CurrencyType::UNKNOWN;
-            if (content.find(STR_RUB) != std::string::npos || content.find("RUB") != std::string::npos) {
+            if (content.find(STR_RUB_UTF8) != std::string::npos ||
+                content.find(STR_RUB) != std::string::npos ||
+                content.find("RUB") != std::string::npos) {
                 currency = CurrencyType::RUB;
             } else if (content.find(STR_USD) != std::string::npos || content.find("USD") != std::string::npos) {
                 currency = CurrencyType::USD;
@@ -72,9 +75,17 @@ namespace optionx::platforms::intrade_bar {
             }
 
             std::string cleaned_content = content;
-            cleaned_content.replace(cleaned_content.find(","), 1, ".");
-            const std::string marker = (currency == CurrencyType::RUB) ? STR_RUB : STR_USD;
+            std::replace(cleaned_content.begin(), cleaned_content.end(), ',', '.');
+            const std::string marker = (currency == CurrencyType::RUB) ? STR_RUB_UTF8 : STR_USD;
             size_t pos = cleaned_content.find(marker);
+            if (pos == std::string::npos && currency == CurrencyType::RUB) {
+                pos = cleaned_content.find(STR_RUB);
+            }
+            if (pos == std::string::npos && currency == CurrencyType::RUB) {
+                pos = cleaned_content.find("RUB");
+            } else if (pos == std::string::npos && currency == CurrencyType::USD) {
+                pos = cleaned_content.find("USD");
+            }
             if (pos != std::string::npos) {
                 cleaned_content = cleaned_content.substr(0, pos);
             }

--- a/include/optionx_cpp/platforms/TradeUpPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/RequestManager.hpp
@@ -109,7 +109,7 @@ namespace optionx::platforms::tradeup {
             std::shared_ptr<AuthData> auth_data, 
             const std::string &token) {
         if (!token.empty()) {
-            LOGIT_DEBUG(token);
+            LOGIT_DEBUG(utils::redact_secret(token));
             
             auto& client = get_http_client();
             m_host = auth_data->host;
@@ -273,7 +273,7 @@ namespace optionx::platforms::tradeup {
                 return;
             }
 
-            LOGIT_DEBUG(user_id, token, affs_id, cookies);
+            LOGIT_DEBUG(user_id, utils::redact_secret(token), affs_id, utils::redact_secret(cookies));
             result_callback(
                 true, 
                 {}, 
@@ -378,7 +378,7 @@ namespace optionx::platforms::tradeup {
                 m_api_headers.insert_or_assign("Cookie", cookies);
             }
 
-            LOGIT_DEBUG(success, ret, message, cookies, expire);
+            LOGIT_DEBUG(success, ret, message, utils::redact_secret(cookies), expire);
 
             result_callback(success, {}, std::move(ret), std::move(message), m_token, std::move(cookies), expire);
         };

--- a/include/optionx_cpp/storages/ServiceSessionDB.hpp
+++ b/include/optionx_cpp/storages/ServiceSessionDB.hpp
@@ -64,12 +64,23 @@ namespace optionx::storage {
             return m_aes.set_key(key);
         }
 
+        /// \brief Checks whether the session database was opened successfully.
+        /// \return True when the backing database is available.
+        bool is_open() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return static_cast<bool>(m_db);
+        }
+
         /// \brief Retrieves session value by platform and email.
         /// \param platform Platform name.
         /// \param email Email address.
         /// \return Session value as a string, or std::nullopt if not found.
         std::optional<std::string> get_session_value(const std::string& platform, const std::string& email) {
             std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_db) {
+                LOGIT_WARN("Session database is not open.");
+                return std::nullopt;
+            }
             std::string key = platform + ":" + email;
             try {
                 std::string base64_encrypted_value;
@@ -95,6 +106,10 @@ namespace optionx::storage {
         /// \return True if session value is stored successfully, otherwise false.
         bool set_session_value(const std::string& platform, const std::string& email, const std::string& value) {
             std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_db) {
+                LOGIT_WARN("Session database is not open.");
+                return false;
+            }
             std::string key = platform + ":" + email;
             try {
                 m_db->insert_or_assign(utils::Base64::encode(key), utils::Base64::encode(m_aes.encrypt(value)));
@@ -113,6 +128,10 @@ namespace optionx::storage {
         /// \return True if session value is removed successfully, otherwise false.
         bool remove_session(const std::string& platform, const std::string& email) {
             std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_db) {
+                LOGIT_WARN("Session database is not open.");
+                return false;
+            }
             std::string key = platform + ":" + email;
             try {
                 m_db->erase(utils::Base64::encode(key));
@@ -129,6 +148,10 @@ namespace optionx::storage {
         /// \return True if database is cleared successfully, otherwise false.
         bool clear() {
             std::lock_guard<std::mutex> lock(m_mutex);
+            if (!m_db) {
+                LOGIT_WARN("Session database is not open.");
+                return false;
+            }
             try {
                 m_db->clear();
                 return true;
@@ -144,12 +167,15 @@ namespace optionx::storage {
         /// \details Disconnects database and clears encryption key.
         void shutdown() {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_db->disconnect();
+            if (m_db) {
+                m_db->disconnect();
+                m_db.reset();
+            }
             m_aes.clear_key();
         }
 
     private:
-        std::mutex       m_mutex; ///< Mutex for thread safety.
+        mutable std::mutex m_mutex; ///< Mutex for thread safety.
         crypto::AESCrypt m_aes;   ///< AES encryption and decryption instance.
         std::unique_ptr<mdbxc::KeyValueTable<std::string, std::string>> m_db; ///< The SQLite KeyValueDB instance.
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
@@ -538,7 +538,7 @@ namespace optionx::storage {
 
         const auto existing_composite_opt = m_trade_id_index->find(record.trade_id, txn);
         const auto ts_ms = detail::selected_timestamp_ms(record);
-        const auto unix_minutes = static_cast<std::int32_t>(ts_ms / 60000);
+        const auto unix_minutes = detail::timestamp_ms_to_unix_minutes(ts_ms);
         const auto new_composite_key = detail::make_composite_key(
             unix_minutes,
             static_cast<std::uint32_t>(record.trade_id));
@@ -618,7 +618,7 @@ namespace optionx::storage {
 
         const auto existing_composite_opt = m_trade_id_index->find(selected_trade_id, txn);
         const auto ts_ms = detail::selected_timestamp_ms(record);
-        const auto unix_minutes = static_cast<std::int32_t>(ts_ms / 60000);
+        const auto unix_minutes = detail::timestamp_ms_to_unix_minutes(ts_ms);
         const auto new_composite_key = detail::make_composite_key(
             unix_minutes,
             static_cast<std::uint32_t>(selected_trade_id));
@@ -722,7 +722,7 @@ namespace optionx::storage {
             return detail::list_error(TradeRecordDBStatus::INVALID_ARGUMENT, "TradeRecord timestamp is invalid");
         }
 
-        const auto target_min = static_cast<std::int32_t>(timestamp_ms / 60000);
+        const auto target_min = detail::timestamp_ms_to_unix_minutes(timestamp_ms);
         const auto start_key = detail::make_composite_key(target_min, 0);
         const auto stop_key = detail::make_composite_key(target_min, 0xFFFFFFFFu);
 
@@ -756,8 +756,8 @@ namespace optionx::storage {
             return detail::list_error(TradeRecordDBStatus::INVALID_ARGUMENT, "TradeRecord timestamp range is invalid");
         }
 
-        const auto start_min = static_cast<std::int32_t>(start_ms / 60000);
-        const auto stop_min = static_cast<std::int32_t>(stop_ms / 60000);
+        const auto start_min = detail::timestamp_ms_to_unix_minutes(start_ms);
+        const auto stop_min = detail::timestamp_ms_to_unix_minutes(stop_ms);
         const auto start_key = detail::make_composite_key(start_min, 0);
         const auto stop_key = detail::make_composite_key(stop_min, 0xFFFFFFFFu);
 
@@ -814,8 +814,14 @@ namespace optionx::storage {
             }
         }
 
-        const auto start_min = static_cast<std::int32_t>(coarse_start_ms / 60000);
-        const auto stop_min = static_cast<std::int32_t>(coarse_stop_ms / 60000);
+        const auto start_min =
+            query.range_mode == optionx::TimeRangeMode::NONE
+                ? std::numeric_limits<std::int32_t>::min()
+                : detail::timestamp_ms_to_unix_minutes(coarse_start_ms);
+        const auto stop_min =
+            query.range_mode == optionx::TimeRangeMode::NONE
+                ? std::numeric_limits<std::int32_t>::max()
+                : detail::timestamp_ms_to_unix_minutes(coarse_stop_ms);
         const auto start_key = detail::make_composite_key(start_min, 0);
         const auto stop_key = detail::make_composite_key(stop_min, 0xFFFFFFFFu);
 

--- a/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
@@ -6,6 +6,7 @@
 /// \brief Internal helpers used only by TradeRecordDB.
 
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -45,6 +46,19 @@ namespace optionx::storage::detail {
     /// \brief Extracts unix minutes from a composite key.
     inline std::int32_t composite_key_minutes(std::uint64_t key) noexcept {
         return unbias_minutes(static_cast<std::uint32_t>(key >> 32));
+    }
+
+    /// \brief Converts milliseconds to unix minutes with int32 composite-key bounds.
+    inline std::int32_t timestamp_ms_to_unix_minutes(std::int64_t timestamp_ms) noexcept {
+        constexpr auto kMinMinutes = std::numeric_limits<std::int32_t>::min();
+        constexpr auto kMaxMinutes = std::numeric_limits<std::int32_t>::max();
+        constexpr auto kMsPerMinute = static_cast<std::int64_t>(60000);
+        constexpr auto kMinMs = static_cast<std::int64_t>(kMinMinutes) * kMsPerMinute;
+        constexpr auto kMaxMs = static_cast<std::int64_t>(kMaxMinutes) * kMsPerMinute;
+
+        if (timestamp_ms <= kMinMs) return kMinMinutes;
+        if (timestamp_ms >= kMaxMs) return kMaxMinutes;
+        return static_cast<std::int32_t>(timestamp_ms / kMsPerMinute);
     }
 
     /// \brief Extracts trade index from a composite key.

--- a/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/detail.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <utility>
 
+#include <time_shield/time_unit_conversions.hpp>
+
 #include "data.hpp"
 
 namespace optionx::storage::detail {
@@ -52,13 +54,11 @@ namespace optionx::storage::detail {
     inline std::int32_t timestamp_ms_to_unix_minutes(std::int64_t timestamp_ms) noexcept {
         constexpr auto kMinMinutes = std::numeric_limits<std::int32_t>::min();
         constexpr auto kMaxMinutes = std::numeric_limits<std::int32_t>::max();
-        constexpr auto kMsPerMinute = static_cast<std::int64_t>(60000);
-        constexpr auto kMinMs = static_cast<std::int64_t>(kMinMinutes) * kMsPerMinute;
-        constexpr auto kMaxMs = static_cast<std::int64_t>(kMaxMinutes) * kMsPerMinute;
+        const auto minutes = time_shield::ms_to_min<std::int64_t>(timestamp_ms);
 
-        if (timestamp_ms <= kMinMs) return kMinMinutes;
-        if (timestamp_ms >= kMaxMs) return kMaxMinutes;
-        return static_cast<std::int32_t>(timestamp_ms / kMsPerMinute);
+        if (minutes <= static_cast<std::int64_t>(kMinMinutes)) return kMinMinutes;
+        if (minutes >= static_cast<std::int64_t>(kMaxMinutes)) return kMaxMinutes;
+        return static_cast<std::int32_t>(minutes);
     }
 
     /// \brief Extracts trade index from a composite key.

--- a/include/optionx_cpp/utils.hpp
+++ b/include/optionx_cpp/utils.hpp
@@ -23,6 +23,7 @@
 #include "utils/time_utils.hpp"       ///< Time-related utilities, including timestamp retrieval.
 #include "utils/trade_id.hpp"         ///< Unique trade identifier generator
 #include "utils/correlation_id.hpp"   ///< Unique correlation identifier generator
+#include "utils/log_redaction.hpp"    ///< Secret redaction helpers for diagnostics.
 
 // Data encoding
 #include "utils/Base36.hpp"           ///< Base36 encoding/decoding implementation

--- a/include/optionx_cpp/utils/log_redaction.hpp
+++ b/include/optionx_cpp/utils/log_redaction.hpp
@@ -5,6 +5,8 @@
 /// \file log_redaction.hpp
 /// \brief Helpers for removing sensitive values from diagnostic logs.
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 
 namespace optionx::utils {
@@ -12,8 +14,98 @@ namespace optionx::utils {
     /// \brief Replaces a sensitive value with a fixed redaction marker.
     /// \param value Secret value that must not be written to logs.
     /// \return Empty string for empty values, otherwise "***".
-    inline std::string redact_secret(const std::string& value) {
+    inline std::string redact_secret_value(const std::string& value) {
         return value.empty() ? std::string() : std::string("***");
+    }
+
+    /// \brief Backward-compatible alias for redacting a single sensitive value.
+    inline std::string redact_secret(const std::string& value) {
+        return redact_secret_value(value);
+    }
+
+    /// \brief Redacts common secret fields inside a diagnostic string.
+    /// \param text Text that may contain key/value secrets.
+    /// \return Text with recognized secret values replaced by "***".
+    inline std::string redact_secrets_in_text(std::string text) {
+        static constexpr const char* keys[] = {
+            "auth_token",
+            "authorization",
+            "cookie",
+            "cookies",
+            "password",
+            "passwd",
+            "proxy_auth",
+            "session",
+            "token",
+            "user_hash",
+            "x-api-token"
+        };
+
+        auto to_lower_ascii = [](std::string value) {
+            std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+                return static_cast<char>(std::tolower(ch));
+            });
+            return value;
+        };
+
+        auto is_key_boundary = [](char ch) {
+            return !(std::isalnum(static_cast<unsigned char>(ch)) || ch == '_' || ch == '-');
+        };
+
+        auto is_value_delimiter = [](char ch) {
+            return ch == '&' || ch == ',' || ch == ';' ||
+                   ch == '\r' || ch == '\n' || ch == '\t' || ch == ' ';
+        };
+
+        std::string lower = to_lower_ascii(text);
+        for (const std::string key : keys) {
+            std::size_t pos = 0;
+            while ((pos = lower.find(key, pos)) != std::string::npos) {
+                const bool left_ok = (pos == 0) || is_key_boundary(lower[pos - 1]);
+                const std::size_t key_end = pos + key.size();
+                const bool right_ok = key_end >= lower.size() || is_key_boundary(lower[key_end]);
+                if (!left_ok || !right_ok) {
+                    pos = key_end;
+                    continue;
+                }
+
+                std::size_t sep = key_end;
+                while (sep < lower.size() && lower[sep] == ' ') ++sep;
+                if (sep >= lower.size() || (lower[sep] != '=' && lower[sep] != ':')) {
+                    pos = key_end;
+                    continue;
+                }
+
+                std::size_t value_begin = sep + 1;
+                while (value_begin < lower.size() && lower[value_begin] == ' ') ++value_begin;
+                if (value_begin >= lower.size()) {
+                    pos = value_begin;
+                    continue;
+                }
+
+                const char quote = (lower[value_begin] == '"' || lower[value_begin] == '\'')
+                    ? lower[value_begin]
+                    : '\0';
+                if (quote != '\0') ++value_begin;
+
+                std::size_t value_end = value_begin;
+                if (quote != '\0') {
+                    while (value_end < lower.size() && lower[value_end] != quote) ++value_end;
+                } else if (key == "cookie" || key == "cookies" || key == "authorization") {
+                    while (value_end < lower.size() && lower[value_end] != '\r' && lower[value_end] != '\n') {
+                        ++value_end;
+                    }
+                } else {
+                    while (value_end < lower.size() && !is_value_delimiter(lower[value_end])) ++value_end;
+                }
+
+                text.replace(value_begin, value_end - value_begin, "***");
+                lower = to_lower_ascii(text);
+                pos = value_begin + 3;
+            }
+        }
+
+        return text;
     }
 
 } // namespace optionx::utils

--- a/include/optionx_cpp/utils/log_redaction.hpp
+++ b/include/optionx_cpp/utils/log_redaction.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef _OPTIONX_UTILS_LOG_REDACTION_HPP_INCLUDED
+#define _OPTIONX_UTILS_LOG_REDACTION_HPP_INCLUDED
+
+/// \file log_redaction.hpp
+/// \brief Helpers for removing sensitive values from diagnostic logs.
+
+#include <string>
+
+namespace optionx::utils {
+
+    /// \brief Replaces a sensitive value with a fixed redaction marker.
+    /// \param value Secret value that must not be written to logs.
+    /// \return Empty string for empty values, otherwise "***".
+    inline std::string redact_secret(const std::string& value) {
+        return value.empty() ? std::string() : std::string("***");
+    }
+
+} // namespace optionx::utils
+
+#endif // _OPTIONX_UTILS_LOG_REDACTION_HPP_INCLUDED

--- a/include/optionx_cpp/utils/tasks/Task.hpp
+++ b/include/optionx_cpp/utils/tasks/Task.hpp
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <chrono>
 #include <memory>
+#include <string>
 #include <time_shield.hpp>
 #include <logit_cpp/logit.hpp>
 
@@ -78,6 +79,13 @@ namespace optionx::utils {
         }
 
         ~Task() = default;
+
+        /// \brief Checks if a periodic task period can be used safely.
+        /// \param period_ms Period in milliseconds.
+        /// \return True when the period is positive.
+        static bool is_valid_period(int64_t period_ms) noexcept {
+            return period_ms > 0;
+        }
         
         const std::string& name() const {
             return m_name;
@@ -110,11 +118,17 @@ namespace optionx::utils {
 
         /// \brief Sets a new period for periodic tasks.
         /// \param new_period_ms The new period in milliseconds.
-        void set_period(int64_t new_period_ms) {
+        /// \return True if the period was updated; false if the value is invalid.
+        bool set_period(int64_t new_period_ms) {
+            if (!is_valid_period(new_period_ms)) {
+                LOGIT_ERROR("Task period must be positive.");
+                return false;
+            }
             std::lock_guard<std::mutex> lock(m_mutex);
             m_start_time -= m_period_ms;
             m_period_ms = new_period_ms;
             m_start_time += m_period_ms;
+            return true;
         }
 
         /// \brief Resets the timer for periodic tasks.
@@ -258,6 +272,12 @@ namespace optionx::utils {
             }
             case TaskType::PERIODIC: {
                 std::unique_lock<std::mutex> lock(m_mutex);
+                if (!is_valid_period(m_period_ms)) {
+                    lock.unlock();
+                    LOGIT_ERROR("Periodic task has invalid period.");
+                    m_completed = true;
+                    break;
+                }
                 m_execution_time = m_start_time;
                 if (current_time_ms >= m_start_time || m_force_execute || m_shutdown) {
                     while (current_time_ms >= m_start_time) {
@@ -270,6 +290,12 @@ namespace optionx::utils {
             }
             case TaskType::DELAYED_PERIODIC: {
                 std::unique_lock<std::mutex> lock(m_mutex);
+                if (!is_valid_period(m_period_ms)) {
+                    lock.unlock();
+                    LOGIT_ERROR("Delayed periodic task has invalid period.");
+                    m_completed = true;
+                    break;
+                }
                 m_execution_time = m_next_execution_time;
                 if (current_time_ms >= m_next_execution_time || m_force_execute || m_shutdown) {
                     while (current_time_ms >= m_next_execution_time) {
@@ -292,6 +318,12 @@ namespace optionx::utils {
             }
             case TaskType::PERIODIC_ON_DATE: {
                 std::unique_lock<std::mutex> lock(m_mutex);
+                if (!is_valid_period(m_period_ms)) {
+                    lock.unlock();
+                    LOGIT_ERROR("Periodic on-date task has invalid period.");
+                    m_completed = true;
+                    break;
+                }
                 m_execution_time = m_timestamp_ms;
                 if (current_time_ms >= m_timestamp_ms || m_force_execute || m_shutdown) {
                     while (current_time_ms >= m_timestamp_ms) {

--- a/include/optionx_cpp/utils/tasks/TaskManager.hpp
+++ b/include/optionx_cpp/utils/tasks/TaskManager.hpp
@@ -6,6 +6,7 @@
 /// \brief Contains the definition of the TaskManager class for managing tasks.
 
 #include "Task.hpp"
+#include <algorithm>
 #include <list>
 #include <mutex>
 #include <atomic>
@@ -52,7 +53,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_periodic_task(int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(TaskType::PERIODIC, std::move(callback), 0, period_ms));
             return true;
         }
@@ -62,7 +63,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_delayed_periodic_task(int64_t delay_ms, int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(TaskType::DELAYED_PERIODIC, std::move(callback), delay_ms, period_ms));
             return true;
         }
@@ -81,7 +82,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_periodic_on_date_task(int64_t timestamp_ms, int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(TaskType::PERIODIC_ON_DATE, std::move(callback), 0, period_ms, timestamp_ms));
             return true;
         }
@@ -112,7 +113,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_periodic_task(std::string name, int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(std::move(name), TaskType::PERIODIC, std::move(callback), 0, period_ms));
             return true;
         }
@@ -123,7 +124,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_delayed_periodic_task(std::string name, int64_t delay_ms, int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(std::move(name), TaskType::DELAYED_PERIODIC, std::move(callback), delay_ms, period_ms));
             return true;
         }
@@ -144,7 +145,7 @@ namespace optionx::utils {
         /// \param period_ms Period in milliseconds between executions.
         /// \param callback The callback function to execute.
         bool add_periodic_on_date_task(std::string name, int64_t timestamp_ms, int64_t period_ms, Task::Callback callback) {
-            if (m_shutdown) return false;
+            if (!can_add_periodic_task(period_ms)) return false;
             add_task(std::make_shared<Task>(std::move(name), TaskType::PERIODIC_ON_DATE, std::move(callback), 0, period_ms, timestamp_ms));
             return true;
         }
@@ -263,6 +264,16 @@ namespace optionx::utils {
             m_pending_tasks.push_back(std::move(task));
             lock.unlock();
             m_cv.notify_one();
+        }
+
+        /// \brief Validates state and period before adding a periodic task.
+        bool can_add_periodic_task(int64_t period_ms) const {
+            if (m_shutdown) return false;
+            if (!Task::is_valid_period(period_ms)) {
+                LOGIT_ERROR("Periodic task period must be positive.");
+                return false;
+            }
+            return true;
         }
     }; // TaskManager
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -77,6 +77,28 @@ TEST(IntradeBarAuthData, KeepsDisconnectedDomainRetryPeriodInConfig) {
     EXPECT_EQ(order_interval_message, "Order interval must be non-negative");
 }
 
+TEST(IntradeBarApiResponses, ParsesBalanceWithCommaDotIntegerAndUtf8Ruble) {
+    const auto comma_usd = parse_balance("12,34 $");
+    ASSERT_TRUE(comma_usd.has_value());
+    EXPECT_DOUBLE_EQ(comma_usd->first, 12.34);
+    EXPECT_EQ(comma_usd->second, CurrencyType::USD);
+
+    const auto dot_usd = parse_balance("12.34 USD");
+    ASSERT_TRUE(dot_usd.has_value());
+    EXPECT_DOUBLE_EQ(dot_usd->first, 12.34);
+    EXPECT_EQ(dot_usd->second, CurrencyType::USD);
+
+    const auto integer_usd = parse_balance("12 $");
+    ASSERT_TRUE(integer_usd.has_value());
+    EXPECT_DOUBLE_EQ(integer_usd->first, 12.0);
+    EXPECT_EQ(integer_usd->second, CurrencyType::USD);
+
+    const auto rub = parse_balance(std::string("123,45 ") + "\xE2\x82\xBD");
+    ASSERT_TRUE(rub.has_value());
+    EXPECT_DOUBLE_EQ(rub->first, 123.45);
+    EXPECT_EQ(rub->second, CurrencyType::RUB);
+}
+
 TEST(IntradeBarApiResponses, TradeWorkflowPayloadsKeepBrokerSpecificFieldsTyped) {
     TradeOpenInfo opened;
     opened.option_id = 123;

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -169,7 +169,7 @@ namespace optionx::modules {
             }
             case AccountInfoType::PAYOUT_ABOVE_MIN:
                 if (request.min_payout == 0.0) return true;
-                return (request.min_payout >= get_payout(request));
+                return (get_payout(request) >= request.min_payout);
             case AccountInfoType::AMOUNT_BELOW_BALANCE:
                 return (request.amount <= balance);
             default:
@@ -508,6 +508,40 @@ std::unique_ptr<TradeRequest> make_valid_sprint_trade_request() {
     trade_request->order_type = OrderType::BUY;
     trade_request->duration = 10;
     return trade_request;
+}
+
+TEST(AccountInfoDataTest, PayoutAboveMinAcceptsBrokerPayoutGreaterThanMinimum) {
+    optionx::platforms::intrade_bar::AccountInfoData account_info;
+    account_info.currency = CurrencyType::USD;
+    account_info.account_type = AccountType::DEMO;
+
+    auto request = std::make_shared<TradeRequest>();
+    request->symbol = "EURUSD";
+    request->amount = 10.0;
+    request->currency = CurrencyType::USD;
+    request->account_type = AccountType::DEMO;
+    request->option_type = OptionType::SPRINT;
+    request->order_type = OrderType::BUY;
+    request->duration = 180;
+    const int64_t timestamp = 1719302400;
+
+    request->min_payout = 0.81;
+    EXPECT_TRUE(account_info.get_for_trade<bool>(
+        AccountInfoType::PAYOUT_ABOVE_MIN,
+        request,
+        timestamp));
+
+    request->min_payout = 0.82;
+    EXPECT_TRUE(account_info.get_for_trade<bool>(
+        AccountInfoType::PAYOUT_ABOVE_MIN,
+        request,
+        timestamp));
+
+    request->min_payout = 0.83;
+    EXPECT_FALSE(account_info.get_for_trade<bool>(
+        AccountInfoType::PAYOUT_ABOVE_MIN,
+        request,
+        timestamp));
 }
 
 TEST_F(TradeManagerTestFixture, OrderIntervalDelaysQueuedTrades) {

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -16,6 +16,7 @@ using optionx::TradeRecord;
 using optionx::storage::TradeRecordDB;
 using optionx::storage::TradeRecordDBStatus;
 using optionx::storage::detail::selected_timestamp_ms;
+using optionx::storage::detail::timestamp_ms_to_unix_minutes;
 
 std::string unique_db_path(const std::string& name) {
     static std::atomic<std::uint64_t> counter{0};
@@ -389,6 +390,12 @@ TEST(CompositeKeyTest, OrdersAcrossMinuteBuckets) {
     EXPECT_EQ(selected_timestamp_ms(range.records[0]), ts_bucket0);
     EXPECT_EQ(selected_timestamp_ms(range.records[1]), ts_bucket1);
     EXPECT_EQ(selected_timestamp_ms(range.records[2]), ts_bucket2);
+}
+
+TEST(CompositeKeyTest, ConvertsNegativeTimestampsUsingFloorMinutes) {
+    EXPECT_EQ(timestamp_ms_to_unix_minutes(-1), -1);
+    EXPECT_EQ(timestamp_ms_to_unix_minutes(-60000), -1);
+    EXPECT_EQ(timestamp_ms_to_unix_minutes(-60001), -2);
 }
 
 TEST(CompositeKeyTest, UpdateMovesBetweenMinuteBuckets) {

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -180,6 +180,19 @@ TEST(TradeRecordDBTest, UpsertFindMigrateEraseClearAndCount) {
     EXPECT_EQ(db.get_trade_id(), 1u);
 }
 
+TEST(TradeRecordDBTest, DefaultQueryReturnsAllModernRecords) {
+    const auto config = make_config("trade_record_db_default_query");
+    TradeRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    ASSERT_TRUE(db.upsert(make_record(1, 1712345600100)).ok());
+
+    const auto result = db.find_records(optionx::TradeRecordQuery{});
+    ASSERT_TRUE(result.ok()) << result.message;
+    ASSERT_EQ(result.records.size(), 1u);
+    EXPECT_EQ(result.records[0].request_unique_id, 1);
+}
+
 TEST(TradeRecordDBTest, WriteRemovesStaleUidIndexWhenUidChanges) {
     const auto config = make_config("trade_record_db_stale_uid");
     TradeRecordDB db(config);

--- a/tests/utils_task_manager_test.cpp
+++ b/tests/utils_task_manager_test.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/utils.hpp>
+
+TEST(LogRedactionTest, RedactsNonEmptySecrets) {
+    EXPECT_TRUE(optionx::utils::redact_secret("").empty());
+    EXPECT_EQ(optionx::utils::redact_secret("session=abc"), "***");
+}
+
+TEST(TaskManagerTest, RejectsInvalidPeriodicPeriods) {
+    optionx::utils::TaskManager manager;
+    auto callback = [](std::shared_ptr<optionx::utils::Task>) {};
+
+    EXPECT_FALSE(manager.add_periodic_task(0, callback));
+    EXPECT_FALSE(manager.add_periodic_task(-1, callback));
+    EXPECT_FALSE(manager.add_delayed_periodic_task(1, 0, callback));
+    EXPECT_FALSE(manager.add_periodic_on_date_task(1, 0, callback));
+    EXPECT_FALSE(manager.add_periodic_task("bad-periodic", 0, callback));
+    EXPECT_FALSE(manager.add_delayed_periodic_task("bad-delayed-periodic", 1, 0, callback));
+    EXPECT_FALSE(manager.add_periodic_on_date_task("bad-periodic-on-date", 1, 0, callback));
+}
+
+TEST(TaskTest, KeepsPreviousPeriodWhenSetPeriodIsInvalid) {
+    int calls = 0;
+    auto task = std::make_shared<optionx::utils::Task>(
+        optionx::utils::TaskType::PERIODIC,
+        [&calls](std::shared_ptr<optionx::utils::Task>) {
+            ++calls;
+        },
+        0,
+        10);
+
+    EXPECT_FALSE(task->set_period(0));
+    EXPECT_TRUE(task->set_period(1));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/utils_task_manager_test.cpp
+++ b/tests/utils_task_manager_test.cpp
@@ -3,8 +3,26 @@
 #include <optionx_cpp/utils.hpp>
 
 TEST(LogRedactionTest, RedactsNonEmptySecrets) {
-    EXPECT_TRUE(optionx::utils::redact_secret("").empty());
-    EXPECT_EQ(optionx::utils::redact_secret("session=abc"), "***");
+    EXPECT_TRUE(optionx::utils::redact_secret_value("").empty());
+    EXPECT_EQ(optionx::utils::redact_secret_value("session=abc"), "***");
+    EXPECT_EQ(optionx::utils::redact_secret("legacy-token"), "***");
+}
+
+TEST(LogRedactionTest, RedactsSecretFieldsInsideText) {
+    using optionx::utils::redact_secrets_in_text;
+
+    EXPECT_EQ(
+        redact_secrets_in_text("status=ok token=abc123 user_hash=deadbeef"),
+        "status=ok token=*** user_hash=***");
+    EXPECT_EQ(
+        redact_secrets_in_text("password=secret&symbol=EURUSD"),
+        "password=***&symbol=EURUSD");
+    EXPECT_EQ(
+        redact_secrets_in_text("Cookie: user_id=42; user_hash=deadbeef"),
+        "Cookie: ***");
+    EXPECT_EQ(
+        redact_secrets_in_text("plain diagnostic text"),
+        "plain diagnostic text");
 }
 
 TEST(TaskManagerTest, RejectsInvalidPeriodicPeriods) {


### PR DESCRIPTION
## Summary
- fix Intrade Bar payout-min validation and balance parsing edge cases
- make BalanceManager connected/disconnected task transitions single-path through AccountInfoUpdateEvent
- redact broker cookies/tokens in logs, and add a helper for masking secret fields inside diagnostic text
- harden periodic task scheduling against zero/negative periods
- make ServiceSessionDB tolerate failed DB open without null dereference
- make TradeRecordQuery{} mean all records and use time_shield minute conversion for DB timestamp keys

## Validation
- cmake --build build-codex --target intrade_bar_api_response_test trade_manager_test trade_record_db_test utils_task_manager_test -- -j1
- cmake --build build-codex --target utils_task_manager_test trade_record_db_test intrade_bar_api_response_test -- -j1
- .\build-codex\intrade_bar_api_response_test.exe --gtest_brief=1
- .\build-codex\trade_manager_test.exe --gtest_brief=1
- .\build-codex\trade_record_db_test.exe --gtest_brief=1
- .\build-codex\utils_task_manager_test.exe --gtest_brief=1
- .\build-codex\trade_record_stats_test.exe --gtest_brief=1
- .\build-codex\trade_record_storage_test.exe --gtest_brief=1
- .\build-codex\trade_result_query_test.exe --gtest_brief=1
- .\build-codex\intrade_bar_platform_test.exe --gtest_brief=1
- git diff --check