### PR TITLE
feat(trading): add DST-aware trade time zones

### DIFF
--- a/include/optionx_cpp/data/trading.hpp
+++ b/include/optionx_cpp/data/trading.hpp
@@ -35,6 +35,7 @@
 #include "trading/TradeResult.hpp"
 #include "trading/TradeResultQuery.hpp"
 #include "trading/TradeRecordTimeRange.hpp"
+#include "trading/TradeTimeZone.hpp"
 #include "trading/TradeHistoryRequest.hpp"
 #include "trading/TradeRequest.hpp"
 #include "trading/IMoneyManagementParams.hpp"

--- a/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordQuery.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "TradeRecordTimeRange.hpp"
+#include "TradeTimeZone.hpp"
 #include "TradeRecordFilter.hpp"
 #include "TradeRecord.hpp"
 
@@ -47,7 +48,7 @@ namespace optionx {
     public:
         std::int64_t start_ms = 0;       ///< Range start in milliseconds (UTC).
         std::int64_t stop_ms = 0;        ///< Range end in milliseconds (UTC).
-        std::int64_t time_zone_sec = 0;  ///< Time zone offset in seconds for local-time filtering.
+        TradeTimeZone time_zone;         ///< Local-time context for component filters.
 
         TradeRecordTimeField time_field = TradeRecordTimeField::AUTO; ///< Which timestamp to query on.
         TimeRangeMode range_mode = TimeRangeMode::NONE;               ///< Range inclusion mode.

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -15,6 +15,7 @@
 #include "enums.hpp"
 #include "TradeRecord.hpp"
 #include "TradeRecordFilter.hpp"
+#include "TradeTimeZone.hpp"
 #include "utils/trade_state_utils.hpp"
 
 namespace optionx {
@@ -168,7 +169,7 @@ namespace optionx {
     public:
         TradeStatsSelection selection = TradeStatsSelection::ALL_TRADES;
         double start_balance = 0.0;
-        std::int64_t time_zone_sec = 0;
+        TradeTimeZone time_zone;
         TradeRecordFilter filter;
         bool include_errors = false;
         bool include_non_terminal = false;

--- a/include/optionx_cpp/data/trading/TradeTimeZone.hpp
+++ b/include/optionx_cpp/data/trading/TradeTimeZone.hpp
@@ -1,0 +1,133 @@
+#pragma once
+#ifndef _OPTIONX_TRADE_TIME_ZONE_HPP_INCLUDED
+#define _OPTIONX_TRADE_TIME_ZONE_HPP_INCLUDED
+
+/// \file TradeTimeZone.hpp
+/// \brief Defines a local-time context for trade queries and statistics.
+
+#include <cstdint>
+
+#include <time_shield/constants.hpp>
+#include <time_shield/date_time_conversions.hpp>
+#include <time_shield/enums.hpp>
+#include <time_shield/time_zone_conversions.hpp>
+#include <time_shield/types.hpp>
+
+namespace optionx {
+
+    /// \enum TradeTimeZoneMode
+    /// \brief Selects whether local-time calculations use a fixed offset or a named zone.
+    enum class TradeTimeZoneMode {
+        FIXED_OFFSET, ///< Fixed UTC offset in seconds.
+        NAMED_ZONE    ///< time-shield named zone with historical/DST offset resolution.
+    };
+
+    /// \class TradeTimeZone
+    /// \brief Time-zone context used by local-time filters, buckets and day queries.
+    ///
+    /// Fixed-offset mode preserves the old `time_zone_sec` behavior. Named-zone
+    /// mode delegates offset resolution to time-shield and therefore accounts for
+    /// DST transitions supported by `time_shield::TimeZone`.
+    class TradeTimeZone {
+    public:
+        TradeTimeZoneMode mode = TradeTimeZoneMode::FIXED_OFFSET;
+        std::int64_t offset_sec = 0;
+        time_shield::TimeZone zone = time_shield::UTC;
+
+        /// \brief Creates UTC fixed-offset context.
+        static TradeTimeZone utc() noexcept {
+            return fixed_offset(0);
+        }
+
+        /// \brief Creates fixed-offset context.
+        /// \param offset_seconds UTC offset in seconds.
+        static TradeTimeZone fixed_offset(std::int64_t offset_seconds) noexcept {
+            TradeTimeZone result;
+            result.mode = TradeTimeZoneMode::FIXED_OFFSET;
+            result.offset_sec = offset_seconds;
+            result.zone = time_shield::UTC;
+            return result;
+        }
+
+        /// \brief Creates named-zone context.
+        /// \param value time-shield zone value. UNKNOWN falls back to UTC.
+        static TradeTimeZone named(time_shield::TimeZone value) noexcept {
+            if (value == time_shield::UNKNOWN) {
+                return utc();
+            }
+
+            TradeTimeZone result;
+            result.mode = TradeTimeZoneMode::NAMED_ZONE;
+            result.offset_sec = 0;
+            result.zone = value;
+            return result;
+        }
+
+        /// \brief Returns true when this context uses time-shield named-zone rules.
+        bool is_named_zone() const noexcept {
+            return mode == TradeTimeZoneMode::NAMED_ZONE &&
+                   zone != time_shield::UNKNOWN;
+        }
+
+        /// \brief Resolves UTC offset for the provided UTC timestamp.
+        /// \param utc_ms UTC timestamp in milliseconds.
+        /// \return Offset in seconds. Unsupported named zones fall back to UTC.
+        std::int64_t offset_at_utc_ms(std::int64_t utc_ms) const noexcept {
+            if (!is_named_zone()) {
+                return offset_sec;
+            }
+
+            time_shield::tz_t resolved = 0;
+            return time_shield::zone_offset_at_utc_ms(
+                static_cast<time_shield::ts_ms_t>(utc_ms),
+                zone,
+                resolved)
+                    ? static_cast<std::int64_t>(resolved)
+                    : 0;
+        }
+
+        /// \brief Converts UTC milliseconds to this context's local civil milliseconds.
+        std::int64_t to_local_ms(std::int64_t utc_ms) const noexcept {
+            return utc_ms + offset_at_utc_ms(utc_ms) * time_shield::MS_PER_SEC;
+        }
+
+        /// \brief Converts local civil milliseconds in this context back to UTC.
+        std::int64_t to_utc_ms(std::int64_t local_ms) const noexcept {
+            if (!is_named_zone()) {
+                return local_ms - offset_sec * time_shield::MS_PER_SEC;
+            }
+
+            const auto utc_ms = time_shield::zone_to_gmt_ms(
+                static_cast<time_shield::ts_ms_t>(local_ms),
+                zone,
+                time_shield::AmbiguousTimePolicy::first_occurrence,
+                time_shield::NonexistentTimePolicy::shift_forward);
+            if (utc_ms == time_shield::ERROR_TIMESTAMP) {
+                return local_ms;
+            }
+            return static_cast<std::int64_t>(utc_ms);
+        }
+
+        /// \brief Returns UTC timestamp for local day start containing utc_ms.
+        std::int64_t start_of_local_day_utc_ms(std::int64_t utc_ms) const noexcept {
+            const auto local_ms = to_local_ms(utc_ms);
+            return to_utc_ms(time_shield::start_of_day_ms(local_ms));
+        }
+
+        /// \brief Returns UTC timestamp for next local day start after the day containing utc_ms.
+        std::int64_t next_local_day_start_utc_ms(std::int64_t utc_ms) const noexcept {
+            const auto local_ms = to_local_ms(utc_ms);
+            const auto day_start_local = time_shield::start_of_day_ms(local_ms);
+            return to_utc_ms(day_start_local + time_shield::MS_PER_DAY);
+        }
+
+        /// \brief Returns UTC timestamp for local hour start containing utc_ms.
+        std::int64_t start_of_local_hour_utc_ms(std::int64_t utc_ms) const noexcept {
+            const auto local_ms = to_local_ms(utc_ms);
+            return to_utc_ms(time_shield::start_of_hour_ms(local_ms));
+        }
+    };
+
+} // namespace optionx
+
+#endif // _OPTIONX_TRADE_TIME_ZONE_HPP_INCLUDED

--- a/include/optionx_cpp/data/trading/TradeTimeZone.hpp
+++ b/include/optionx_cpp/data/trading/TradeTimeZone.hpp
@@ -30,10 +30,6 @@ namespace optionx {
     /// DST transitions supported by `time_shield::TimeZone`.
     class TradeTimeZone {
     public:
-        TradeTimeZoneMode mode = TradeTimeZoneMode::FIXED_OFFSET;
-        std::int64_t offset_sec = 0;
-        time_shield::TimeZone zone = time_shield::UTC;
-
         /// \brief Creates UTC fixed-offset context.
         static TradeTimeZone utc() noexcept {
             return fixed_offset(0);
@@ -43,9 +39,9 @@ namespace optionx {
         /// \param offset_seconds UTC offset in seconds.
         static TradeTimeZone fixed_offset(std::int64_t offset_seconds) noexcept {
             TradeTimeZone result;
-            result.mode = TradeTimeZoneMode::FIXED_OFFSET;
-            result.offset_sec = offset_seconds;
-            result.zone = time_shield::UTC;
+            result.m_mode = TradeTimeZoneMode::FIXED_OFFSET;
+            result.m_offset_sec = offset_seconds;
+            result.m_zone = time_shield::UTC;
             return result;
         }
 
@@ -57,16 +53,31 @@ namespace optionx {
             }
 
             TradeTimeZone result;
-            result.mode = TradeTimeZoneMode::NAMED_ZONE;
-            result.offset_sec = 0;
-            result.zone = value;
+            result.m_mode = TradeTimeZoneMode::NAMED_ZONE;
+            result.m_offset_sec = 0;
+            result.m_zone = value;
             return result;
+        }
+
+        /// \brief Returns the stored timezone mode.
+        TradeTimeZoneMode mode() const noexcept {
+            return m_mode;
+        }
+
+        /// \brief Returns the fixed UTC offset in seconds, or 0 for named zones.
+        std::int64_t offset_sec() const noexcept {
+            return m_offset_sec;
+        }
+
+        /// \brief Returns the named zone, or UTC for fixed-offset mode.
+        time_shield::TimeZone zone() const noexcept {
+            return m_zone;
         }
 
         /// \brief Returns true when this context uses time-shield named-zone rules.
         bool is_named_zone() const noexcept {
-            return mode == TradeTimeZoneMode::NAMED_ZONE &&
-                   zone != time_shield::UNKNOWN;
+            return m_mode == TradeTimeZoneMode::NAMED_ZONE &&
+                   m_zone != time_shield::UNKNOWN;
         }
 
         /// \brief Resolves UTC offset for the provided UTC timestamp.
@@ -74,13 +85,13 @@ namespace optionx {
         /// \return Offset in seconds. Unsupported named zones fall back to UTC.
         std::int64_t offset_at_utc_ms(std::int64_t utc_ms) const noexcept {
             if (!is_named_zone()) {
-                return offset_sec;
+                return m_offset_sec;
             }
 
             time_shield::tz_t resolved = 0;
             return time_shield::zone_offset_at_utc_ms(
                 static_cast<time_shield::ts_ms_t>(utc_ms),
-                zone,
+                m_zone,
                 resolved)
                     ? static_cast<std::int64_t>(resolved)
                     : 0;
@@ -94,12 +105,12 @@ namespace optionx {
         /// \brief Converts local civil milliseconds in this context back to UTC.
         std::int64_t to_utc_ms(std::int64_t local_ms) const noexcept {
             if (!is_named_zone()) {
-                return local_ms - offset_sec * time_shield::MS_PER_SEC;
+                return local_ms - m_offset_sec * time_shield::MS_PER_SEC;
             }
 
             const auto utc_ms = time_shield::zone_to_gmt_ms(
                 static_cast<time_shield::ts_ms_t>(local_ms),
-                zone,
+                m_zone,
                 time_shield::AmbiguousTimePolicy::first_occurrence,
                 time_shield::NonexistentTimePolicy::shift_forward);
             if (utc_ms == time_shield::ERROR_TIMESTAMP) {
@@ -123,9 +134,15 @@ namespace optionx {
 
         /// \brief Returns UTC timestamp for local hour start containing utc_ms.
         std::int64_t start_of_local_hour_utc_ms(std::int64_t utc_ms) const noexcept {
-            const auto local_ms = to_local_ms(utc_ms);
-            return to_utc_ms(time_shield::start_of_hour_ms(local_ms));
+            const auto offset_ms = offset_at_utc_ms(utc_ms) * time_shield::MS_PER_SEC;
+            const auto local_ms = utc_ms + offset_ms;
+            return time_shield::start_of_hour_ms(local_ms) - offset_ms;
         }
+
+    private:
+        TradeTimeZoneMode m_mode = TradeTimeZoneMode::FIXED_OFFSET;
+        std::int64_t m_offset_sec = 0;
+        time_shield::TimeZone m_zone = time_shield::UTC;
     };
 
 } // namespace optionx

--- a/include/optionx_cpp/data/trading/TradeTimeZone.hpp
+++ b/include/optionx_cpp/data/trading/TradeTimeZone.hpp
@@ -28,6 +28,11 @@ namespace optionx {
     /// Fixed-offset mode preserves the old `time_zone_sec` behavior. Named-zone
     /// mode delegates offset resolution to time-shield and therefore accounts for
     /// DST transitions supported by `time_shield::TimeZone`.
+    ///
+    /// Conversion helpers are total functions: if an unsupported named-zone
+    /// conversion cannot be resolved, the context falls back to UTC/identity
+    /// semantics instead of pushing error handling into filters, statistics and
+    /// storage queries.
     class TradeTimeZone {
     public:
         /// \brief Creates UTC fixed-offset context.
@@ -82,7 +87,8 @@ namespace optionx {
 
         /// \brief Resolves UTC offset for the provided UTC timestamp.
         /// \param utc_ms UTC timestamp in milliseconds.
-        /// \return Offset in seconds. Unsupported named zones fall back to UTC.
+        /// \return Resolved offset in seconds. Unsupported named-zone resolution
+        ///         falls back to zero, i.e. UTC.
         std::int64_t offset_at_utc_ms(std::int64_t utc_ms) const noexcept {
             if (!is_named_zone()) {
                 return m_offset_sec;
@@ -103,6 +109,8 @@ namespace optionx {
         }
 
         /// \brief Converts local civil milliseconds in this context back to UTC.
+        /// \details Unsupported named-zone conversions fall back to treating the
+        ///          supplied civil timestamp as UTC.
         std::int64_t to_utc_ms(std::int64_t local_ms) const noexcept {
             if (!is_named_zone()) {
                 return local_ms - m_offset_sec * time_shield::MS_PER_SEC;

--- a/include/optionx_cpp/storages/TradeRecordDB.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB.hpp
@@ -196,11 +196,27 @@ namespace optionx::storage {
 
         /// \brief Finds all records for the current calendar day (local time).
         /// \param now_ms Current wall-clock time in milliseconds (UTC).
+        /// \param time_zone Local-time context used to resolve the day boundaries.
+        /// \return List result for the day containing now_ms in local time.
+        TradeRecordDBListResult find_today(
+            std::int64_t now_ms,
+            const optionx::TradeTimeZone& time_zone) const;
+
+        /// \brief Finds all records for the current calendar day using a fixed offset.
+        /// \param now_ms Current wall-clock time in milliseconds (UTC).
         /// \param time_zone_sec Time zone offset in seconds.
         /// \return List result for the day containing now_ms in local time.
         TradeRecordDBListResult find_today(std::int64_t now_ms, std::int64_t time_zone_sec = 0) const;
 
         /// \brief Finds all records for the calendar day containing day_start_ms.
+        /// \param day_start_ms Any timestamp within the target day (UTC).
+        /// \param time_zone Local-time context used to resolve the day boundaries.
+        /// \return List result for that calendar day.
+        TradeRecordDBListResult find_day(
+            std::int64_t day_start_ms,
+            const optionx::TradeTimeZone& time_zone) const;
+
+        /// \brief Finds all records for the calendar day using a fixed offset.
         /// \param day_start_ms Any timestamp within the target day (UTC).
         /// \param time_zone_sec Time zone offset in seconds.
         /// \return List result for that calendar day.
@@ -347,8 +363,12 @@ namespace optionx::storage {
         TradeRecordDBListResult find_by_timestamp_no_lock(std::int64_t timestamp_ms) const;
         TradeRecordDBListResult find_range_no_lock(std::int64_t start_ms, std::int64_t stop_ms) const;
         TradeRecordDBListResult find_records_no_lock(const optionx::TradeRecordQuery& query) const;
-        TradeRecordDBListResult find_today_no_lock(std::int64_t now_ms, std::int64_t time_zone_sec) const;
-        TradeRecordDBListResult find_day_no_lock(std::int64_t day_start_ms, std::int64_t time_zone_sec) const;
+        TradeRecordDBListResult find_today_no_lock(
+            std::int64_t now_ms,
+            const optionx::TradeTimeZone& time_zone) const;
+        TradeRecordDBListResult find_day_no_lock(
+            std::int64_t day_start_ms,
+            const optionx::TradeTimeZone& time_zone) const;
         TradeRecordDBStatus erase_by_trade_id_no_lock(std::uint64_t trade_id);
         TradeRecordDBStatus clear_no_lock();
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
@@ -36,7 +36,7 @@ namespace optionx::storage {
             std::set<std::int64_t> durations_set;
 
             for (const auto& rec : records) {
-                if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone_sec)) continue;
+                if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) continue;
                 if (!config.include_errors && optionx::is_error_trade_state(rec.trade_state)) continue;
                 if (!config.include_non_terminal && !optionx::is_terminal_trade_state(rec.trade_state)) continue;
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
@@ -188,10 +188,12 @@ namespace optionx::storage {
         return std::move(result.records);
     }
 
-    inline TradeRecordDBListResult TradeRecordDB::find_today(std::int64_t now_ms, std::int64_t time_zone_sec) const {
+    inline TradeRecordDBListResult TradeRecordDB::find_today(
+            std::int64_t now_ms,
+            const optionx::TradeTimeZone& time_zone) const {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            return find_today_no_lock(now_ms, time_zone_sec);
+            return find_today_no_lock(now_ms, time_zone);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("TradeRecordDB find_today database error: ", ex);
             return detail::list_error(TradeRecordDBStatus::DB_ERROR, ex.what());
@@ -201,10 +203,18 @@ namespace optionx::storage {
         }
     }
 
-    inline TradeRecordDBListResult TradeRecordDB::find_day(std::int64_t day_start_ms, std::int64_t time_zone_sec) const {
+    inline TradeRecordDBListResult TradeRecordDB::find_today(
+            std::int64_t now_ms,
+            std::int64_t time_zone_sec) const {
+        return find_today(now_ms, optionx::TradeTimeZone::fixed_offset(time_zone_sec));
+    }
+
+    inline TradeRecordDBListResult TradeRecordDB::find_day(
+            std::int64_t day_start_ms,
+            const optionx::TradeTimeZone& time_zone) const {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            return find_day_no_lock(day_start_ms, time_zone_sec);
+            return find_day_no_lock(day_start_ms, time_zone);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("TradeRecordDB find_day database error: ", ex);
             return detail::list_error(TradeRecordDBStatus::DB_ERROR, ex.what());
@@ -212,6 +222,12 @@ namespace optionx::storage {
             LOGIT_PRINT_ERROR("TradeRecordDB find_day error: ", ex);
             return detail::list_error(TradeRecordDBStatus::DB_ERROR, ex.what());
         }
+    }
+
+    inline TradeRecordDBListResult TradeRecordDB::find_day(
+            std::int64_t day_start_ms,
+            std::int64_t time_zone_sec) const {
+        return find_day(day_start_ms, optionx::TradeTimeZone::fixed_offset(time_zone_sec));
     }
 
     inline TradeRecordDBStatus TradeRecordDB::erase_by_trade_id(std::uint64_t trade_id) {
@@ -875,21 +891,22 @@ namespace optionx::storage {
         return result;
     }
 
-    inline TradeRecordDBListResult TradeRecordDB::find_today_no_lock(std::int64_t now_ms, std::int64_t time_zone_sec) const {
-        return find_day_no_lock(now_ms, time_zone_sec);
+    inline TradeRecordDBListResult TradeRecordDB::find_today_no_lock(
+            std::int64_t now_ms,
+            const optionx::TradeTimeZone& time_zone) const {
+        return find_day_no_lock(now_ms, time_zone);
     }
 
-    inline TradeRecordDBListResult TradeRecordDB::find_day_no_lock(std::int64_t day_start_ms, std::int64_t time_zone_sec) const {
+    inline TradeRecordDBListResult TradeRecordDB::find_day_no_lock(
+            std::int64_t day_start_ms,
+            const optionx::TradeTimeZone& time_zone) const {
         optionx::TradeRecordQuery query;
         query.time_field = optionx::TradeRecordTimeField::AUTO;
         query.range_mode = optionx::TimeRangeMode::HALF_OPEN;
+        query.time_zone = time_zone;
 
-        // Convert day_start_ms to local time, snap to local midnight, then back to UTC.
-        const auto local_ms = day_start_ms + time_zone_sec * 1000;
-        const auto day_start_local = time_shield::start_of_day_ms(local_ms);
-        const auto day_end_local = day_start_local + time_shield::MS_PER_DAY;
-        query.start_ms = day_start_local - time_zone_sec * 1000;
-        query.stop_ms = day_end_local - time_zone_sec * 1000;
+        query.start_ms = time_zone.start_of_local_day_utc_ms(day_start_ms);
+        query.stop_ms = time_zone.next_local_day_start_utc_ms(day_start_ms);
 
         return find_records_no_lock(query);
     }

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -40,19 +40,19 @@ namespace optionx::storage {
                 }
             }
 
-            return match_filter(record, query.filter, query.time_zone_sec, ts);
+            return match_filter(record, query.filter, query.time_zone, ts);
         }
 
         /// \brief Matches a record against a TradeRecordFilter with optional timezone.
         /// \param record Trade record to test.
         /// \param filter Filter predicates.
-        /// \param time_zone_sec Time zone offset in seconds for local-time filters (0 = UTC).
+        /// \param time_zone Local-time context for component filters.
         /// \param selected_ms Pre-computed selected timestamp (0 = derive from record).
         /// \return True if the record passes all active filter predicates.
         static bool match_filter(
                 const TradeRecord& record,
                 const TradeRecordFilter& filter,
-                std::int64_t time_zone_sec = 0,
+                const optionx::TradeTimeZone& time_zone = optionx::TradeTimeZone::utc(),
                 std::int64_t selected_ms = 0) noexcept {
 
             if (!filter.platforms.match(record.platform_type)) return false;
@@ -101,8 +101,8 @@ namespace optionx::storage {
                 selected_ms = optionx::select_timestamp_ms(record, optionx::TradeRecordTimeField::AUTO);
             }
             if (selected_ms > 0) {
-                const auto local_ms = selected_ms + time_zone_sec * 1000;
-                const auto sec = static_cast<time_shield::ts_t>(local_ms / 1000);
+                const auto local_ms = time_zone.to_local_ms(selected_ms);
+                const auto sec = time_shield::ms_to_sec<time_shield::ts_t>(local_ms);
                 const auto dt = time_shield::to_date_time<time_shield::DateTimeStruct>(sec);
 
                 const auto hour = static_cast<std::uint32_t>(dt.hour);

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -63,7 +63,7 @@ namespace optionx::storage {
 
             for (const auto& rec : records) {
                 // 1. Filter predicate (applies to both outcome and monetary)
-                if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone_sec)) {
+                if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) {
                     continue;
                 }
 
@@ -119,13 +119,12 @@ namespace optionx::storage {
                         stats.profit_curve.y_value.push_back(stats.total_profit);
 
                         // Daily / hourly profit buckets
-                        const auto local_ms = curve_ts + config.time_zone_sec * 1000;
-                        const auto day_start_local = time_shield::start_of_day_ms(local_ms);
-                        const auto day_utc = day_start_local - config.time_zone_sec * 1000;
+                        const auto day_utc =
+                            config.time_zone.start_of_local_day_utc_ms(curve_ts);
                         daily_profit_map[day_utc] += profit;
 
-                        const auto hour_start_local = time_shield::start_of_hour_ms(local_ms);
-                        const auto hour_utc = hour_start_local - config.time_zone_sec * 1000;
+                        const auto hour_utc =
+                            config.time_zone.start_of_local_hour_utc_ms(curve_ts);
                         hourly_profit_map[hour_utc] += profit;
                     }
 
@@ -171,8 +170,8 @@ namespace optionx::storage {
                     // Time-of-day buckets
                     const auto ts = optionx::select_timestamp_ms(rec, optionx::TradeRecordTimeField::AUTO);
                     if (ts > 0) {
-                        const auto local_ms = ts + config.time_zone_sec * 1000;
-                        const auto sec = static_cast<time_shield::ts_t>(local_ms / 1000);
+                        const auto local_ms = config.time_zone.to_local_ms(ts);
+                        const auto sec = time_shield::ms_to_sec<time_shield::ts_t>(local_ms);
                         const auto dt = time_shield::to_date_time<time_shield::DateTimeStruct>(sec);
                         const auto sec_of_day = dt.hour * 3600 + dt.min * 60 + dt.sec;
                         const auto min_of_day = dt.hour * 60 + dt.min;
@@ -338,7 +337,7 @@ namespace optionx::storage {
         static bool include_outcome(
                 const optionx::TradeRecord& rec,
                 const optionx::TradeStatsConfig& config) noexcept {
-            if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone_sec)) {
+            if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) {
                 return false;
             }
             if (config.selection == optionx::TradeStatsSelection::FIRST_MM_STEP && rec.mm_step != 0) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -161,6 +161,23 @@ TEST(TradeRecordFilterMatcherTest, NamedZoneUsesDstForHourFilter) {
     EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
 }
 
+TEST(TradeTimeZoneTest, RepeatedDstHourHasDistinctUtcBuckets) {
+    const auto tz = optionx::TradeTimeZone::named(time_shield::CET);
+
+    const auto first = time_shield::to_timestamp_ms(2026, 10, 25, 0, 30, 0);
+    const auto second = time_shield::to_timestamp_ms(2026, 10, 25, 1, 30, 0);
+
+    EXPECT_EQ(
+        tz.start_of_local_hour_utc_ms(first),
+        time_shield::to_timestamp_ms(2026, 10, 25, 0, 0, 0));
+    EXPECT_EQ(
+        tz.start_of_local_hour_utc_ms(second),
+        time_shield::to_timestamp_ms(2026, 10, 25, 1, 0, 0));
+    EXPECT_NE(
+        tz.start_of_local_hour_utc_ms(first),
+        tz.start_of_local_hour_utc_ms(second));
+}
+
 TEST(TradeRecordStatusFixerTest, MarksStaleAsCheckError) {
     std::vector<TradeRecord> records;
     // Terminal trade at 1000000
@@ -291,6 +308,36 @@ TEST(TradeRecordDBTest, FindDayUsesNamedZoneDstBoundaries) {
     EXPECT_FALSE(contains_uid(result.records, 4));
 }
 
+TEST(TradeRecordDBTest, FindDayUsesNamedZoneDstEndBoundaries) {
+    const auto config = make_config("find_day_named_zone_dst_end");
+    TradeRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    const auto before_day = time_shield::to_timestamp_ms(2026, 10, 24, 21, 30, 0);
+    const auto first_repeated_hour = time_shield::to_timestamp_ms(2026, 10, 25, 0, 30, 0);
+    const auto second_repeated_hour = time_shield::to_timestamp_ms(2026, 10, 25, 1, 30, 0);
+    const auto late_day = time_shield::to_timestamp_ms(2026, 10, 25, 22, 30, 0);
+    const auto after_day = time_shield::to_timestamp_ms(2026, 10, 25, 23, 30, 0);
+
+    ASSERT_TRUE(db.upsert(make_win_record(1, before_day)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(2, first_repeated_hour)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(3, second_repeated_hour)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(4, late_day)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(5, after_day)).ok());
+
+    const auto result = db.find_day(
+        time_shield::to_timestamp_ms(2026, 10, 25, 12, 0, 0),
+        optionx::TradeTimeZone::named(time_shield::CET));
+
+    ASSERT_TRUE(result.ok()) << result.message;
+    EXPECT_EQ(result.records.size(), 3u);
+    EXPECT_FALSE(contains_uid(result.records, 1));
+    EXPECT_TRUE(contains_uid(result.records, 2));
+    EXPECT_TRUE(contains_uid(result.records, 3));
+    EXPECT_TRUE(contains_uid(result.records, 4));
+    EXPECT_FALSE(contains_uid(result.records, 5));
+}
+
 TEST(TradeStatsCalculatorTest, ComputesBasicWinrate) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, 8.2, "EURUSD", optionx::TradeState::WIN));
@@ -351,6 +398,39 @@ TEST(TradeStatsCalculatorTest, NamedZoneUsesDstForLocalHourBuckets) {
     EXPECT_EQ(named_stats->by_hour[13].wins, 0u);
     EXPECT_EQ(fixed_stats->by_hour[13].wins, 1u);
     EXPECT_EQ(fixed_stats->by_hour[14].wins, 0u);
+}
+
+TEST(TradeStatsCalculatorTest, RepeatedDstHourUsesDistinctHourlyProfitBuckets) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(
+        1,
+        time_shield::to_timestamp_ms(2026, 10, 25, 0, 30, 0),
+        10.0,
+        8.0,
+        "EURUSD",
+        optionx::TradeState::WIN));
+    records.push_back(make_win_record(
+        2,
+        time_shield::to_timestamp_ms(2026, 10, 25, 1, 30, 0),
+        10.0,
+        9.0,
+        "EURUSD",
+        optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.time_zone = optionx::TradeTimeZone::named(time_shield::CET);
+    cfg.include_non_terminal = false;
+    const auto stats = TradeStatsCalculator::calc(records, cfg);
+
+    ASSERT_EQ(stats->hourly_profit.x_time.size(), 2u);
+    EXPECT_EQ(
+        stats->hourly_profit.x_time[0],
+        time_shield::to_timestamp_ms(2026, 10, 25, 0, 0, 0));
+    EXPECT_EQ(
+        stats->hourly_profit.x_time[1],
+        time_shield::to_timestamp_ms(2026, 10, 25, 1, 0, 0));
+    EXPECT_DOUBLE_EQ(stats->hourly_profit.y_value[0], 8.0);
+    EXPECT_DOUBLE_EQ(stats->hourly_profit.y_value[1], 9.0);
 }
 
 TEST(TradeStatsCalculatorTest, DrawdownAndEquityCurve) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -23,6 +23,12 @@ using optionx::storage::TradeStatsCalculator;
 using optionx::storage::TradeMetaStatsCalculator;
 using optionx::storage::detail::selected_timestamp_ms;
 
+bool contains_uid(const std::vector<TradeRecord>& records, std::int64_t uid) {
+    return std::any_of(records.begin(), records.end(), [uid](const TradeRecord& record) {
+        return record.request_unique_id == uid;
+    });
+}
+
 std::string unique_db_path(const std::string& name) {
     static std::atomic<std::uint64_t> counter{0};
     const auto stamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -141,6 +147,20 @@ TEST(TradeRecordFilterMatcherTest, TimeRangeClosedAndHalfOpen) {
     EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query)); // 100000 >= 100000
 }
 
+TEST(TradeRecordFilterMatcherTest, NamedZoneUsesDstForHourFilter) {
+    TradeRecord rec = make_win_record(
+        1,
+        time_shield::to_timestamp_ms(2026, 7, 1, 12, 0, 0));
+
+    TradeRecordQuery query;
+    query.time_zone = optionx::TradeTimeZone::named(time_shield::CET);
+    query.filter.hours.add_include(14);
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(rec, query));
+
+    query.time_zone = optionx::TradeTimeZone::fixed_offset(time_shield::SEC_PER_HOUR);
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
+}
+
 TEST(TradeRecordStatusFixerTest, MarksStaleAsCheckError) {
     std::vector<TradeRecord> records;
     // Terminal trade at 1000000
@@ -244,6 +264,33 @@ TEST(TradeRecordDBTest, FindTodayReturnsEmptyWhenNoTrades) {
     EXPECT_TRUE(result.records.empty());
 }
 
+TEST(TradeRecordDBTest, FindDayUsesNamedZoneDstBoundaries) {
+    const auto config = make_config("find_day_named_zone_dst");
+    TradeRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    const auto before_day = time_shield::to_timestamp_ms(2026, 3, 28, 22, 30, 0);
+    const auto start_day = time_shield::to_timestamp_ms(2026, 3, 28, 23, 30, 0);
+    const auto end_day = time_shield::to_timestamp_ms(2026, 3, 29, 21, 30, 0);
+    const auto after_day = time_shield::to_timestamp_ms(2026, 3, 29, 22, 30, 0);
+
+    ASSERT_TRUE(db.upsert(make_win_record(1, before_day)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(2, start_day)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(3, end_day)).ok());
+    ASSERT_TRUE(db.upsert(make_win_record(4, after_day)).ok());
+
+    const auto result = db.find_day(
+        time_shield::to_timestamp_ms(2026, 3, 29, 12, 0, 0),
+        optionx::TradeTimeZone::named(time_shield::CET));
+
+    ASSERT_TRUE(result.ok()) << result.message;
+    EXPECT_EQ(result.records.size(), 2u);
+    EXPECT_FALSE(contains_uid(result.records, 1));
+    EXPECT_TRUE(contains_uid(result.records, 2));
+    EXPECT_TRUE(contains_uid(result.records, 3));
+    EXPECT_FALSE(contains_uid(result.records, 4));
+}
+
 TEST(TradeStatsCalculatorTest, ComputesBasicWinrate) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, 8.2, "EURUSD", optionx::TradeState::WIN));
@@ -269,7 +316,7 @@ TEST(TradeStatsCalculatorTest, ComputesBySymbolAndHour) {
     records.push_back(make_win_record(2, 7200000, 10.0, -10.0, "GBPUSD", optionx::TradeState::LOSS));
 
     optionx::TradeStatsConfig cfg;
-    cfg.time_zone_sec = 0;
+    cfg.time_zone = optionx::TradeTimeZone::utc();
     cfg.include_non_terminal = false;
     auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
     auto& stats = *stats_ptr;
@@ -278,6 +325,32 @@ TEST(TradeStatsCalculatorTest, ComputesBySymbolAndHour) {
     EXPECT_EQ(stats.by_symbol.at("EURUSD").wins, 1u);
     EXPECT_EQ(stats.by_hour[1].wins, 1u);  // 3600000 ms = 1 hour
     EXPECT_EQ(stats.by_hour[2].losses, 1u);
+}
+
+TEST(TradeStatsCalculatorTest, NamedZoneUsesDstForLocalHourBuckets) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(
+        1,
+        time_shield::to_timestamp_ms(2026, 7, 1, 12, 0, 0),
+        10.0,
+        8.2,
+        "EURUSD",
+        optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig named_cfg;
+    named_cfg.time_zone = optionx::TradeTimeZone::named(time_shield::CET);
+    named_cfg.include_non_terminal = false;
+    const auto named_stats = TradeStatsCalculator::calc(records, named_cfg);
+
+    optionx::TradeStatsConfig fixed_cfg;
+    fixed_cfg.time_zone = optionx::TradeTimeZone::fixed_offset(time_shield::SEC_PER_HOUR);
+    fixed_cfg.include_non_terminal = false;
+    const auto fixed_stats = TradeStatsCalculator::calc(records, fixed_cfg);
+
+    EXPECT_EQ(named_stats->by_hour[14].wins, 1u);
+    EXPECT_EQ(named_stats->by_hour[13].wins, 0u);
+    EXPECT_EQ(fixed_stats->by_hour[13].wins, 1u);
+    EXPECT_EQ(fixed_stats->by_hour[14].wins, 0u);
 }
 
 TEST(TradeStatsCalculatorTest, DrawdownAndEquityCurve) {


### PR DESCRIPTION
## Summary
- add `TradeTimeZone` with fixed-offset and `time_shield::TimeZone` named-zone modes
- replace `TradeRecordQuery::time_zone_sec` and `TradeStatsConfig::time_zone_sec` with `TradeTimeZone`
- make local-time filters, stats buckets, and DB day queries resolve DST through time-shield named zones
- preserve repeated DST fallback hours as distinct UTC buckets for hourly profit charts
- document the total-function UTC/identity fallback used for unsupported named-zone conversions
- keep `TradeTimeZone` state private and expose factory/getter API
- keep fixed-offset `find_today/find_day(..., time_zone_sec)` overloads as compatibility shorthands
- add tests for CET summer hour filtering/buckets, DST-start day boundaries, and DST-end repeated-hour boundaries

## Breaking API
- `TradeRecordQuery::time_zone_sec` was replaced with `TradeRecordQuery::time_zone`.
- `TradeStatsConfig::time_zone_sec` was replaced with `TradeStatsConfig::time_zone`.
- Use `TradeTimeZone::fixed_offset(seconds)` for the old fixed-offset behavior.
- Use `TradeTimeZone::named(time_shield::CET)` or another supported `time_shield::TimeZone` when DST-aware local time is required.

## Validation
- cmake --build build-codex --target trade_record_stats_test trade_record_db_test trade_record_storage_test -- -j1
- cmake --build build-codex --target intrade_bar_api_response_test trade_manager_test trade_result_query_test -- -j1
- cmake --build build-codex -- -j1
- .\build-codex\trade_record_stats_test.exe --gtest_brief=1
- .\build-codex\trade_record_db_test.exe --gtest_brief=1
- .\build-codex\trade_record_storage_test.exe --gtest_brief=1
- .\build-codex\trade_result_query_test.exe --gtest_brief=1
- .\build-codex\intrade_bar_api_response_test.exe --gtest_brief=1
- .\build-codex\trade_manager_test.exe --gtest_brief=1
- git diff --check