### PR TITLE
Fix SpreadPack packing and bounds

### DIFF
--- a/include/optionx_cpp/data/trading.hpp
+++ b/include/optionx_cpp/data/trading.hpp
@@ -32,6 +32,7 @@
 #include "utils/string_utils.hpp"
 
 #include "trading/enums.hpp"
+#include "trading/SpreadPack.hpp"
 #include "trading/TradeResult.hpp"
 #include "trading/TradeResultQuery.hpp"
 #include "trading/TradeRecordTimeRange.hpp"

--- a/include/optionx_cpp/data/trading/SpreadPack.hpp
+++ b/include/optionx_cpp/data/trading/SpreadPack.hpp
@@ -10,7 +10,7 @@
 #include <limits>
 #include <stdexcept>
 
-#include "data/trading/enums.hpp"
+#include "enums.hpp"
 
 namespace optionx {
 
@@ -23,31 +23,25 @@ namespace optionx {
         static constexpr std::uint8_t max_digits = 18;
 
         void set_open_spread(double value, std::uint8_t d) {
-            if (d > max_digits) throw std::invalid_argument("SpreadPack digits exceeds 18");
+            const auto fixed = pack_fixed(value, d);
             digits = d;
-            const double scale = std::pow(10.0, digits);
-            const auto fixed = static_cast<std::int32_t>(std::round(value * scale));
-            raw = (raw & ~0xFFFFFFFFu) | (static_cast<std::uint32_t>(fixed) & 0xFFFFFFFFu);
+            raw = (raw & kUpperMask) | (static_cast<std::uint64_t>(fixed) & kLowerMask);
         }
 
         void set_close_spread(double value, std::uint8_t d) {
-            if (d > max_digits) throw std::invalid_argument("SpreadPack digits exceeds 18");
+            const auto fixed = pack_fixed(value, d);
             digits = d;
-            const double scale = std::pow(10.0, digits);
-            const auto fixed = static_cast<std::int32_t>(std::round(value * scale));
-            raw = (raw & 0xFFFFFFFFu) | (static_cast<std::uint64_t>(static_cast<std::uint32_t>(fixed)) << 32);
+            raw = (raw & kLowerMask) | (static_cast<std::uint64_t>(fixed) << 32);
         }
 
         double open_spread() const {
-            if (digits == 0) return 0.0;
-            const double scale = std::pow(10.0, digits);
+            const double scale = scale_for_digits(digits);
             const auto fixed = static_cast<std::int32_t>(static_cast<std::uint32_t>(raw));
             return static_cast<double>(fixed) / scale;
         }
 
         double close_spread() const {
-            if (digits == 0) return 0.0;
-            const double scale = std::pow(10.0, digits);
+            const double scale = scale_for_digits(digits);
             const auto fixed = static_cast<std::int32_t>(static_cast<std::uint32_t>(raw >> 32));
             return static_cast<double>(fixed) / scale;
         }
@@ -80,6 +74,37 @@ namespace optionx {
                 return price + half;
             }
             return price - half;
+        }
+
+    private:
+        static constexpr std::uint64_t kLowerMask = 0x00000000FFFFFFFFull;
+        static constexpr std::uint64_t kUpperMask = 0xFFFFFFFF00000000ull;
+
+        static double scale_for_digits(std::uint8_t d) {
+            return d == 0 ? 1.0 : std::pow(10.0, d);
+        }
+
+        static std::uint32_t pack_fixed(double value, std::uint8_t d) {
+            if (d > max_digits) {
+                throw std::invalid_argument("SpreadPack digits exceeds 18");
+            }
+            if (!std::isfinite(value)) {
+                throw std::invalid_argument("SpreadPack spread value must be finite");
+            }
+
+            const double scaled = value * scale_for_digits(d);
+            if (!std::isfinite(scaled)) {
+                throw std::out_of_range("SpreadPack fixed-point value is out of range");
+            }
+
+            const double rounded = std::round(scaled);
+            if (rounded < static_cast<double>(std::numeric_limits<std::int32_t>::min()) ||
+                rounded > static_cast<double>(std::numeric_limits<std::int32_t>::max())) {
+                throw std::out_of_range("SpreadPack fixed-point value is out of range");
+            }
+
+            const auto fixed = static_cast<std::int32_t>(rounded);
+            return static_cast<std::uint32_t>(fixed);
         }
     };
 

--- a/include/optionx_cpp/data/trading/SpreadPack.hpp
+++ b/include/optionx_cpp/data/trading/SpreadPack.hpp
@@ -16,18 +16,36 @@ namespace optionx {
 
     /// \struct SpreadPack
     /// \brief Packs open and close spread values into a single 64-bit word with shared decimal precision.
+    ///
+    /// Both packed values use the same `digits` precision. Prefer set_spreads()
+    /// when open and close spread are known together; individual setters are
+    /// intended for updates that keep the same precision.
     struct SpreadPack {
         std::uint64_t raw = 0;     ///< Lower 32 bits = open spread fixed-point, upper 32 bits = close spread fixed-point.
         std::uint8_t  digits = 0;  ///< Number of decimal places for both spreads.
 
         static constexpr std::uint8_t max_digits = 18;
 
+        /// \brief Sets both spreads using one shared decimal precision.
+        /// \param open_value Open spread.
+        /// \param close_value Close spread.
+        /// \param d Number of decimal places for both values.
+        void set_spreads(double open_value, double close_value, std::uint8_t d) {
+            const auto open_fixed = pack_fixed(open_value, d);
+            const auto close_fixed = pack_fixed(close_value, d);
+            digits = d;
+            raw = (static_cast<std::uint64_t>(close_fixed) << 32) |
+                  (static_cast<std::uint64_t>(open_fixed) & kLowerMask);
+        }
+
+        /// \brief Sets open spread and updates shared decimal precision.
         void set_open_spread(double value, std::uint8_t d) {
             const auto fixed = pack_fixed(value, d);
             digits = d;
             raw = (raw & kUpperMask) | (static_cast<std::uint64_t>(fixed) & kLowerMask);
         }
 
+        /// \brief Sets close spread and updates shared decimal precision.
         void set_close_spread(double value, std::uint8_t d) {
             const auto fixed = pack_fixed(value, d);
             digits = d;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -954,11 +954,7 @@ namespace optionx::platforms::intrade_bar {
                     tick.symbol = normalize_symbol_name(symbol_name);
                     tick.volume_digits = 0;
 
-                    if (tick.symbol.substr(3, 3) == "JPY") {
-                        tick.price_digits = 3;
-                    } else {
-                        tick.price_digits = 5;
-                    }
+                    tick.price_digits = price_digits_for_symbol(tick.symbol);
 
                     tick.tick.ask = el.value()["ask"];
                     tick.tick.bid = el.value()["bid"];

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
@@ -279,6 +279,7 @@ namespace optionx::platforms::intrade_bar {
                     const std::string& error_desc) {
             const int64_t timestamp = OPTIONX_TIMESTAMP_MS;
             auto account_info  = get_account_info();
+            set_zero_spread_for_symbol(result->spread, request->symbol);
             if (!success) {
                 LOGIT_WARN(
                     "Intrade Bar trade: open failed. status=",
@@ -461,6 +462,7 @@ namespace optionx::platforms::intrade_bar {
             std::shared_ptr<TradeResult> result) {
         if (!request ||!result) return;
         auto account_info = get_account_info();
+        set_zero_spread_for_symbol(result->spread, request->symbol);
         if (!success) {
             result->balance = account_info->balance;
         } else {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -594,6 +594,10 @@ namespace optionx::platforms::intrade_bar {
             record.error_desc.clear();
         }
 
+        inline void apply_intrade_bar_zero_spread(TradeRecord& record) {
+            set_zero_spread_for_symbol(record.spread, record.symbol);
+        }
+
         inline std::optional<TradeRecord> parse_history_attr_row(
                 const std::string& row,
                 AccountType account_type) {
@@ -630,6 +634,7 @@ namespace optionx::platforms::intrade_bar {
             }
             record.account_type = account_type;
             record.platform_type = PlatformType::INTRADE_BAR;
+            apply_intrade_bar_zero_spread(record);
             return record;
         }
 
@@ -683,6 +688,7 @@ namespace optionx::platforms::intrade_bar {
             record.account_type = account_type;
             record.platform_type = PlatformType::INTRADE_BAR;
             apply_history_gross_result_to_record(record, gross_result->amount);
+            apply_intrade_bar_zero_spread(record);
             return record;
         }
 
@@ -867,6 +873,7 @@ namespace optionx::platforms::intrade_bar {
             record.platform_type = PlatformType::INTRADE_BAR;
 
             detail::apply_history_gross_result_to_record(record, gross_result->amount);
+            detail::apply_intrade_bar_zero_spread(record);
             records.push_back(std::move(record));
         }
 

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
@@ -63,8 +63,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param symbol Symbol whose price precision should be stored.
     inline void set_zero_spread_for_symbol(SpreadPack& spread, const std::string& symbol) {
         const auto digits = price_digits_for_symbol(symbol);
-        spread.set_open_spread(0.0, digits);
-        spread.set_close_spread(0.0, digits);
+        spread.set_spreads(0.0, 0.0, digits);
     }
 
     using ::optionx::utils::validate_status;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
@@ -46,6 +46,27 @@ namespace optionx::platforms::intrade_bar {
         return symbol;
     }
 
+    /// \brief Returns the broker price precision used for a normalized symbol.
+    /// \param symbol Broker or public symbol name.
+    /// \return Number of price decimal places.
+    inline std::uint8_t price_digits_for_symbol(const std::string& symbol) {
+        const std::string normalized = normalize_symbol_name(symbol);
+        if (normalized == "BTCUSDT") return 2;
+        if (normalized.size() >= 6 && normalized.substr(3, 3) == "JPY") {
+            return 3;
+        }
+        return 5;
+    }
+
+    /// \brief Marks a SpreadPack as a known zero-spread Intrade Bar value.
+    /// \param spread Spread pack to fill.
+    /// \param symbol Symbol whose price precision should be stored.
+    inline void set_zero_spread_for_symbol(SpreadPack& spread, const std::string& symbol) {
+        const auto digits = price_digits_for_symbol(symbol);
+        spread.set_open_spread(0.0, digits);
+        spread.set_close_spread(0.0, digits);
+    }
+
     using ::optionx::utils::validate_status;
     using ::optionx::utils::validate_ddos_protection;
     using ::optionx::utils::validate_response;

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -41,6 +41,19 @@ TEST(IntradeBarApiResponses, ApiResultMarksMissingHttpStatusExplicitly) {
     EXPECT_FALSE(failure.has_http_status());
 }
 
+TEST(IntradeBarApiResponses, PriceDigitsMatchBrokerSymbols) {
+    EXPECT_EQ(price_digits_for_symbol("BTCUSD"), 2);
+    EXPECT_EQ(price_digits_for_symbol("BTCUSDT"), 2);
+    EXPECT_EQ(price_digits_for_symbol("EUR/JPY"), 3);
+    EXPECT_EQ(price_digits_for_symbol("EURUSD"), 5);
+
+    SpreadPack spread;
+    set_zero_spread_for_symbol(spread, "BTCUSD");
+    EXPECT_EQ(spread.digits, 2);
+    EXPECT_DOUBLE_EQ(spread.open_spread(), 0.0);
+    EXPECT_DOUBLE_EQ(spread.close_spread(), 0.0);
+}
+
 TEST(IntradeBarAuthData, KeepsDisconnectedDomainRetryPeriodInConfig) {
     AuthData auth_data;
     auth_data.set_email_password("user@example.test", "secret");
@@ -251,6 +264,9 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryCsvExport) {
     EXPECT_EQ(trades[0].account_type, AccountType::DEMO);
     EXPECT_EQ(trades[0].platform_type, PlatformType::INTRADE_BAR);
     EXPECT_EQ(trades[0].duration, 180);
+    EXPECT_EQ(trades[0].spread.digits, 5);
+    EXPECT_DOUBLE_EQ(trades[0].spread.open_spread(), 0.0);
+    EXPECT_DOUBLE_EQ(trades[0].spread.close_spread(), 0.0);
 
     EXPECT_EQ(trades[1].option_id, 123);
     EXPECT_EQ(trades[1].symbol, "AUDNZD");
@@ -266,11 +282,13 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryCsvExport) {
     EXPECT_EQ(trades[3].symbol, "BTCUSDT");
     EXPECT_EQ(trades[3].trade_state, TradeState::WIN);
     EXPECT_EQ(trades[3].duration, 300);
+    EXPECT_EQ(trades[3].spread.digits, 2);
 
     EXPECT_EQ(trades[4].symbol, "EURUSD");
     EXPECT_EQ(trades[4].currency, CurrencyType::RUB);
     EXPECT_EQ(trades[4].trade_state, TradeState::WIN);
     EXPECT_DOUBLE_EQ(trades[4].profit, 80.0);
+    EXPECT_EQ(trades[4].spread.digits, 5);
 }
 
 TEST(IntradeBarApiResponses, ParsesTradeHistoryHtmlSnapshotAndMergesWithCsv) {
@@ -292,6 +310,12 @@ TEST(IntradeBarApiResponses, ParsesTradeHistoryHtmlSnapshotAndMergesWithCsv) {
     EXPECT_EQ(html_trades[0].open_date, time_shield::sec_to_ms(1719146073));
     EXPECT_EQ(html_trades[0].close_date, time_shield::sec_to_ms(1719146373));
     EXPECT_EQ(html_trades[0].duration, 300);
+    EXPECT_EQ(html_trades[0].spread.digits, 2);
+    EXPECT_DOUBLE_EQ(html_trades[0].spread.open_spread(), 0.0);
+    EXPECT_DOUBLE_EQ(html_trades[0].spread.close_spread(), 0.0);
+
+    EXPECT_EQ(html_trades[1].symbol, "EURUSD");
+    EXPECT_EQ(html_trades[1].spread.digits, 5);
 
     std::vector<TradeRecord> csv_trades;
     TradeRecord csv_trade;

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -368,6 +368,18 @@ TEST(SpreadPackTest, PreservesCloseSpreadWhenOpenIsSetAfterwards) {
     EXPECT_DOUBLE_EQ(pack.spread_difference(), -0.00025);
 }
 
+TEST(SpreadPackTest, SetsBothSpreadsAtomicallyWithSharedPrecision) {
+    optionx::SpreadPack pack;
+    pack.set_spreads(0.00015, -0.00010, 5);
+
+    EXPECT_EQ(pack.digits, 5);
+    EXPECT_DOUBLE_EQ(pack.open_spread(), 0.00015);
+    EXPECT_DOUBLE_EQ(pack.close_spread(), -0.00010);
+    EXPECT_DOUBLE_EQ(pack.spread_difference(), -0.00025);
+    EXPECT_TRUE(pack.is_open_spread_positive());
+    EXPECT_FALSE(pack.is_close_spread_positive());
+}
+
 TEST(SpreadPackTest, HandlesZeroAndEdgeValues) {
     optionx::SpreadPack pack;
     pack.set_open_spread(0.0, 0);
@@ -391,6 +403,7 @@ TEST(SpreadPackTest, RejectsInvalidValuesAndPreservesPreviousState) {
     EXPECT_THROW(pack.set_open_spread(std::numeric_limits<double>::infinity(), 5), std::invalid_argument);
     EXPECT_THROW(pack.set_close_spread(0.000000003, 18), std::out_of_range);
     EXPECT_THROW(pack.set_open_spread(0.1, optionx::SpreadPack::max_digits + 1), std::invalid_argument);
+    EXPECT_THROW(pack.set_spreads(0.0, 0.000000003, 18), std::out_of_range);
 
     EXPECT_EQ(pack.raw, raw);
     EXPECT_EQ(pack.digits, digits);

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -357,12 +358,42 @@ TEST(SpreadPackTest, PacksAndUnpacksValues) {
     EXPECT_FALSE(pack.is_close_spread_positive());
 }
 
+TEST(SpreadPackTest, PreservesCloseSpreadWhenOpenIsSetAfterwards) {
+    optionx::SpreadPack pack;
+    pack.set_close_spread(-0.00010, 5);
+    pack.set_open_spread(0.00015, 5);
+
+    EXPECT_DOUBLE_EQ(pack.open_spread(), 0.00015);
+    EXPECT_DOUBLE_EQ(pack.close_spread(), -0.00010);
+    EXPECT_DOUBLE_EQ(pack.spread_difference(), -0.00025);
+}
+
 TEST(SpreadPackTest, HandlesZeroAndEdgeValues) {
     optionx::SpreadPack pack;
     pack.set_open_spread(0.0, 0);
     pack.set_close_spread(0.0, 0);
     EXPECT_DOUBLE_EQ(pack.open_spread(), 0.0);
     EXPECT_DOUBLE_EQ(pack.close_spread(), 0.0);
+
+    pack.set_open_spread(2.0, 0);
+    pack.set_close_spread(-3.0, 0);
+    EXPECT_DOUBLE_EQ(pack.open_spread(), 2.0);
+    EXPECT_DOUBLE_EQ(pack.close_spread(), -3.0);
+}
+
+TEST(SpreadPackTest, RejectsInvalidValuesAndPreservesPreviousState) {
+    optionx::SpreadPack pack;
+    pack.set_open_spread(0.00015, 5);
+    pack.set_close_spread(-0.00010, 5);
+    const auto raw = pack.raw;
+    const auto digits = pack.digits;
+
+    EXPECT_THROW(pack.set_open_spread(std::numeric_limits<double>::infinity(), 5), std::invalid_argument);
+    EXPECT_THROW(pack.set_close_spread(0.000000003, 18), std::out_of_range);
+    EXPECT_THROW(pack.set_open_spread(0.1, optionx::SpreadPack::max_digits + 1), std::invalid_argument);
+
+    EXPECT_EQ(pack.raw, raw);
+    EXPECT_EQ(pack.digits, digits);
 }
 
 TEST(CompositeKeyTest, OrdersAcrossMinuteBuckets) {


### PR DESCRIPTION
## Summary
- fix `SpreadPack::set_open_spread()` so setting open spread no longer clears an already packed close spread
- validate packed fixed-point values before casting to `int32_t`
- treat `digits == 0` as integer-scale storage instead of forcing unpacked values to `0.0`
- document the shared-precision `SpreadPack::digits` contract and add atomic `set_spreads(open, close, digits)`
- expose `SpreadPack.hpp` explicitly from the `data/trading.hpp` umbrella header
- mark Intrade Bar broker results/history records as known zero-spread values while preserving price digits by symbol
- reuse Intrade Bar symbol price precision for `/price_now` ticks, including BTCUSDT/BTCUSD = 2 digits
- add regression tests for setter order, shared precision, integer precision, invalid values, zero-spread metadata, and state preservation after failed packing

## Validation
- cmake --build build-codex --target trade_record_db_test intrade_bar_api_response_test -- -j1
- .\build-codex\trade_record_db_test.exe --gtest_brief=1
- .\build-codex\intrade_bar_api_response_test.exe --gtest_brief=1
- cmake --build build-codex --target trade_manager_test intrade_bar_smoke_cli -- -j1
- .\build-codex\trade_manager_test.exe --gtest_brief=1
- cmake --build build-codex --target trade_record_storage_test -- -j1
- cmake --build build-codex --target trade_record_stats_test -- -j1
- .\build-codex\trade_record_storage_test.exe --gtest_brief=1
- .\build-codex\trade_record_stats_test.exe --gtest_brief=1
- cmake --build build-codex --target trade_result_query_test -- -j1
- .\build-codex\trade_result_query_test.exe --gtest_brief=1
- git diff --check

Note: an attempted full `cmake --build build-codex -- -j1` timed out while child build processes remained alive; after stopping those stale build processes, the relevant targets above built and tested successfully.