### PR TITLE
[codex] Normalize Intrade BTC symbol rules

### DIFF
--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -13,6 +13,7 @@
 #include "common/ApiResult.hpp"
 #include "common/BaseTradingPlatform.hpp"
 #include "IntradeBarPlatform/TradeHistorySource.hpp"
+#include "IntradeBarPlatform/SymbolUtils.hpp"
 #include "IntradeBarPlatform/AuthData.hpp"
 #include "IntradeBarPlatform/AccountInfoData.hpp"
 #include "IntradeBarPlatform/ApiResponses.hpp"

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
@@ -162,8 +162,10 @@ namespace optionx::platforms::intrade_bar {
                     return get_min_duration(request);
                 case AccountInfoType::MAX_DURATION:
                     return get_max_duration_sec(request);
-                case AccountInfoType::START_TIME: return time_shield::start_of_day(request.timestamp) + start_time;
-                case AccountInfoType::END_TIME: return time_shield::start_of_day(request.timestamp) + end_time;
+                case AccountInfoType::START_TIME:
+                    return time_shield::start_of_day(request.timestamp) + get_start_time_sec(request);
+                case AccountInfoType::END_TIME:
+                    return time_shield::start_of_day(request.timestamp) + get_end_time_sec(request);
                 case AccountInfoType::ORDER_QUEUE_TIMEOUT: return order_queue_timeout;
                 case AccountInfoType::RESPONSE_TIMEOUT: return responce_timeout;
                 case AccountInfoType::ORDER_INTERVAL_MS: return order_interval_ms;
@@ -258,6 +260,20 @@ namespace optionx::platforms::intrade_bar {
             return std::min(
                 time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)),
                 max_duration);
+        }
+
+        /// \brief Gets the trading session start time for the requested symbol.
+        /// \param request The account information request.
+        /// \return Session start offset from local day start in seconds.
+        int64_t get_start_time_sec(const AccountInfoRequest& request) const {
+            return is_btc_symbol(request.symbol) ? start_btc_time : start_time;
+        }
+
+        /// \brief Gets the trading session end time for the requested symbol.
+        /// \param request The account information request.
+        /// \return Session end offset from local day start in seconds.
+        int64_t get_end_time_sec(const AccountInfoRequest& request) const {
+            return is_btc_symbol(request.symbol) ? end_btc_time : end_time;
         }
 
         /// \brief Checks if the amount limits apply based on the time of day.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
@@ -5,6 +5,8 @@
 /// \file AccountInfoData.hpp
 /// \brief Contains the AccountInfoData class for Intrade Bar platform account information.
 
+#include "SymbolUtils.hpp"
+
 namespace optionx::platforms::intrade_bar {
 
     /// \class AccountInfoData
@@ -84,11 +86,11 @@ namespace optionx::platforms::intrade_bar {
                     "USDCAD","USDCHF","USDJPY",
                     "BTCUSDT"
                 };
-                return (symbols.find(request.symbol) != symbols.end());
+                return (symbols.find(normalize_symbol_name(request.symbol)) != symbols.end());
             }
             case AccountInfoType::OPTION_TYPE_AVAILABILITY:
                 if (request.option_type == OptionType::CLASSIC &&
-                    (request.symbol == "BTCUSDT" || request.symbol == "BTCUSD")) return false;
+                    is_btc_symbol(request.symbol)) return false;
                 return (request.option_type == OptionType::CLASSIC || request.option_type == OptionType::SPRINT);
             case AccountInfoType::ORDER_TYPE_AVAILABILITY:
                 return (request.order_type == OrderType::BUY || request.order_type == OrderType::SELL);
@@ -110,10 +112,8 @@ namespace optionx::platforms::intrade_bar {
                 return true;
             case AccountInfoType::DURATION_AVAILABLE: {
                 if (request.option_type == OptionType::CLASSIC) return true;
-                const int64_t req_min_duration = (request.symbol == "BTCUSD" || request.symbol == "BTCUSDT") ?
-                    min_btc_duration : min_duration;
-                const int64_t req_max_duration = (request.symbol == "BTCUSD" || request.symbol == "BTCUSDT") ?
-                    max_duration : std::min(time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)), max_duration);
+                const int64_t req_min_duration = get_min_duration(request);
+                const int64_t req_max_duration = get_max_duration_sec(request);
                 return (request.duration >= req_min_duration &&
                         request.duration <= req_max_duration &&
                         (request.duration % time_shield::SEC_PER_MIN) == 0 &&
@@ -159,9 +159,9 @@ namespace optionx::platforms::intrade_bar {
                 case AccountInfoType::MIN_AMOUNT: return static_cast<int64_t>(get_min_amount(request));
                 case AccountInfoType::MAX_AMOUNT: return static_cast<int64_t>(get_max_amount(request));
                 case AccountInfoType::MIN_DURATION:
-                    return (request.symbol == "BTCUSD" || request.symbol == "BTCUSDT") ? min_btc_duration : min_duration;
+                    return get_min_duration(request);
                 case AccountInfoType::MAX_DURATION:
-                    return std::min(time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)), max_duration);
+                    return get_max_duration_sec(request);
                 case AccountInfoType::START_TIME: return time_shield::start_of_day(request.timestamp) + start_time;
                 case AccountInfoType::END_TIME: return time_shield::start_of_day(request.timestamp) + end_time;
                 case AccountInfoType::ORDER_QUEUE_TIMEOUT: return order_queue_timeout;
@@ -241,6 +241,25 @@ namespace optionx::platforms::intrade_bar {
                     max_usd_amount : (currency == CurrencyType::RUB ? max_rub_amount : 0.0)));
         }
 
+        /// \brief Gets the minimum sprint duration for the requested symbol.
+        /// \param request The account information request.
+        /// \return Minimum duration in seconds.
+        int64_t get_min_duration(const AccountInfoRequest& request) const {
+            return is_btc_symbol(request.symbol) ? min_btc_duration : min_duration;
+        }
+
+        /// \brief Gets the maximum sprint duration for the requested symbol.
+        /// \param request The account information request.
+        /// \return Maximum duration in seconds.
+        int64_t get_max_duration_sec(const AccountInfoRequest& request) const {
+            if (is_btc_symbol(request.symbol)) {
+                return max_duration;
+            }
+            return std::min(
+                time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)),
+                max_duration);
+        }
+
         /// \brief Checks if the amount limits apply based on the time of day.
         /// \param second_day The time in seconds since the start of the day.
         /// \return True if amount limits are in effect, false otherwise.
@@ -293,7 +312,7 @@ namespace optionx::platforms::intrade_bar {
             }
 
             const int64_t sec_of_day = time_shield::sec_of_day(request.timestamp);
-            if (request.symbol == "BTCUSDT" || request.symbol == "BTCUSD") {
+            if (is_btc_symbol(request.symbol)) {
                 if (request.option_type == OptionType::CLASSIC ||
                     request.duration < min_btc_duration ||
                     request.duration > max_duration) {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/SymbolUtils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/SymbolUtils.hpp
@@ -1,10 +1,11 @@
 #pragma once
-#ifndef _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED
-#define _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED
+#ifndef _OPTIONX_PLATFORMS_INTRADEBAR_SYMBOL_UTILS_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_INTRADEBAR_SYMBOL_UTILS_HPP_INCLUDED
 
 /// \file SymbolUtils.hpp
 /// \brief Broker-specific symbol normalization helpers for Intrade Bar.
 
+#include <cctype>
 #include <string>
 
 namespace optionx::platforms::intrade_bar {
@@ -17,6 +18,9 @@ namespace optionx::platforms::intrade_bar {
             auto it_str = symbol.find('/');
             if (it_str != std::string::npos) symbol.erase(it_str, 1);
             else break;
+        }
+        for (auto& ch : symbol) {
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
         }
         if (symbol == "BTCUSD") return "BTCUSDT";
         return symbol;
@@ -31,4 +35,4 @@ namespace optionx::platforms::intrade_bar {
 
 } // namespace optionx::platforms::intrade_bar
 
-#endif // _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED
+#endif // _OPTIONX_PLATFORMS_INTRADEBAR_SYMBOL_UTILS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/SymbolUtils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/SymbolUtils.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED
+
+/// \file SymbolUtils.hpp
+/// \brief Broker-specific symbol normalization helpers for Intrade Bar.
+
+#include <string>
+
+namespace optionx::platforms::intrade_bar {
+
+    /// \brief Converts public symbol aliases to broker-side Intrade Bar names.
+    /// \param symbol Public or broker symbol name.
+    /// \return Normalized broker symbol name.
+    inline std::string normalize_symbol_name(std::string symbol) {
+        for (;;) {
+            auto it_str = symbol.find('/');
+            if (it_str != std::string::npos) symbol.erase(it_str, 1);
+            else break;
+        }
+        if (symbol == "BTCUSD") return "BTCUSDT";
+        return symbol;
+    }
+
+    /// \brief Checks whether a public or broker symbol refers to the BTCUSDT instrument.
+    /// \param symbol Public or broker symbol name.
+    /// \return True for BTCUSD/BTCUSDT aliases.
+    inline bool is_btc_symbol(const std::string& symbol) {
+        return normalize_symbol_name(symbol) == "BTCUSDT";
+    }
+
+} // namespace optionx::platforms::intrade_bar
+
+#endif // _OPTIONX_PLATFORMS_INTRADERBAR_SYMBOL_UTILS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeExecutionModule.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeExecutionModule.hpp
@@ -5,6 +5,8 @@
 /// \file TradeExecutionModule.hpp
 /// \brief Implements trade execution functionality for the Intrade Bar platform.
 
+#include "SymbolUtils.hpp"
+
 namespace optionx::platforms::intrade_bar {
 
     /// \class TradeExecutionModule
@@ -45,6 +47,9 @@ namespace optionx::platforms::intrade_bar {
         bool preprocess_trade_request(
                 std::unique_ptr<TradeRequest> &trade_request,
                 std::unique_ptr<TradeResult> &trade_result) override final {
+            if (trade_request) {
+                trade_request->symbol = normalize_symbol_name(std::move(trade_request->symbol));
+            }
             if (trade_request &&
                 trade_request->option_type == OptionType::CLASSIC) {
                 if (trade_request->expiry_time > 0) {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
@@ -5,6 +5,8 @@
 /// \file http_utils.hpp
 /// \brief Contains utility functions for handling HTTP responses and errors.
 
+#include "SymbolUtils.hpp"
+
 namespace optionx::platforms::intrade_bar {
 
     /// \brief Validates the HTTP response for status and DDoS protection.
@@ -34,16 +36,6 @@ namespace optionx::platforms::intrade_bar {
             return false;
         }
         return true;
-    }
-
-    std::string normalize_symbol_name(std::string symbol) {
-        for (;;) {
-            auto it_str = symbol.find('/');
-            if(it_str != std::string::npos) symbol.erase(it_str, 1);
-            else break;
-        }
-        if (symbol == "BTCUSD") return "BTCUSDT";
-        return symbol;
     }
 
     /// \brief Returns the broker price precision used for a normalized symbol.

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -59,13 +59,19 @@ TEST(IntradeBarApiResponses, PriceDigitsMatchBrokerSymbols) {
 
 TEST(IntradeBarSymbols, NormalizesBtcAliases) {
     EXPECT_EQ(normalize_symbol_name("BTCUSD"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("btcusd"), "BTCUSDT");
     EXPECT_EQ(normalize_symbol_name("BTC/USDT"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("btc/usdt"), "BTCUSDT");
     EXPECT_EQ(normalize_symbol_name("BTC/USD"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("btc/usd"), "BTCUSDT");
     EXPECT_EQ(normalize_symbol_name("EUR/USD"), "EURUSD");
+    EXPECT_EQ(normalize_symbol_name("eur/usd"), "EURUSD");
 
     EXPECT_TRUE(is_btc_symbol("BTCUSD"));
+    EXPECT_TRUE(is_btc_symbol("btcusd"));
     EXPECT_TRUE(is_btc_symbol("BTCUSDT"));
     EXPECT_TRUE(is_btc_symbol("BTC/USD"));
+    EXPECT_TRUE(is_btc_symbol("btc/usd"));
     EXPECT_FALSE(is_btc_symbol("EURUSD"));
 }
 
@@ -75,6 +81,9 @@ TEST(IntradeBarAccountInfo, AcceptsBtcAliasAndUsesBtcDurationRules) {
     AccountInfoRequest request;
     request.type = AccountInfoType::SYMBOL_AVAILABILITY;
     request.symbol = "BTCUSD";
+    EXPECT_TRUE(account.get_info<bool>(request));
+
+    request.symbol = "btcusd";
     EXPECT_TRUE(account.get_info<bool>(request));
 
     request.symbol = "BTC/USD";
@@ -112,7 +121,7 @@ TEST(IntradeBarTradeExecution, NormalizesBtcAliasBeforeQueueProcessing) {
     };
 
     auto request = std::make_unique<TradeRequest>();
-    request->symbol = "BTCUSD";
+    request->symbol = "btc/usd";
     request->option_type = OptionType::SPRINT;
     request->order_type = OrderType::BUY;
     request->account_type = AccountType::DEMO;
@@ -123,7 +132,7 @@ TEST(IntradeBarTradeExecution, NormalizesBtcAliasBeforeQueueProcessing) {
     platform.run(false);
     ASSERT_TRUE(platform.place_trade(std::move(request)));
 
-    for (int i = 0; i < 20 && !callback_called; ++i) {
+    for (int i = 0; i < 200 && !callback_called; ++i) {
         platform.process();
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -77,6 +77,8 @@ TEST(IntradeBarSymbols, NormalizesBtcAliases) {
 
 TEST(IntradeBarAccountInfo, AcceptsBtcAliasAndUsesBtcDurationRules) {
     AccountInfoData account;
+    const int64_t day_timestamp = 1712345600;
+    const int64_t day_start = time_shield::start_of_day(day_timestamp);
 
     AccountInfoRequest request;
     request.type = AccountInfoType::SYMBOL_AVAILABILITY;
@@ -103,6 +105,19 @@ TEST(IntradeBarAccountInfo, AcceptsBtcAliasAndUsesBtcDurationRules) {
 
     request.symbol = "EURUSD";
     EXPECT_LT(account.get_info<int64_t>(request), account.max_duration);
+
+    request.timestamp = day_timestamp;
+    request.symbol = "btc/usd";
+    request.type = AccountInfoType::START_TIME;
+    EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.start_btc_time);
+    request.type = AccountInfoType::END_TIME;
+    EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.end_btc_time);
+
+    request.symbol = "EURUSD";
+    request.type = AccountInfoType::START_TIME;
+    EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.start_time);
+    request.type = AccountInfoType::END_TIME;
+    EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.end_time);
 }
 
 TEST(IntradeBarTradeExecution, NormalizesBtcAliasBeforeQueueProcessing) {

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include <optionx_cpp/platforms/IntradeBarPlatform.hpp>
 
 using namespace optionx;
@@ -52,6 +55,84 @@ TEST(IntradeBarApiResponses, PriceDigitsMatchBrokerSymbols) {
     EXPECT_EQ(spread.digits, 2);
     EXPECT_DOUBLE_EQ(spread.open_spread(), 0.0);
     EXPECT_DOUBLE_EQ(spread.close_spread(), 0.0);
+}
+
+TEST(IntradeBarSymbols, NormalizesBtcAliases) {
+    EXPECT_EQ(normalize_symbol_name("BTCUSD"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("BTC/USDT"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("BTC/USD"), "BTCUSDT");
+    EXPECT_EQ(normalize_symbol_name("EUR/USD"), "EURUSD");
+
+    EXPECT_TRUE(is_btc_symbol("BTCUSD"));
+    EXPECT_TRUE(is_btc_symbol("BTCUSDT"));
+    EXPECT_TRUE(is_btc_symbol("BTC/USD"));
+    EXPECT_FALSE(is_btc_symbol("EURUSD"));
+}
+
+TEST(IntradeBarAccountInfo, AcceptsBtcAliasAndUsesBtcDurationRules) {
+    AccountInfoData account;
+
+    AccountInfoRequest request;
+    request.type = AccountInfoType::SYMBOL_AVAILABILITY;
+    request.symbol = "BTCUSD";
+    EXPECT_TRUE(account.get_info<bool>(request));
+
+    request.symbol = "BTC/USD";
+    EXPECT_TRUE(account.get_info<bool>(request));
+
+    request.symbol = "BTCUSDT";
+    EXPECT_TRUE(account.get_info<bool>(request));
+
+    request.type = AccountInfoType::MIN_DURATION;
+    request.symbol = "BTCUSD";
+    EXPECT_EQ(account.get_info<int64_t>(request), account.min_btc_duration);
+
+    request.type = AccountInfoType::MAX_DURATION;
+    request.symbol = "BTCUSD";
+    request.timestamp = account.end_time - 30;
+    EXPECT_EQ(account.get_info<int64_t>(request), account.max_duration);
+
+    request.symbol = "EURUSD";
+    EXPECT_LT(account.get_info<int64_t>(request), account.max_duration);
+}
+
+TEST(IntradeBarTradeExecution, NormalizesBtcAliasBeforeQueueProcessing) {
+    IntradeBarPlatform platform;
+
+    bool callback_called = false;
+    std::string callback_symbol;
+    TradeErrorCode callback_error = TradeErrorCode::INVALID_REQUEST;
+
+    platform.on_trade_result() = [&](
+            std::unique_ptr<TradeRequest> request,
+            std::unique_ptr<TradeResult> result) {
+        callback_called = true;
+        callback_symbol = request ? request->symbol : std::string();
+        callback_error = result ? result->error_code : TradeErrorCode::INVALID_REQUEST;
+    };
+
+    auto request = std::make_unique<TradeRequest>();
+    request->symbol = "BTCUSD";
+    request->option_type = OptionType::SPRINT;
+    request->order_type = OrderType::BUY;
+    request->account_type = AccountType::DEMO;
+    request->currency = CurrencyType::USD;
+    request->amount = 1.0;
+    request->duration = 300;
+
+    platform.run(false);
+    ASSERT_TRUE(platform.place_trade(std::move(request)));
+
+    for (int i = 0; i < 20 && !callback_called; ++i) {
+        platform.process();
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+
+    platform.shutdown();
+
+    ASSERT_TRUE(callback_called);
+    EXPECT_EQ(callback_symbol, "BTCUSDT");
+    EXPECT_EQ(callback_error, TradeErrorCode::NO_CONNECTION);
 }
 
 TEST(IntradeBarAuthData, KeepsDisconnectedDomainRetryPeriodInConfig) {


### PR DESCRIPTION
## Summary

- add a single Intrade Bar symbol utility for BTCUSD/BTCUSDT normalization
- normalize symbols by removing `/` and uppercasing ASCII broker symbols
- accept BTCUSD/BTC/USD/btcusd aliases in account-info symbol checks
- use BTC-specific session fields for START_TIME/END_TIME and BTC duration rules for MIN_DURATION/MAX_DURATION/DURATION_AVAILABLE
- normalize BTC aliases to broker-side BTCUSDT before queued trade execution
- cover alias normalization, account-info duration/session rules, and direct place_trade preprocessing in tests

## Root Cause

The CLI and quote paths normalized BTCUSD to BTCUSDT, but AccountInfoData checked SYMBOL_AVAILABILITY against the raw request symbol. Direct library users could therefore pass BTCUSD to place_trade() and get inconsistent validation/transport behavior. MAX_DURATION also used the standard-pair session bound even for BTC, while DURATION_AVAILABLE already treated BTC as a separate instrument. START_TIME/END_TIME likewise ignored the existing start_btc_time/end_btc_time fields.

## Note

This PR wires the existing BTC session fields into the public account-info API. The current defaults remain `start_btc_time = 0` and `end_btc_time = 86400`; if live broker checks show a different BTC schedule, that should be handled by a follow-up default/config change.

## Validation

- cmake --build build-codex --target intrade_bar_api_response_test -- -j1
- .\build-codex\intrade_bar_api_response_test.exe
- cmake --build build-codex --target intrade_bar_smoke_cli -- -j1
- git diff --check