### PR TITLE
[codex] Report failing Intrade history source status

### DIFF
--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -1073,6 +1073,18 @@ namespace optionx::platforms::intrade_bar {
                 if (record.comment.empty()) record.comment = request.comment;
             }
         }
+
+        long select_combined_trade_history_status(
+                bool csv_success,
+                long csv_status_code,
+                bool html_success,
+                long html_status_code) {
+            if (!csv_success && csv_status_code >= 0) return csv_status_code;
+            if (!html_success && html_status_code >= 0) return html_status_code;
+            if (!csv_success) return csv_status_code;
+            if (!html_success) return html_status_code;
+            return csv_status_code >= 0 ? csv_status_code : html_status_code;
+        }
     }
 
     void RequestManager::request_trade_history(
@@ -1122,13 +1134,24 @@ namespace optionx::platforms::intrade_bar {
                         if (csv_success && html_success) {
                             callback(
                                 true,
-                                csv_status_code >= 0 ? csv_status_code : html_status_code,
+                                select_combined_trade_history_status(
+                                    csv_success,
+                                    csv_status_code,
+                                    html_success,
+                                    html_status_code),
                                 merge_trade_history_csv_with_html(
                                     std::move(csv_records),
                                     html_records));
                             return;
                         }
-                        callback(false, csv_status_code >= 0 ? csv_status_code : html_status_code, {});
+                        callback(
+                            false,
+                            select_combined_trade_history_status(
+                                csv_success,
+                                csv_status_code,
+                                html_success,
+                                html_status_code),
+                            {});
                     });
             });
     }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -330,6 +330,8 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryStatusPrefersFailedSource) {
     EXPECT_EQ(select_combined_trade_history_status(true, 200, false, 451), 451);
     EXPECT_EQ(select_combined_trade_history_status(false, 500, true, 200), 500);
     EXPECT_EQ(select_combined_trade_history_status(false, -1, false, 451), 451);
+    EXPECT_EQ(select_combined_trade_history_status(false, -1, false, -2), -1);
+    EXPECT_EQ(select_combined_trade_history_status(false, 500, false, 451), 500);
     EXPECT_EQ(select_combined_trade_history_status(true, 200, true, 200), 200);
 }
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -326,6 +326,13 @@ TEST(IntradeBarApiResponses, ParsesTradeHistorySourceConfigValues) {
         TradeHistorySource::HTML);
 }
 
+TEST(IntradeBarApiResponses, CombinedTradeHistoryStatusPrefersFailedSource) {
+    EXPECT_EQ(select_combined_trade_history_status(true, 200, false, 451), 451);
+    EXPECT_EQ(select_combined_trade_history_status(false, 500, true, 200), 500);
+    EXPECT_EQ(select_combined_trade_history_status(false, -1, false, 451), 451);
+    EXPECT_EQ(select_combined_trade_history_status(true, 200, true, 200), 200);
+}
+
 TEST(IntradeBarApiResponses, HistoryRangeFilterExcludesRecordsWithoutSelectedTimestamp) {
     TradeHistoryRequest request;
     request.start_ms = 1000;


### PR DESCRIPTION
## Summary

- make HTML_CSV trade history failures report the status code of the source that failed
- keep the existing success behavior for combined CSV/HTML history
- add unit coverage for combined CSV/HTML status selection, including both-source failure edges

## Root Cause

The HTML_CSV path previously reported `csv_status_code >= 0 ? csv_status_code : html_status_code` for both success and failure. If CSV succeeded with HTTP 200 and HTML failed with HTTP 451/500, callers received a failed result with status 200, hiding the real failing broker source.

## Follow-up

A future PR should add a RequestManager-level mock/integration-style test for `request_trade_history()` with controllable CSV/HTML responses, verifying that the final callback is invoked once and receives the failed source status. The current PR covers the status-selection policy directly.

## Validation

- cmake --build build-codex --target intrade_bar_api_response_test -- -j1
- .\build-codex\intrade_bar_api_response_test.exe
- cmake --build build-codex --target intrade_bar_smoke_cli -- -j1
- git diff --check