### PR TITLE
[codex] Clear HTTP rate limits on shutdown

### DIFF
--- a/include/optionx_cpp/modules/BaseHttpClientModule.hpp
+++ b/include/optionx_cpp/modules/BaseHttpClientModule.hpp
@@ -25,6 +25,7 @@ namespace optionx::modules {
 
         /// \brief Default virtual destructor.
         virtual ~BaseHttpClientModule() noexcept override {
+            deinitialize_rate_limits();
             m_client.cancel_requests();
             m_http_tasks.clear();
         }
@@ -105,7 +106,9 @@ namespace optionx::modules {
         /// \param requests_per_minute Maximum number of requests allowed per minute.
         template<class T>
         void set_rate_limit_rpm(T rate_limit_id, uint32_t requests_per_minute) {
-            m_rate_limits[static_cast<uint32_t>(rate_limit_id)] = kurlyk::create_rate_limit_rpm(requests_per_minute);
+            const auto id = static_cast<uint32_t>(rate_limit_id);
+            auto handle = kurlyk::create_rate_limit_rpm(requests_per_minute);
+            replace_rate_limit(id, std::move(handle));
         }
 
         /// \brief Creates a rate limit based on Requests Per Second (RPS).
@@ -113,10 +116,23 @@ namespace optionx::modules {
         /// \param requests_per_second Maximum number of requests allowed per second.
         template<class T>
         void set_rate_limit_rps(T rate_limit_id, uint32_t requests_per_second) {
-            m_rate_limits[static_cast<uint32_t>(rate_limit_id)] = kurlyk::create_rate_limit_rps(requests_per_second);
+            const auto id = static_cast<uint32_t>(rate_limit_id);
+            auto handle = kurlyk::create_rate_limit_rps(requests_per_second);
+            replace_rate_limit(id, std::move(handle));
         }
 
     private:
+
+        void replace_rate_limit(uint32_t id, kurlyk::HttpRateLimitHandlePtr handle) {
+            auto it = m_rate_limits.find(id);
+            if (it != m_rate_limits.end()) {
+                if (it->second) kurlyk::remove_limit(it->second);
+                it->second = std::move(handle);
+                return;
+            }
+
+            m_rate_limits.emplace(id, std::move(handle));
+        }
 
         /// \brief Processes all pending HTTP responses.
         void process_http_responses() {

--- a/include/optionx_cpp/modules/BaseHttpClientModule.hpp
+++ b/include/optionx_cpp/modules/BaseHttpClientModule.hpp
@@ -91,9 +91,13 @@ namespace optionx::modules {
 
         /// \brief Deinitializes all rate limits by resetting them.
         void deinitialize_rate_limits() {
-            for (auto item : m_rate_limits) {
-                kurlyk::remove_limit(item.second);
+            for (auto& item : m_rate_limits) {
+                if (item.second) {
+                    kurlyk::remove_limit(item.second);
+                    item.second.reset();
+                }
             }
+            m_rate_limits.clear();
         }
 
         /// \brief Creates a rate limit based on Requests Per Minute (RPM).

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -42,14 +42,54 @@ TEST(BaseHttpClientModule, ShutdownClearsRateLimitsAndIsRepeatable) {
     module.add_general_limit();
     EXPECT_EQ(module.rate_limit_count(), 1u);
     EXPECT_NE(module.general_limit_id(), 0u);
+    const auto limit_id = module.general_limit_id();
+    EXPECT_TRUE(static_cast<bool>(kurlyk::get_rate_limit(limit_id)));
 
     module.shutdown();
     EXPECT_EQ(module.rate_limit_count(), 0u);
     EXPECT_EQ(module.general_limit_id(), 0u);
+    EXPECT_FALSE(static_cast<bool>(kurlyk::get_rate_limit(limit_id)));
 
     module.shutdown();
     EXPECT_EQ(module.rate_limit_count(), 0u);
     EXPECT_EQ(module.general_limit_id(), 0u);
+    EXPECT_FALSE(static_cast<bool>(kurlyk::get_rate_limit(limit_id)));
+}
+
+TEST(BaseHttpClientModule, DestructorClearsRateLimits) {
+    optionx::utils::EventBus bus;
+    std::uint32_t limit_id = 0;
+
+    {
+        TestHttpClientModule module(bus);
+        module.add_general_limit();
+        limit_id = module.general_limit_id();
+        ASSERT_NE(limit_id, 0u);
+        EXPECT_TRUE(static_cast<bool>(kurlyk::get_rate_limit(limit_id)));
+    }
+
+    EXPECT_FALSE(static_cast<bool>(kurlyk::get_rate_limit(limit_id)));
+}
+
+TEST(BaseHttpClientModule, ReplacingRateLimitClearsPreviousHandle) {
+    optionx::utils::EventBus bus;
+    TestHttpClientModule module(bus);
+
+    module.add_general_limit();
+    const auto first_limit_id = module.general_limit_id();
+    ASSERT_NE(first_limit_id, 0u);
+    EXPECT_TRUE(static_cast<bool>(kurlyk::get_rate_limit(first_limit_id)));
+
+    module.add_general_limit();
+    const auto second_limit_id = module.general_limit_id();
+    ASSERT_NE(second_limit_id, 0u);
+    EXPECT_NE(first_limit_id, second_limit_id);
+
+    EXPECT_FALSE(static_cast<bool>(kurlyk::get_rate_limit(first_limit_id)));
+    EXPECT_TRUE(static_cast<bool>(kurlyk::get_rate_limit(second_limit_id)));
+
+    module.shutdown();
+    EXPECT_FALSE(static_cast<bool>(kurlyk::get_rate_limit(second_limit_id)));
 }
 
 TEST(IntradeBarApiResponses, ApiResultCarriesTypedSuccessPayload) {

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -9,6 +9,49 @@ using namespace optionx;
 using namespace optionx::platforms;
 using namespace optionx::platforms::intrade_bar;
 
+namespace {
+
+enum class TestRateLimitType : std::uint32_t {
+    GENERAL
+};
+
+class TestHttpClientModule : public optionx::modules::BaseHttpClientModule {
+public:
+    explicit TestHttpClientModule(optionx::utils::EventBus& bus)
+        : optionx::modules::BaseHttpClientModule(bus) {}
+
+    void add_general_limit() {
+        set_rate_limit_rps(TestRateLimitType::GENERAL, 1);
+    }
+
+    std::size_t rate_limit_count() const {
+        return m_rate_limits.size();
+    }
+
+    std::uint32_t general_limit_id() const {
+        return get_rate_limit(TestRateLimitType::GENERAL);
+    }
+};
+
+} // namespace
+
+TEST(BaseHttpClientModule, ShutdownClearsRateLimitsAndIsRepeatable) {
+    optionx::utils::EventBus bus;
+    TestHttpClientModule module(bus);
+
+    module.add_general_limit();
+    EXPECT_EQ(module.rate_limit_count(), 1u);
+    EXPECT_NE(module.general_limit_id(), 0u);
+
+    module.shutdown();
+    EXPECT_EQ(module.rate_limit_count(), 0u);
+    EXPECT_EQ(module.general_limit_id(), 0u);
+
+    module.shutdown();
+    EXPECT_EQ(module.rate_limit_count(), 0u);
+    EXPECT_EQ(module.general_limit_id(), 0u);
+}
+
 TEST(IntradeBarApiResponses, ApiResultCarriesTypedSuccessPayload) {
     auto result = BalanceInfoResult::ok(BalanceInfo{42.5, CurrencyType::USD}, 200);
 


### PR DESCRIPTION
## Summary
- make `BaseHttpClientModule` rate-limit cleanup idempotent by clearing stored handles after removal
- clear rate limits from the destructor when callers do not invoke `shutdown()` explicitly
- remove an existing `kurlyk` rate limit before replacing the handle for the same local rate-limit id
- add unit tests for repeated `shutdown()`, destructor cleanup, and same-id replacement cleanup

## Root Cause
`shutdown()` calls `deinitialize_rate_limits()`, but the module kept the same rate-limit handles in `m_rate_limits` after removing them from `kurlyk`. Repeated shutdown paths could try to remove the same handles again; even if `kurlyk` tolerated that, the module state did not represent that cleanup had completed.

A related lifecycle issue was that destruction without explicit `shutdown()` could leave manager-owned `kurlyk` rate-limit handles registered. Reconfiguring the same local rate-limit id also overwrote the local handle without explicitly releasing the previously registered limit.

## Validation
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe`
- `cmake --build build-codex --target intrade_bar_smoke_cli -- -j1`
- `git diff --check`

Note: the first `intrade_bar_smoke_cli` build attempt timed out without output; the immediate repeat completed successfully.