### PR TITLE
[codex] Initialize task execution timestamps

### DIFF
--- a/include/optionx_cpp/utils/tasks/Task.hpp
+++ b/include/optionx_cpp/utils/tasks/Task.hpp
@@ -52,6 +52,11 @@ namespace optionx::utils {
               m_start_time(get_current_time() + m_period_ms),
               m_next_execution_time(get_current_time() + delay_ms),
               m_reschedule_time(0),
+              m_execution_time(initial_execution_time(
+                  type,
+                  m_start_time,
+                  m_next_execution_time,
+                  m_timestamp_ms)),
               m_completed(false), m_force_execute(false), m_shutdown(false) {
         }
         
@@ -74,6 +79,11 @@ namespace optionx::utils {
               m_start_time(get_current_time() + m_period_ms),
               m_next_execution_time(get_current_time() + delay_ms),
               m_reschedule_time(0),
+              m_execution_time(initial_execution_time(
+                  type,
+                  m_start_time,
+                  m_next_execution_time,
+                  m_timestamp_ms)),
               m_completed(false), m_force_execute(false), m_shutdown(false),
               m_name(std::move(name)) {
         }
@@ -100,6 +110,7 @@ namespace optionx::utils {
             m_start_time = new_time_ms;
             m_timestamp_ms = new_time_ms;
             m_reschedule_time = new_time_ms;
+            m_execution_time = new_time_ms;
             m_completed = false;
         }
 
@@ -113,6 +124,7 @@ namespace optionx::utils {
             m_start_time = m_next_execution_time;
             m_timestamp_ms = m_next_execution_time;
             m_reschedule_time = m_next_execution_time;
+            m_execution_time = m_next_execution_time;
             m_completed = false;
         }
 
@@ -218,7 +230,9 @@ namespace optionx::utils {
 #           endif
         }
 
-        /// \brief Gets the task's next execution time.
+        /// \brief Gets the task's scheduled execution time.
+        /// \details The value is initialized at construction and then updated
+        ///          when the task is processed or explicitly rescheduled.
         int64_t get_next_execution_time() const {
             std::lock_guard<std::mutex> lock(m_mutex);
             return m_execution_time;
@@ -345,6 +359,26 @@ namespace optionx::utils {
         friend class TaskManager;
 
     private:
+        static int64_t initial_execution_time(
+                TaskType type,
+                int64_t start_time,
+                int64_t next_execution_time,
+                int64_t timestamp_ms) noexcept {
+            switch (type) {
+            case TaskType::SINGLE:
+            case TaskType::PERIODIC:
+                return start_time;
+            case TaskType::DELAYED_SINGLE:
+            case TaskType::DELAYED_PERIODIC:
+                return next_execution_time;
+            case TaskType::ON_DATE:
+            case TaskType::PERIODIC_ON_DATE:
+                return timestamp_ms;
+            default:
+                return start_time;
+            }
+        }
+
         mutable std::mutex m_mutex;
         TaskType m_type;
         Callback m_callback;

--- a/include/optionx_cpp/utils/tasks/Task.hpp
+++ b/include/optionx_cpp/utils/tasks/Task.hpp
@@ -140,6 +140,9 @@ namespace optionx::utils {
             m_start_time -= m_period_ms;
             m_period_ms = new_period_ms;
             m_start_time += m_period_ms;
+            if (m_type == TaskType::PERIODIC) {
+                m_execution_time = m_start_time;
+            }
             return true;
         }
 

--- a/include/optionx_cpp/utils/tasks/TaskManager.hpp
+++ b/include/optionx_cpp/utils/tasks/TaskManager.hpp
@@ -206,7 +206,12 @@ namespace optionx::utils {
             }
         }
 
-        /// \brief Shuts down the task manager, preventing further additions.
+        /// \brief Cancels and drains currently queued tasks.
+        /// \details During the drain, new tasks are rejected and existing tasks
+        ///          receive the shutdown flag. After the drain completes, the
+        ///          manager becomes reusable and new tasks may be scheduled
+        ///          again. This method is also used by the destructor as a final
+        ///          drain step.
         void shutdown() {
             LOGIT_TRACE0();
             m_shutdown = true;

--- a/tests/utils_task_manager_test.cpp
+++ b/tests/utils_task_manager_test.cpp
@@ -52,6 +52,72 @@ TEST(TaskTest, KeepsPreviousPeriodWhenSetPeriodIsInvalid) {
     EXPECT_TRUE(task->set_period(1));
 }
 
+TEST(TaskTest, InitializesExecutionTimeBeforeProcessing) {
+    auto callback = [](std::shared_ptr<optionx::utils::Task>) {};
+    const auto before_ms = optionx::utils::Task::get_current_time();
+
+    optionx::utils::Task single(
+        optionx::utils::TaskType::SINGLE,
+        callback);
+    optionx::utils::Task delayed(
+        optionx::utils::TaskType::DELAYED_SINGLE,
+        callback,
+        5000);
+    optionx::utils::Task periodic(
+        optionx::utils::TaskType::PERIODIC,
+        callback,
+        0,
+        7000);
+    optionx::utils::Task delayed_periodic(
+        optionx::utils::TaskType::DELAYED_PERIODIC,
+        callback,
+        3000,
+        7000);
+    optionx::utils::Task on_date(
+        optionx::utils::TaskType::ON_DATE,
+        callback,
+        0,
+        0,
+        123456789);
+    optionx::utils::Task periodic_on_date(
+        optionx::utils::TaskType::PERIODIC_ON_DATE,
+        callback,
+        0,
+        7000,
+        123456789);
+
+    const auto after_ms = optionx::utils::Task::get_current_time();
+
+    EXPECT_GE(single.get_next_execution_time(), before_ms);
+    EXPECT_LE(single.get_next_execution_time(), after_ms);
+    EXPECT_GE(delayed.get_next_execution_time(), before_ms + 5000);
+    EXPECT_LE(delayed.get_next_execution_time(), after_ms + 5000);
+    EXPECT_GE(periodic.get_next_execution_time(), before_ms + 7000);
+    EXPECT_LE(periodic.get_next_execution_time(), after_ms + 7000);
+    EXPECT_GE(delayed_periodic.get_next_execution_time(), before_ms + 3000);
+    EXPECT_LE(delayed_periodic.get_next_execution_time(), after_ms + 3000);
+    EXPECT_EQ(on_date.get_next_execution_time(), 123456789);
+    EXPECT_EQ(periodic_on_date.get_next_execution_time(), 123456789);
+}
+
+TEST(TaskTest, RescheduleUpdatesExecutionTimeBeforeProcessing) {
+    auto callback = [](std::shared_ptr<optionx::utils::Task>) {};
+    optionx::utils::Task task(
+        optionx::utils::TaskType::DELAYED_SINGLE,
+        callback,
+        5000);
+
+    task.reschedule_at(123456789);
+    EXPECT_EQ(task.get_next_execution_time(), 123456789);
+
+    const auto before_ms = optionx::utils::Task::get_current_time();
+    task.reschedule_in(5000);
+    const auto after_ms = optionx::utils::Task::get_current_time();
+
+    EXPECT_GE(task.get_next_execution_time(), before_ms + 5000);
+    EXPECT_LE(task.get_next_execution_time(), after_ms + 5000);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/utils_task_manager_test.cpp
+++ b/tests/utils_task_manager_test.cpp
@@ -118,6 +118,24 @@ TEST(TaskTest, RescheduleUpdatesExecutionTimeBeforeProcessing) {
     EXPECT_LE(task.get_next_execution_time(), after_ms + 5000);
 }
 
+TEST(TaskTest, SetPeriodUpdatesExecutionTimeBeforeProcessing) {
+    auto callback = [](std::shared_ptr<optionx::utils::Task>) {};
+    const auto before_ms = optionx::utils::Task::get_current_time();
+
+    optionx::utils::Task task(
+        optionx::utils::TaskType::PERIODIC,
+        callback,
+        0,
+        5000);
+
+    ASSERT_TRUE(task.set_period(8000));
+
+    const auto after_ms = optionx::utils::Task::get_current_time();
+
+    EXPECT_GE(task.get_next_execution_time(), before_ms + 8000);
+    EXPECT_LE(task.get_next_execution_time(), after_ms + 8000);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- initialize `Task::m_execution_time` during construction for every `TaskType`
- keep the scheduled execution timestamp in sync when a task is explicitly rescheduled
- keep the scheduled timestamp in sync when `PERIODIC` task period changes before processing
- document the current reusable drain semantics of `TaskManager::shutdown()`
- add unit coverage for pre-process execution timestamps, rescheduling, and period changes

## Root Cause
`Task::m_execution_time` was assigned only from `Task::process()`. Calling `get_next_execution_time()` or `get_delay()` before the first processing tick could therefore read an indeterminate value. The field now starts with the task type's initial scheduled timestamp: immediate/periodic start time, delayed next execution time, or explicit on-date timestamp.

After the initial fix, `set_period()` still left `PERIODIC` tasks with the old scheduled timestamp until the next `process()` call. It now updates `m_execution_time` together with the adjusted `m_start_time`.

`TaskManager::shutdown()` currently drains and cancels queued work, then returns the manager to a reusable state. The behavior is kept unchanged because broker modules rely on it, but the Doxygen now states that contract explicitly.

## Validation
- `cmake --build build-codex --target utils_task_manager_test -- -j1`
- `./build-codex/utils_task_manager_test.exe` — 7 tests passed
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe` — 34 tests passed
- `git diff --check`

Note: the first `intrade_bar_api_response_test` build attempt timed out without output; the immediate repeat completed successfully.