### PR TITLE
[codex] Harden header-only ODR helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,4 +232,8 @@ if(BUILD_TESTS)
             )
         endif()
     endforeach()
+
+    if(TARGET header_only_odr_test)
+        target_sources(header_only_odr_test PRIVATE tests/header_only_odr_companion.cc)
+    endif()
 endif()

--- a/include/optionx_cpp/data/account.hpp
+++ b/include/optionx_cpp/data/account.hpp
@@ -5,6 +5,9 @@
 /// \file account.hpp
 /// \brief Core components for account management and data querying.
 
+#include "utils/enum_utils.hpp"
+#include "utils/string_utils.hpp"
+
 #include "account/enums.hpp"
 #include "account/AccountInfoRequest.hpp"
 #include "account/IAuthData.hpp"

--- a/include/optionx_cpp/data/account/BaseAccountInfoData.hpp
+++ b/include/optionx_cpp/data/account/BaseAccountInfoData.hpp
@@ -160,49 +160,49 @@ namespace optionx {
 
     /// \brief Template specialization for retrieving boolean account information.
     template<>
-    const bool BaseAccountInfoData::get_info<bool>(const AccountInfoRequest& request) const {
+    inline const bool BaseAccountInfoData::get_info<bool>(const AccountInfoRequest& request) const {
         return get_info_bool(request);
     }
 
     /// \brief Template specialization for retrieving integer account information.
     template<>
-    const int BaseAccountInfoData::get_info<int>(const AccountInfoRequest& request) const {
+    inline const int BaseAccountInfoData::get_info<int>(const AccountInfoRequest& request) const {
         return static_cast<int>(get_info_int64(request));
     }
 
     /// \brief Template specialization for retrieving int64_t account information.
     template<>
-    const int64_t BaseAccountInfoData::get_info<int64_t>(const AccountInfoRequest& request) const {
+    inline const int64_t BaseAccountInfoData::get_info<int64_t>(const AccountInfoRequest& request) const {
         return get_info_int64(request);
     }
 
     /// \brief Template specialization for retrieving size_t account information.
     template<>
-    const size_t BaseAccountInfoData::get_info<size_t>(const AccountInfoRequest& request) const {
+    inline const size_t BaseAccountInfoData::get_info<size_t>(const AccountInfoRequest& request) const {
         return static_cast<size_t>(get_info_int64(request));
     }
 
     /// \brief Template specialization for retrieving CurrencyType account information.
     template<>
-    const CurrencyType BaseAccountInfoData::get_info<CurrencyType>(const AccountInfoRequest& request) const {
+    inline const CurrencyType BaseAccountInfoData::get_info<CurrencyType>(const AccountInfoRequest& request) const {
         return static_cast<CurrencyType>(get_info_int64(request));
     }
 
     /// \brief Template specialization for retrieving AccountType account information.
     template<>
-    const AccountType BaseAccountInfoData::get_info<AccountType>(const AccountInfoRequest& request) const {
+    inline const AccountType BaseAccountInfoData::get_info<AccountType>(const AccountInfoRequest& request) const {
         return static_cast<AccountType>(get_info_int64(request));
     }
 
     /// \brief Template specialization for retrieving double account information.
     template<>
-    const double BaseAccountInfoData::get_info<double>(const AccountInfoRequest& request) const {
+    inline const double BaseAccountInfoData::get_info<double>(const AccountInfoRequest& request) const {
         return get_info_f64(request);
     }
 
     /// \brief Template specialization for retrieving string account information.
     template<>
-    const std::string BaseAccountInfoData::get_info<std::string>(const AccountInfoRequest& request) const {
+    inline const std::string BaseAccountInfoData::get_info<std::string>(const AccountInfoRequest& request) const {
         return get_info_str(request);
     }
 

--- a/include/optionx_cpp/data/account/enums.hpp
+++ b/include/optionx_cpp/data/account/enums.hpp
@@ -8,6 +8,8 @@
 ///          and trade request pre-processing. Used to query account capabilities, limits
 ///          and validate trading parameters.
 
+#include "utils/enum_utils.hpp"
+
 namespace optionx {
 
     /// \enum AccountInfoType
@@ -78,7 +80,7 @@ namespace optionx {
             "SOCKS5",
             "SOCKS5_HOSTNAME"
         };
-        return data_str[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(data_str, static_cast<size_t>(value));
     }
 
     /// \brief Converts a string to its corresponding ProxyType enum value.
@@ -116,7 +118,7 @@ namespace optionx {
     }
 
     /// \brief Stream output operator for kurlyk::ProxyType.
-    std::ostream& operator<<(std::ostream& os, kurlyk::ProxyType value) {
+    inline std::ostream& operator<<(std::ostream& os, kurlyk::ProxyType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -151,7 +153,7 @@ namespace optionx {
             "CONNECTED",
             "DISCONNECTED",
             "FAILED_TO_CONNECT"};
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     };
 
     /// \brief Converts string to AccountUpdateStatus enumeration.
@@ -199,7 +201,7 @@ namespace optionx {
     }
 
     /// \brief Stream output operator for AccountUpdateStatus.
-    std::ostream& operator<<(std::ostream& os, AccountUpdateStatus value) {
+    inline std::ostream& operator<<(std::ostream& os, AccountUpdateStatus value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -222,7 +224,7 @@ namespace optionx {
             "NONE",
             "EMAIL_PASSWORD",
             "USER_TOKEN"};
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     };
 
     /// \brief Converts string to AuthMethod enumeration.
@@ -264,7 +266,7 @@ namespace optionx {
     }
 
     /// \brief Stream output operator for AuthMethod.
-    std::ostream& operator<<(std::ostream& os, AuthMethod value) {
+    inline std::ostream& operator<<(std::ostream& os, AuthMethod value) {
         os << optionx::to_str(value);
         return os;
     }

--- a/include/optionx_cpp/data/account/enums.hpp
+++ b/include/optionx_cpp/data/account/enums.hpp
@@ -8,8 +8,6 @@
 ///          and trade request pre-processing. Used to query account capabilities, limits
 ///          and validate trading parameters.
 
-#include "utils/enum_utils.hpp"
-
 namespace optionx {
 
     /// \enum AccountInfoType

--- a/include/optionx_cpp/data/bridge.hpp
+++ b/include/optionx_cpp/data/bridge.hpp
@@ -5,6 +5,9 @@
 /// \file bridge.hpp
 /// \brief Includes bridge-related headers.
 
+#include "utils/enum_utils.hpp"
+#include "utils/string_utils.hpp"
+
 #include "bridge/enums.hpp"
 #include "bridge/IBridgeConfig.hpp"
 #include "bridge/BridgeStatusUpdate.hpp"

--- a/include/optionx_cpp/data/bridge/enums.hpp
+++ b/include/optionx_cpp/data/bridge/enums.hpp
@@ -5,6 +5,8 @@
 /// \file enums.hpp
 /// \brief
 
+#include "utils/enum_utils.hpp"
+
 namespace optionx {
 
     /// \enum BridgeStatus
@@ -31,7 +33,7 @@ namespace optionx {
             "CLIENT_CONNECTED",
             "CLIENT_DISCONNECTED",
             "CONNECTION_ERROR"};
-		return str_data[static_cast<size_t>(value)];
+		return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to BridgeStatus enumeration.
@@ -77,7 +79,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for BridgeStatus.
-	std::ostream& operator<<(std::ostream& os, BridgeStatus value) {
+	inline std::ostream& operator<<(std::ostream& os, BridgeStatus value) {
         os << optionx::to_str(value);
         return os;
     }

--- a/include/optionx_cpp/data/bridge/enums.hpp
+++ b/include/optionx_cpp/data/bridge/enums.hpp
@@ -5,8 +5,6 @@
 /// \file enums.hpp
 /// \brief
 
-#include "utils/enum_utils.hpp"
-
 namespace optionx {
 
     /// \enum BridgeStatus

--- a/include/optionx_cpp/data/trading/enums.hpp
+++ b/include/optionx_cpp/data/trading/enums.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <unordered_map>
 #include <nlohmann/json.hpp>
-#include "utils/enum_utils.hpp"
 
 namespace optionx {
 

--- a/include/optionx_cpp/data/trading/enums.hpp
+++ b/include/optionx_cpp/data/trading/enums.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <nlohmann/json.hpp>
+#include "utils/enum_utils.hpp"
 
 namespace optionx {
 
@@ -32,12 +33,12 @@ namespace optionx {
         static const std::vector<std::string> str_data_2 = {"Unknown", "Simulator", "Clicker", "Intrade Bar", "TradeUp"};
 
         switch (mode) {
-            case 0: return str_data_0[static_cast<size_t>(value)];
-            case 1: return str_data_1[static_cast<size_t>(value)];
-            case 2: return str_data_2[static_cast<size_t>(value)];
+            case 0: return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
+            case 1: return utils::enum_string_or_unknown(str_data_1, static_cast<size_t>(value));
+            case 2: return utils::enum_string_or_unknown(str_data_2, static_cast<size_t>(value));
             default: break;
         }
-		return str_data_0[static_cast<size_t>(value)];
+		return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to PlatformType enumeration.
@@ -81,7 +82,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for PlatformType.
-	std::ostream& operator<<(std::ostream& os, PlatformType value) {
+	inline std::ostream& operator<<(std::ostream& os, PlatformType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -100,7 +101,7 @@ namespace optionx {
     /// \return Constant reference to the corresponding string.
     inline const std::string& to_str(BridgeType value, int mode = 0) noexcept {
         static const std::vector<std::string> str_data = {"UNKNOWN", "INTRADE_BAR_LEGACY"};
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     }
 
     /// \brief Converts string to BridgeType enumeration.
@@ -164,11 +165,11 @@ namespace optionx {
         static const std::vector<std::string> str_data_1 = {"Unknown", "Demo", "Real"};
 
 		switch (mode) {
-            case 0: return str_data_0[static_cast<size_t>(value)];
-            case 1: return str_data_1[static_cast<size_t>(value)];
+            case 0: return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
+            case 1: return utils::enum_string_or_unknown(str_data_1, static_cast<size_t>(value));
             default: break;
         }
-		return str_data_0[static_cast<size_t>(value)];
+		return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to AccountType enumeration.
@@ -208,7 +209,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for AccountType.
-	std::ostream& operator<<(std::ostream& os, AccountType value) {
+	inline std::ostream& operator<<(std::ostream& os, AccountType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -230,11 +231,11 @@ namespace optionx {
         static const std::vector<std::string> str_data_0 = {"UNKNOWN", "SPRINT", "CLASSIC"};
         static const std::vector<std::string> str_data_1 = {"Unknown", "Sprint", "Classic"};
         switch (mode) {
-            case 0: return str_data_0[static_cast<size_t>(value)];
-            case 1: return str_data_1[static_cast<size_t>(value)];
+            case 0: return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
+            case 1: return utils::enum_string_or_unknown(str_data_1, static_cast<size_t>(value));
             default: break;
         };
-		return str_data_0[static_cast<size_t>(value)];
+		return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to OptionType enumeration.
@@ -273,7 +274,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for OptionType.
-	std::ostream& operator<<(std::ostream& os, OptionType value) {
+	inline std::ostream& operator<<(std::ostream& os, OptionType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -298,13 +299,13 @@ namespace optionx {
         static const std::vector<std::string> str_data_3 = {"Unknown", "Put", "Call"};
 
         switch (mode) {
-            case 0: return str_data_0[static_cast<size_t>(value)];
-            case 1: return str_data_1[static_cast<size_t>(value)];
-            case 2: return str_data_2[static_cast<size_t>(value)];
-            case 3: return str_data_3[static_cast<size_t>(value)];
+            case 0: return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
+            case 1: return utils::enum_string_or_unknown(str_data_1, static_cast<size_t>(value));
+            case 2: return utils::enum_string_or_unknown(str_data_2, static_cast<size_t>(value));
+            case 3: return utils::enum_string_or_unknown(str_data_3, static_cast<size_t>(value));
             default: break;
         };
-		return str_data_0[static_cast<size_t>(value)];
+		return utils::enum_string_or_unknown(str_data_0, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to OrderType enumeration.
@@ -345,7 +346,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for OrderType.
-	std::ostream& operator<<(std::ostream& os, OrderType value) {
+	inline std::ostream& operator<<(std::ostream& os, OrderType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -383,7 +384,7 @@ namespace optionx {
             "UAH",
             "KZT"
         };
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     };
 
 	/// \brief Converts string to CurrencyType enumeration.
@@ -431,7 +432,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for CurrencyType.
-	std::ostream& operator<<(std::ostream& os, CurrencyType value) {
+	inline std::ostream& operator<<(std::ostream& os, CurrencyType value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -473,7 +474,7 @@ namespace optionx {
             "REFUND",
             "CANCELED_TRADE"
         };
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     }
 
 	/// \brief Converts a string to its corresponding TradeState enumeration value.
@@ -527,7 +528,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for TradeState.
-	std::ostream& operator<<(std::ostream& os, TradeState value) {
+	inline std::ostream& operator<<(std::ostream& os, TradeState value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -656,7 +657,7 @@ namespace optionx {
     }
 
 	/// \brief Stream output operator for TradeErrorCode.
-    std::ostream& operator<<(std::ostream& os, TradeErrorCode value) {
+    inline std::ostream& operator<<(std::ostream& os, TradeErrorCode value) {
         os << optionx::to_str(value);
         return os;
     }
@@ -714,7 +715,7 @@ namespace optionx {
             "SKU_SYMBOL",
             "SKU_BAR"
         };
-        return str_data[static_cast<size_t>(value)];
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
     }
 
     /// \brief Converts a string to its corresponding MmSystemType enumeration value.

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
@@ -201,7 +201,7 @@ namespace optionx::modules {
     };
 
     template<typename PreprocessFunction>
-    bool TradeQueueManager::add_trade(
+    inline bool TradeQueueManager::add_trade(
             std::unique_ptr<TradeRequest> request,
             PlatformType platform_type,
             PreprocessFunction preprocess) {
@@ -231,12 +231,12 @@ namespace optionx::modules {
         return true;
     }
 
-    void TradeQueueManager::set_trade_result_callback(trade_result_callback_t callback) {
+    inline void TradeQueueManager::set_trade_result_callback(trade_result_callback_t callback) {
         std::lock_guard<std::mutex> lock(m_trade_result_mutex);
         m_trade_result_callback = std::move(callback);
     }
 
-    TradeQueueManager::transaction_t TradeQueueManager::pop_next_transaction() {
+    inline TradeQueueManager::transaction_t TradeQueueManager::pop_next_transaction() {
         const int64_t order_interval_ms = std::max<int64_t>(
             0,
             m_account_info.get_info<int64_t>(AccountInfoType::ORDER_INTERVAL_MS));
@@ -256,7 +256,7 @@ namespace optionx::modules {
         return nullptr;
     }
 
-    void TradeQueueManager::handle_canceled_transactions(std::list<transaction_t>& calceled_transactions) {
+    inline void TradeQueueManager::handle_canceled_transactions(std::list<transaction_t>& calceled_transactions) {
         const int64_t timestamp = OPTIONX_TIMESTAMP_MS;
         for (const auto &transaction : calceled_transactions) {
             m_trade_state_manager.finalize_transaction_with_error(
@@ -267,7 +267,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::clean_expired_transactions(
+    inline void TradeQueueManager::clean_expired_transactions(
             int64_t current_time_ms,
             std::list<transaction_t>& calceled_transactions) {
         const int64_t timeout_ms = time_shield::sec_to_ms(m_account_info.get_info<int64_t>(AccountInfoType::ORDER_QUEUE_TIMEOUT));
@@ -284,7 +284,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::handle_closing_error(
+    inline void TradeQueueManager::handle_closing_error(
             const transaction_t& transaction,
             int64_t timestamp) {
         auto& result = transaction->result;
@@ -300,7 +300,7 @@ namespace optionx::modules {
         dispatch_trade_event(transaction);
     }
 
-    void TradeQueueManager::process_pending_transactions() {
+    inline void TradeQueueManager::process_pending_transactions() {
         std::unique_lock<std::mutex> lock(m_pending_mutex);
         if (m_pending_transactions.empty()) return;
 
@@ -347,7 +347,7 @@ namespace optionx::modules {
         handle_canceled_transactions(calceled_transactions);
     }
 
-    void TradeQueueManager::process_closing_transactions() {
+    inline void TradeQueueManager::process_closing_transactions() {
         if (m_open_transactions.empty()) return;
         const int64_t timestamp = OPTIONX_TIMESTAMP_MS;
         auto it = m_open_transactions.begin();
@@ -411,7 +411,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::process_finalizing_transactions() {
+    inline void TradeQueueManager::process_finalizing_transactions() {
         auto it = m_open_transactions.begin();
         while (it != m_open_transactions.end()) {
             auto& transaction = *it;
@@ -430,7 +430,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::finalize_all_trades() {
+    inline void TradeQueueManager::finalize_all_trades() {
         LOGIT_0TRACE();
 
         std::list<transaction_t> pending_transactions;
@@ -460,14 +460,14 @@ namespace optionx::modules {
         m_has_sent_order = false;
     }
 
-    void TradeQueueManager::increment_open_trades(
+    inline void TradeQueueManager::increment_open_trades(
         const std::shared_ptr<TradeRequest>& request,
         const std::shared_ptr<TradeResult>& result) {
         m_local_open_trades++;
         emit_open_trades(request, result);
     }
 
-    void TradeQueueManager::decrement_open_trades(
+    inline void TradeQueueManager::decrement_open_trades(
         const std::shared_ptr<TradeRequest>& request,
         const std::shared_ptr<TradeResult>& result) {
         if (m_local_open_trades > 0) {
@@ -476,7 +476,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::process_snapshot_open_trades() {
+    inline void TradeQueueManager::process_snapshot_open_trades() {
         if (m_snapshot_open_trades <= 0) return;
         if (m_snapshot_close_due_times_ms.empty()) {
             if (m_snapshot_unknown_close_trades > 0) {
@@ -516,18 +516,18 @@ namespace optionx::modules {
         }
     }
 
-    int64_t TradeQueueManager::current_open_trades() const {
+    inline int64_t TradeQueueManager::current_open_trades() const {
         return m_local_open_trades + m_snapshot_open_trades;
     }
 
-    void TradeQueueManager::emit_open_trades(
+    inline void TradeQueueManager::emit_open_trades(
             const std::shared_ptr<TradeRequest>& request,
             const std::shared_ptr<TradeResult>& result) {
         events::OpenTradesEvent event(current_open_trades(), request, result);
         notify(event);
     }
 
-    bool TradeQueueManager::clear_snapshot_open_trades() {
+    inline bool TradeQueueManager::clear_snapshot_open_trades() {
         const bool changed =
             m_snapshot_open_trades != 0 ||
             m_snapshot_unknown_close_trades != 0 ||
@@ -539,13 +539,13 @@ namespace optionx::modules {
         return changed;
     }
 
-    void TradeQueueManager::request_snapshot_refresh(const char* reason) {
+    inline void TradeQueueManager::request_snapshot_refresh(const char* reason) {
         if (m_snapshot_refresh_requested) return;
         m_snapshot_refresh_requested = true;
         notify(events::OpenTradesSnapshotRefreshRequestEvent(reason ? reason : ""));
     }
 
-    int64_t TradeQueueManager::add_snapshot_close_buffer(
+    inline int64_t TradeQueueManager::add_snapshot_close_buffer(
             int64_t close_time_ms,
             int64_t close_buffer_ms) const {
         if (close_buffer_ms <= 0) return close_time_ms;
@@ -554,7 +554,7 @@ namespace optionx::modules {
         return close_time_ms + close_buffer_ms;
     }
 
-    void TradeQueueManager::dispatch_trade_event(const transaction_t& transaction) {
+    inline void TradeQueueManager::dispatch_trade_event(const transaction_t& transaction) {
         auto &request = transaction->request;
         auto &result  = transaction->result;
 
@@ -569,7 +569,7 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::handle_event(const events::PriceUpdateEvent& event) {
+    inline void TradeQueueManager::handle_event(const events::PriceUpdateEvent& event) {
         for (auto& transaction : m_open_transactions) {
             auto& request = transaction->request;
             auto& result = transaction->result;
@@ -593,11 +593,11 @@ namespace optionx::modules {
         }
     }
 
-    void TradeQueueManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void TradeQueueManager::handle_event(const events::DisconnectRequestEvent& event) {
         finalize_all_trades();
     }
 
-    void TradeQueueManager::handle_event(const events::OpenTradesSnapshotEvent& event) {
+    inline void TradeQueueManager::handle_event(const events::OpenTradesSnapshotEvent& event) {
         std::unique_lock<std::mutex> lock(m_pending_mutex);
         m_snapshot_refresh_requested = false;
         if (!m_pending_transactions.empty() ||

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
@@ -100,7 +100,7 @@ namespace optionx::modules {
         return TradeErrorCode::SUCCESS;
     }
 
-    TradeState TradeStateManager::determine_trade_state(
+    inline TradeState TradeStateManager::determine_trade_state(
             const std::shared_ptr<TradeResult>& result,
             const std::shared_ptr<TradeRequest>& request,
             const TickData& tick) const {
@@ -124,18 +124,18 @@ namespace optionx::modules {
         return TradeState::STANDOFF;
     }
 
-    bool TradeStateManager::is_closable_state(TradeState state) const {
+    inline bool TradeStateManager::is_closable_state(TradeState state) const {
         return state == TradeState::WAITING_CLOSE ||
                state == TradeState::OPEN_SUCCESS ||
                state == TradeState::IN_PROGRESS;
     }
 
-    bool TradeStateManager::is_transition_to_waiting_close(TradeState trade_state) const {
+    inline bool TradeStateManager::is_transition_to_waiting_close(TradeState trade_state) const {
         return trade_state == TradeState::OPEN_SUCCESS ||
                trade_state == TradeState::IN_PROGRESS;
     }
 
-    bool TradeStateManager::is_terminal_state(TradeState trade_state) const {
+    inline bool TradeStateManager::is_terminal_state(TradeState trade_state) const {
         return trade_state == TradeState::OPEN_ERROR ||
                trade_state == TradeState::CHECK_ERROR ||
                trade_state == TradeState::WIN ||
@@ -144,7 +144,7 @@ namespace optionx::modules {
                trade_state == TradeState::REFUND;
     }
 
-    int64_t TradeStateManager::calculate_close_date(
+    inline int64_t TradeStateManager::calculate_close_date(
             const std::shared_ptr<TradeResult>& result,
             const std::shared_ptr<TradeRequest>& request) const {
         if (result->close_date > 0) return result->close_date;
@@ -159,7 +159,7 @@ namespace optionx::modules {
         return 0;
     }
 
-    void TradeStateManager::finalize_transaction_with_error(
+    inline void TradeStateManager::finalize_transaction_with_error(
             const std::shared_ptr<events::TradeTransactionEvent>& transaction,
             TradeErrorCode error_code,
             TradeState state,

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/ActiveTradesSyncManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/ActiveTradesSyncManager.hpp
@@ -117,7 +117,7 @@ namespace optionx::platforms::intrade_bar {
         std::shared_ptr<AccountInfoData> get_account_info();
     };
 
-    void ActiveTradesSyncManager::on_event(const utils::Event* const event) {
+    inline void ActiveTradesSyncManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::AuthDataEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -135,17 +135,17 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void ActiveTradesSyncManager::process() {
+    inline void ActiveTradesSyncManager::process() {
         m_task_manager.process();
     }
 
-    void ActiveTradesSyncManager::shutdown() {
+    inline void ActiveTradesSyncManager::shutdown() {
         m_task_manager.shutdown();
         m_refresh_scheduled = false;
         reset_sync_state();
     }
 
-    void ActiveTradesSyncManager::request_sync(std::string reason) {
+    inline void ActiveTradesSyncManager::request_sync(std::string reason) {
         if (m_sync_in_progress) {
             LOGIT_DEBUG(
                 "Intrade Bar active trades sync: snapshot already in progress. reason=",
@@ -238,13 +238,13 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void ActiveTradesSyncManager::reset_sync_state() {
+    inline void ActiveTradesSyncManager::reset_sync_state() {
         m_sync_in_progress = false;
         m_active_sync_generation = 0;
         ++m_sync_generation;
     }
 
-    void ActiveTradesSyncManager::invalidate_account_context(const char* reason) {
+    inline void ActiveTradesSyncManager::invalidate_account_context(const char* reason) {
         ++m_account_context_generation;
         m_task_manager.shutdown();
         m_refresh_scheduled = false;
@@ -256,7 +256,7 @@ namespace optionx::platforms::intrade_bar {
             m_account_context_generation);
     }
 
-    ActiveTradesSyncManager::AccountContext
+    inline ActiveTradesSyncManager::AccountContext
     ActiveTradesSyncManager::capture_account_context(
             const std::shared_ptr<AccountInfoData>& account_info) const {
         AccountContext context;
@@ -267,7 +267,7 @@ namespace optionx::platforms::intrade_bar {
         return context;
     }
 
-    bool ActiveTradesSyncManager::is_account_context_current(
+    inline bool ActiveTradesSyncManager::is_account_context_current(
             const AccountContext& expected,
             const std::shared_ptr<AccountInfoData>& current) const {
         return expected.generation == m_account_context_generation &&
@@ -276,7 +276,7 @@ namespace optionx::platforms::intrade_bar {
             expected.currency == current->currency;
     }
 
-    void ActiveTradesSyncManager::schedule_sync(std::string reason) {
+    inline void ActiveTradesSyncManager::schedule_sync(std::string reason) {
         if (m_refresh_scheduled) {
             LOGIT_DEBUG(
                 "Intrade Bar active trades sync: refresh already scheduled. reason=",
@@ -313,7 +313,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void ActiveTradesSyncManager::handle_event(const events::AuthDataEvent& event) {
+    inline void ActiveTradesSyncManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
             m_active_trades_close_buffer_ms = auth_data->active_trades_close_buffer_ms;
             m_active_trades_sync_period_ms = auth_data->active_trades_sync_period_ms;
@@ -333,15 +333,15 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void ActiveTradesSyncManager::handle_event(const events::RestartAuthEvent& event) {
+    inline void ActiveTradesSyncManager::handle_event(const events::RestartAuthEvent& event) {
         request_sync("restart-auth");
     }
 
-    void ActiveTradesSyncManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void ActiveTradesSyncManager::handle_event(const events::DisconnectRequestEvent& event) {
         invalidate_account_context("disconnect-request");
     }
 
-    void ActiveTradesSyncManager::handle_event(const events::AccountInfoUpdateEvent& event) {
+    inline void ActiveTradesSyncManager::handle_event(const events::AccountInfoUpdateEvent& event) {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             request_sync("connected");
@@ -357,12 +357,12 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void ActiveTradesSyncManager::handle_event(
+    inline void ActiveTradesSyncManager::handle_event(
             const events::OpenTradesSnapshotRefreshRequestEvent& event) {
         schedule_sync(event.reason.empty() ? "refresh-request" : event.reason);
     }
 
-    std::shared_ptr<AccountInfoData> ActiveTradesSyncManager::get_account_info() {
+    inline std::shared_ptr<AccountInfoData> ActiveTradesSyncManager::get_account_info() {
         if (auto account_info = std::dynamic_pointer_cast<AccountInfoData>(m_account_info)) {
             return account_info;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -178,7 +178,7 @@ namespace optionx::platforms::intrade_bar {
         std::shared_ptr<AccountInfoData> get_account_info();
     };
 
-    void AuthManager::on_event(const utils::Event* const event) {
+    inline void AuthManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::AuthDataEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -193,15 +193,15 @@ namespace optionx::platforms::intrade_bar {
         }
     };
 
-    void AuthManager::process() {
+    inline void AuthManager::process() {
         m_task_manager.process();
     }
 
-    void AuthManager::shutdown() {
+    inline void AuthManager::shutdown() {
         m_task_manager.shutdown();
     }
 
-    void AuthManager::set_auth_credentials(
+    inline void AuthManager::set_auth_credentials(
             const std::string& user_id,
             const std::string& user_hash) {
         std::string cookies = "user_id=" + user_id + "; user_hash=" + user_hash;
@@ -210,7 +210,7 @@ namespace optionx::platforms::intrade_bar {
         set_account_user_id(user_id);
     }
 
-    void AuthManager::set_account_user_id(const std::string& user_id) {
+    inline void AuthManager::set_account_user_id(const std::string& user_id) {
         auto account_info = get_account_info();
         if (auto parsed = utils::parse_i64_strict(user_id)) {
             account_info->user_id = *parsed;
@@ -222,7 +222,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::handle_event(const events::AuthDataEvent& event) {
+    inline void AuthManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
             LOGIT_TRACE0();
             auto [success, message] = auth_data->validate();
@@ -235,7 +235,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::handle_event(const events::ConnectRequestEvent& event) {
+    inline void AuthManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_TRACE0();
         auto callback = event.callback;
         m_task_manager.add_single_task(
@@ -345,7 +345,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void AuthManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void AuthManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_TRACE0();
         auto callback = event.callback;
         m_task_manager.add_single_task(
@@ -393,7 +393,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void AuthManager::handle_event(const events::RestartAuthEvent& event) {
+    inline void AuthManager::handle_event(const events::RestartAuthEvent& event) {
         start_authentication([this](const ConnectionResult& result) {
             if (!result.success) {
                 auto account_info = get_account_info();
@@ -414,7 +414,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
     
-    void AuthManager::handle_auto_domain_and_auth(
+    inline void AuthManager::handle_auto_domain_and_auth(
             connection_callback_t callback,
             std::function<void(connection_callback_t)> auth_func) {
 
@@ -450,7 +450,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::validate_email_pass(connection_callback_t callback) {
+    inline void AuthManager::validate_email_pass(connection_callback_t callback) {
         // Validate email and password
         if (m_auth_data->email.empty() ||
             m_auth_data->password.empty()) {
@@ -504,7 +504,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::validate_user_token(connection_callback_t callback) {
+    inline void AuthManager::validate_user_token(connection_callback_t callback) {
         // Validate user_id and token
         if (m_auth_data->user_id.empty() || m_auth_data->token.empty()) {
             LOGIT_ERROR_IF(m_auth_data->user_id.empty(), "Validation failed: User ID is missing.");
@@ -531,7 +531,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void AuthManager::handle_auth_failure(
+    inline void AuthManager::handle_auth_failure(
             const std::string& reason,
             connection_callback_t callback) {
         using Status = events::AccountInfoUpdateEvent::Status;
@@ -543,7 +543,7 @@ namespace optionx::platforms::intrade_bar {
             reason));
     }
 
-    void AuthManager::execute_authentication_flow(
+    inline void AuthManager::execute_authentication_flow(
             connection_callback_t callback) {
         perform_auth_flow([this, callback](
                 bool success,
@@ -564,7 +564,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void AuthManager::perform_auth_flow(
+    inline void AuthManager::perform_auth_flow(
             std::function<void(
                 bool success,
                 const std::string& reason)> result_callback) {
@@ -645,7 +645,7 @@ namespace optionx::platforms::intrade_bar {
         m_request_manager.request_main_page(m_auth_data, handle_main_page_response);
     }
 
-    void AuthManager::start_authentication(connection_callback_t callback) {
+    inline void AuthManager::start_authentication(connection_callback_t callback) {
         LOGIT_TRACE0();
         LOGIT_INFO("Intrade Bar auth: requesting profile.");
         m_request_manager.request_profile([this, callback](
@@ -662,7 +662,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void AuthManager::handle_account_type_switch(
+    inline void AuthManager::handle_account_type_switch(
             AccountType account_type,
             CurrencyType currency,
             connection_callback_t callback) {
@@ -683,7 +683,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::handle_account_type_switch_attempt(
+    inline void AuthManager::handle_account_type_switch_attempt(
             CurrencyType currency,
             connection_callback_t callback,
             int64_t started_ms,
@@ -742,7 +742,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void AuthManager::handle_currency_switch(
+    inline void AuthManager::handle_currency_switch(
             CurrencyType currency,
             connection_callback_t callback) {
         LOGIT_TRACE0();
@@ -761,7 +761,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void AuthManager::handle_currency_switch_attempt(
+    inline void AuthManager::handle_currency_switch_attempt(
             connection_callback_t callback,
             int64_t started_ms,
             int attempt) {
@@ -818,7 +818,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void AuthManager::schedule_settings_switch_retry(
+    inline void AuthManager::schedule_settings_switch_retry(
             std::string operation_name,
             int64_t started_ms,
             int attempt,
@@ -898,7 +898,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void AuthManager::finalize_authentication(connection_callback_t callback) {
+    inline void AuthManager::finalize_authentication(connection_callback_t callback) {
         LOGIT_TRACE0();
         LOGIT_INFO("Intrade Bar auth: requesting final balance.");
         m_request_manager.request_balance([this, callback](
@@ -941,7 +941,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    std::shared_ptr<AccountInfoData> AuthManager::get_account_info() {
+    inline std::shared_ptr<AccountInfoData> AuthManager::get_account_info() {
         if (auto account_info = std::dynamic_pointer_cast<AccountInfoData>(m_account_info)) {
             return account_info;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
@@ -113,7 +113,7 @@ namespace optionx::platforms::intrade_bar {
         std::shared_ptr<AccountInfoData> get_account_info();
     };
 
-    void BalanceManager::on_event(const utils::Event* const event) {
+    inline void BalanceManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::ConnectRequestEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -134,16 +134,16 @@ namespace optionx::platforms::intrade_bar {
         }
     };
 
-    void BalanceManager::process() {
+    inline void BalanceManager::process() {
         m_task_manager.process();
     }
 
-    void BalanceManager::shutdown() {
+    inline void BalanceManager::shutdown() {
         m_task_manager.shutdown();
     }
 
     // Handles balance updates.
-    void BalanceManager::handle_balance_update() {
+    inline void BalanceManager::handle_balance_update() {
         if (m_has_balance_update) return;
         m_has_balance_update = true;
         LOGIT_INFO("Intrade Bar balance: requesting balance snapshot.");
@@ -174,7 +174,7 @@ namespace optionx::platforms::intrade_bar {
     }
 
     // Processes successful balance updates.
-    void BalanceManager::process_balance_success(
+    inline void BalanceManager::process_balance_success(
             double balance,
             CurrencyType currency,
             std::shared_ptr<AccountInfoData>& account_info) {
@@ -202,7 +202,7 @@ namespace optionx::platforms::intrade_bar {
     }
 
     // Processes balance update failure.
-    void BalanceManager::process_balance_failure(
+    inline void BalanceManager::process_balance_failure(
             std::shared_ptr<AccountInfoData>& account_info) {
         if (account_info->connect) {
             account_info->connect = false;
@@ -213,12 +213,12 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void BalanceManager::handle_event(const events::BalanceRequestEvent& event) {
+    inline void BalanceManager::handle_event(const events::BalanceRequestEvent& event) {
         m_last_trades_time = time_shield::ms_to_sec(OPTIONX_TIMESTAMP_MS);
         handle_balance_update();
     }
 
-    void BalanceManager::handle_event(const events::AuthDataEvent& event) {
+    inline void BalanceManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
             if (auth_data->balance_check_period_ms > 0) {
                 m_balance_check_period_ms = auth_data->balance_check_period_ms;
@@ -236,7 +236,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void BalanceManager::handle_event(const events::TradeRequestEvent& event) {
+    inline void BalanceManager::handle_event(const events::TradeRequestEvent& event) {
         m_last_trades_time = time_shield::ms_to_sec(OPTIONX_TIMESTAMP_MS);
         auto request = event.request;
         //auto result  = event.result;
@@ -253,17 +253,17 @@ namespace optionx::platforms::intrade_bar {
         m_last_trades_time += max_elapsed;
     }
 
-    void BalanceManager::handle_event(const events::ConnectRequestEvent& event) {
+    inline void BalanceManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_TRACE0();
         m_task_manager.shutdown();
     }
 
-    void BalanceManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void BalanceManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_TRACE0();
         m_task_manager.shutdown();
     }
 
-    void BalanceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
+    inline void BalanceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             handle_connected();
@@ -274,7 +274,7 @@ namespace optionx::platforms::intrade_bar {
     }
 
     /// \brief Handles account connection event.
-    void BalanceManager::handle_connected() {
+    inline void BalanceManager::handle_connected() {
         LOGIT_TRACE0();
 
         m_task_manager.shutdown();
@@ -320,7 +320,7 @@ namespace optionx::platforms::intrade_bar {
     }
 
     /// \brief Handles account disconnection event.
-    void BalanceManager::handle_disconnected() {
+    inline void BalanceManager::handle_disconnected() {
         LOGIT_TRACE0();
 
         m_task_manager.shutdown();
@@ -361,7 +361,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    std::shared_ptr<AccountInfoData> BalanceManager::get_account_info() {
+    inline std::shared_ptr<AccountInfoData> BalanceManager::get_account_info() {
         if (auto account_info = std::dynamic_pointer_cast<AccountInfoData>(m_account_info)) {
             return account_info;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -113,7 +113,7 @@ namespace optionx::platforms::intrade_bar {
         void handle_event(const events::AutoDomainSelectedEvent& event);
     };
 
-    void BtcPriceManager::on_event(const utils::Event* const event) {
+    inline void BtcPriceManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::AuthDataEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -131,7 +131,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void BtcPriceManager::handle_event(const events::AuthDataEvent& event) {
+    inline void BtcPriceManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
             LOGIT_TRACE0();
 
@@ -154,17 +154,17 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void BtcPriceManager::handle_event(const events::ConnectRequestEvent& event) {
+    inline void BtcPriceManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_0TRACE();
         m_websocket_client.disconnect();
     }
 
-    void BtcPriceManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void BtcPriceManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_0TRACE();
         m_websocket_client.disconnect();
     }
 
-    void BtcPriceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
+    inline void BtcPriceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             LOGIT_0TRACE();
@@ -176,7 +176,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
     
-    void BtcPriceManager::handle_event(const events::AutoDomainSelectedEvent& event) {
+    inline void BtcPriceManager::handle_event(const events::AutoDomainSelectedEvent& event) {
         LOGIT_0TRACE();
         if (event.success) {
             std::string host = "wss://" + utils::remove_http_prefix(event.selected_host);
@@ -184,17 +184,17 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void BtcPriceManager::handle_message(const std::string& message) {
+    inline void BtcPriceManager::handle_message(const std::string& message) {
         if (parse_btcusdt_tick(message, m_tick_data[0])) {
             notify_async(std::make_unique<events::PriceUpdateEvent>(m_tick_data));
         }
     }
 
-    void BtcPriceManager::process() {
+    inline void BtcPriceManager::process() {
 
     }
 
-    void BtcPriceManager::shutdown() {
+    inline void BtcPriceManager::shutdown() {
         m_websocket_client.disconnect_and_wait();
         m_tick_data[0].tick.flags = 0;
         m_tick_data[0].flags = 0;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
@@ -68,7 +68,7 @@ namespace optionx::platforms::intrade_bar {
         void handle_price_update(std::shared_ptr<utils::Task> task);
     };
 
-    void PriceManager::on_event(const utils::Event* const event) {
+    inline void PriceManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::ConnectRequestEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -80,19 +80,19 @@ namespace optionx::platforms::intrade_bar {
         }
     };
 
-    void PriceManager::handle_event(const events::ConnectRequestEvent& event) {
+    inline void PriceManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_0TRACE();
         m_task_manager.shutdown();
         m_ticks.clear();
     }
 
-    void PriceManager::handle_event(const events::DisconnectRequestEvent& event) {
+    inline void PriceManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_0TRACE();
         m_task_manager.shutdown();
         m_ticks.clear();
     }
 
-    void PriceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
+    inline void PriceManager::handle_event(const events::AccountInfoUpdateEvent& event) {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             LOGIT_0TRACE();
@@ -115,15 +115,15 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void PriceManager::process() {
+    inline void PriceManager::process() {
         m_task_manager.process();
     }
 
-    void PriceManager::shutdown() {
+    inline void PriceManager::shutdown() {
         m_task_manager.shutdown();
     }
 
-    void PriceManager::handle_price_update(std::shared_ptr<utils::Task> task) {
+    inline void PriceManager::handle_price_update(std::shared_ptr<utils::Task> task) {
         if (m_has_price_update) return;
         m_has_price_update = true;
         LOGIT_DEBUG("Intrade Bar price: requesting price snapshot.");

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -395,7 +395,7 @@ namespace optionx::platforms::intrade_bar {
 	
     // ------------------------------------------------------------------------
 
-    void RequestManager::request_main_page(
+    inline void RequestManager::request_main_page(
             std::shared_ptr<AuthData> auth_data,
             std::function<void(
                 bool success,
@@ -465,7 +465,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_active_trades_snapshot(
+    inline void RequestManager::request_active_trades_snapshot(
             std::function<void(
                 bool success,
                 std::vector<ActiveTradeInfo> trades)> callback) {
@@ -500,7 +500,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(response_callback));
     }
 
-    void RequestManager::request_login(
+    inline void RequestManager::request_login(
             const std::string& req_id,
             const std::string& req_value,
             const std::string& cookies,
@@ -567,7 +567,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_auth(
+    inline void RequestManager::request_auth(
             const std::string& user_id,
             const std::string& user_hash,
             const std::string& cookies,
@@ -612,7 +612,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_balance(
+    inline void RequestManager::request_balance(
             std::function<void(
                 bool success,
                 double balance,
@@ -654,7 +654,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_switch_account_type(
+    inline void RequestManager::request_switch_account_type(
             std::function<void(bool success)> switch_callback) {
         request_switch_account_type_result(
             [switch_callback = std::move(switch_callback)](SettingsSwitchResult result) {
@@ -662,7 +662,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_switch_currency(
+    inline void RequestManager::request_switch_currency(
             std::function<void(bool success)> switch_callback) {
         request_switch_currency_result(
             [switch_callback = std::move(switch_callback)](SettingsSwitchResult result) {
@@ -670,7 +670,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_settings_switch_result(
+    inline void RequestManager::request_settings_switch_result(
             const std::string& operation_name,
             const std::string& endpoint,
             std::function<void(SettingsSwitchResult)> switch_callback) {
@@ -720,7 +720,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
     
-    void RequestManager::request_find_working_domain(
+    inline void RequestManager::request_find_working_domain(
             std::function<void(
                 bool success,
                 std::string& host)> find_callback) {
@@ -843,7 +843,7 @@ namespace optionx::platforms::intrade_bar {
     
     /// \brief Checks if the currently set host in the HTTP client is available.
     /// \param callback Callback that receives the result: true if available, false otherwise.
-    void RequestManager::request_check_current_host_available(
+    inline void RequestManager::request_check_current_host_available(
             std::function<void(bool)> check_callback) {
         LOGIT_TRACE0();
 
@@ -874,7 +874,7 @@ namespace optionx::platforms::intrade_bar {
         client.set_connect_timeout(15);
     }
 
-    void RequestManager::request_profile(
+    inline void RequestManager::request_profile(
             std::function<void(
                 bool success,
                 CurrencyType currency,
@@ -923,7 +923,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_price(
+    inline void RequestManager::request_price(
             std::function<void(
                 bool success,
                 std::vector<TickData> ticks)> price_callback) {
@@ -1087,7 +1087,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    void RequestManager::request_trade_history(
+    inline void RequestManager::request_trade_history(
             const TradeHistoryRequest& request,
             AccountType account_type,
             std::function<void(
@@ -1156,7 +1156,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_trade_history_csv(
+    inline void RequestManager::request_trade_history_csv(
             const TradeHistoryRequest& request,
             AccountType account_type,
             std::function<void(
@@ -1218,7 +1218,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(response_callback));
     }
 
-    void RequestManager::request_trade_history_html(
+    inline void RequestManager::request_trade_history_html(
             const TradeHistoryRequest& request,
             AccountType account_type,
             std::function<void(
@@ -1406,7 +1406,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(response_callback));
     }
 
-    void RequestManager::request_trade_check(
+    inline void RequestManager::request_trade_check(
             int64_t deal_id,
             int retry_attempts,
             std::function<void(
@@ -1499,7 +1499,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_execute_trade(
+    inline void RequestManager::request_execute_trade(
             std::shared_ptr<TradeRequest> request,
             std::function<void(
                 bool success,
@@ -1564,7 +1564,7 @@ namespace optionx::platforms::intrade_bar {
         add_http_request_task(std::move(future), std::move(callback));
     }
 
-    void RequestManager::request_find_working_domain_result(
+    inline void RequestManager::request_find_working_domain_result(
             std::function<void(DomainSelectionResult)> find_callback) {
         request_find_working_domain(
             [find_callback = std::move(find_callback)](
@@ -1579,7 +1579,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_check_current_host_available_result(
+    inline void RequestManager::request_check_current_host_available_result(
             std::function<void(HostAvailabilityResult)> check_callback) {
         request_check_current_host_available(
             [check_callback = std::move(check_callback)](bool success) {
@@ -1592,7 +1592,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_profile_result(
+    inline void RequestManager::request_profile_result(
             std::function<void(ProfileInfoResult)> profile_callback) {
         request_profile(
             [profile_callback = std::move(profile_callback)](
@@ -1608,7 +1608,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_main_page_result(
+    inline void RequestManager::request_main_page_result(
             std::shared_ptr<AuthData> auth_data,
             std::function<void(MainPageChallengeResult)> callback) {
         request_main_page(
@@ -1628,7 +1628,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_active_trades_snapshot_result(
+    inline void RequestManager::request_active_trades_snapshot_result(
             std::function<void(ActiveTradesSnapshotResult)> callback) {
         request_active_trades_snapshot(
             [callback = std::move(callback)](
@@ -1643,7 +1643,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_login_result(
+    inline void RequestManager::request_login_result(
             const std::string& req_id,
             const std::string& req_value,
             const std::string& cookies,
@@ -1670,7 +1670,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_auth_result(
+    inline void RequestManager::request_auth_result(
             const std::string& user_id,
             const std::string& user_hash,
             const std::string& cookies,
@@ -1693,7 +1693,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_balance_result(
+    inline void RequestManager::request_balance_result(
             std::function<void(BalanceInfoResult)> balance_callback) {
         request_balance(
             [balance_callback = std::move(balance_callback)](
@@ -1709,7 +1709,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_switch_account_type_result(
+    inline void RequestManager::request_switch_account_type_result(
             std::function<void(SettingsSwitchResult)> switch_callback) {
         request_settings_switch_result(
             "account type",
@@ -1717,7 +1717,7 @@ namespace optionx::platforms::intrade_bar {
             std::move(switch_callback));
     }
 
-    void RequestManager::request_switch_currency_result(
+    inline void RequestManager::request_switch_currency_result(
             std::function<void(SettingsSwitchResult)> switch_callback) {
         request_settings_switch_result(
             "currency",
@@ -1725,7 +1725,7 @@ namespace optionx::platforms::intrade_bar {
             std::move(switch_callback));
     }
 
-    void RequestManager::request_price_result(
+    inline void RequestManager::request_price_result(
             std::function<void(PriceSnapshotResult)> price_callback) {
         request_price(
             [price_callback = std::move(price_callback)](
@@ -1740,7 +1740,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_trade_history_result(
+    inline void RequestManager::request_trade_history_result(
             const TradeHistoryRequest& request,
             AccountType account_type,
             std::function<void(TradeHistoryApiResult)> callback) {
@@ -1761,7 +1761,7 @@ namespace optionx::platforms::intrade_bar {
                 callback(TradeHistoryApiResult::ok(TradeHistory{std::move(records)}, status_code));
             });
     }
-    void RequestManager::request_trade_check_result(
+    inline void RequestManager::request_trade_check_result(
             int64_t deal_id,
             int retry_attempts,
             std::function<void(TradeCheckResult)> callback_check) {
@@ -1784,7 +1784,7 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    void RequestManager::request_execute_trade_result(
+    inline void RequestManager::request_execute_trade_result(
             std::shared_ptr<TradeRequest> request,
             std::function<void(TradeOpenResult)> result_callback) {
         request_execute_trade(

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
@@ -101,7 +101,7 @@ namespace optionx::platforms::intrade_bar {
         std::shared_ptr<AccountInfoData> get_account_info();
     };
 
-    void TradeManager::on_event(const utils::Event* const event) {
+    inline void TradeManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::TradeRequestEvent*>(event)) {
             handle_event(*msg);
         } else
@@ -113,15 +113,15 @@ namespace optionx::platforms::intrade_bar {
         }
     };
 
-    void TradeManager::process() {
+    inline void TradeManager::process() {
         m_task_manager.process();
     }
 
-    void TradeManager::shutdown() {
+    inline void TradeManager::shutdown() {
         m_task_manager.shutdown();
     }
 
-    bool TradeManager::fetch_trade_history(
+    inline bool TradeManager::fetch_trade_history(
             const TradeHistoryRequest& request,
             trade_history_callback_t callback) {
         if (!callback || !request.has_valid_range()) return false;
@@ -149,7 +149,7 @@ namespace optionx::platforms::intrade_bar {
             });
         return true;
     }
-    bool TradeManager::fetch_trade_result(
+    inline bool TradeManager::fetch_trade_result(
             TradeResultQuery query,
             std::unique_ptr<TradeResult> result,
             trade_result_check_callback_t callback) {
@@ -260,7 +260,7 @@ namespace optionx::platforms::intrade_bar {
         return true;
     }
 
-    void TradeManager::handle_event(const events::TradeRequestEvent& event) {
+    inline void TradeManager::handle_event(const events::TradeRequestEvent& event) {
         auto request = event.request;
         auto result  = event.result;
         LOGIT_INFO(
@@ -359,7 +359,7 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void TradeManager::handle_event(const events::TradeStatusEvent& event) {
+    inline void TradeManager::handle_event(const events::TradeStatusEvent& event) {
         auto request = event.request;
         auto result  = event.result;
         if (!request || !result) {
@@ -446,14 +446,14 @@ namespace optionx::platforms::intrade_bar {
         });
     }
 
-    void TradeManager::handle_event(const events::OpenTradesEvent& event) {
+    inline void TradeManager::handle_event(const events::OpenTradesEvent& event) {
         using Status = events::AccountInfoUpdateEvent::Status;
         auto account_info = get_account_info();
         account_info->open_trades = event.open_trades;
         notify(events::AccountInfoUpdateEvent(account_info, Status::OPEN_TRADES_CHANGED));
     }
 
-    void TradeManager::process_trade_status(
+    inline void TradeManager::process_trade_status(
             bool success,
             double price,
             double profit,
@@ -497,7 +497,7 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    std::shared_ptr<AccountInfoData> TradeManager::get_account_info() {
+    inline std::shared_ptr<AccountInfoData> TradeManager::get_account_info() {
         if (auto account_info = std::dynamic_pointer_cast<AccountInfoData>(m_account_info)) {
             return account_info;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -25,7 +25,7 @@ namespace optionx::platforms::intrade_bar {
     /// \brief Parses the login response and extracts user ID and hash.
     /// \param content The HTTP response content to parse.
     /// \return A pair of optional values for user_id and user_hash. If parsing fails, both values will be std::nullopt.
-    std::optional<std::pair<std::string, std::string>> parse_login(const std::string& content) {
+    inline std::optional<std::pair<std::string, std::string>> parse_login(const std::string& content) {
         try {
             std::string user_id, user_hash, fragment;
             // Extract "/auth/" fragment
@@ -56,7 +56,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param content Raw HTML fragment containing the balance value and currency symbol.
     /// \return Optional pair of balance amount and detected currency type. Returns
     ///         std::nullopt if the content cannot be parsed.
-    std::optional<std::pair<double, CurrencyType>> parse_balance(const std::string& content) {
+    inline std::optional<std::pair<double, CurrencyType>> parse_balance(const std::string& content) {
         try {
             const std::string STR_RUB = u8"₽";
             const std::string STR_RUB_UTF8 = "\xE2\x82\xBD";
@@ -100,7 +100,7 @@ namespace optionx::platforms::intrade_bar {
     /// \brief Parses the response content to extract account and currency information.
     /// \param content The HTTP response content to parse.
     /// \return A pair of optional values for CurrencyType and AccountType. If parsing fails, both values will be std::nullopt.
-    std::pair<CurrencyType, AccountType> parse_profile_response(const std::string& content) {
+    inline std::pair<CurrencyType, AccountType> parse_profile_response(const std::string& content) {
         // Strings for matching
         const char str_demo_ru[] = u8"Демо";
         const char str_real_ru[] = u8"Реал";
@@ -150,7 +150,7 @@ namespace optionx::platforms::intrade_bar {
     /// \return Optional tuple containing the request identifier, request value
     ///         and a cookie string to be used in subsequent requests. Returns
     ///         std::nullopt if any of the required fields cannot be found.
-    std::optional<std::tuple<std::string, std::string, std::string>> parse_main_page_response(
+    inline std::optional<std::tuple<std::string, std::string, std::string>> parse_main_page_response(
             const std::string& content,
             const kurlyk::Headers& headers) {
         std::string req_id, req_value, cookies;
@@ -718,7 +718,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param content Raw authenticated page or trade_load_more2.php fragment.
     /// \param account_type Account type used for the request.
     /// \return Parsed closed trades and next pagination cursor.
-    TradeHistoryHtmlPage parse_trade_history_html_page(
+    inline TradeHistoryHtmlPage parse_trade_history_html_page(
             const std::string& content,
             AccountType account_type) {
         TradeHistoryHtmlPage page;
@@ -754,7 +754,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param content Raw authenticated HTML page.
     /// \param account_type Account type used for the request.
     /// \return Best-effort history records; financial result fields may be unknown.
-    std::vector<TradeRecord> parse_trade_history_html_snapshot(
+    inline std::vector<TradeRecord> parse_trade_history_html_snapshot(
             const std::string& content,
             AccountType account_type) {
         return parse_trade_history_html_page(content, account_type).records;
@@ -764,7 +764,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param csv_records Financially complete CSV records.
     /// \param html_records Best-effort HTML records with broker IDs.
     /// \return CSV records enriched with HTML data only when both sources match.
-    std::vector<TradeRecord> merge_trade_history_csv_with_html(
+    inline std::vector<TradeRecord> merge_trade_history_csv_with_html(
             std::vector<TradeRecord> csv_records,
             const std::vector<TradeRecord>& html_records) {
         std::vector<TradeRecord> merged;
@@ -821,7 +821,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param content Raw semicolon-separated export body.
     /// \param account_type Account type used for the export request.
     /// \return Parsed closed trade records; malformed rows are skipped.
-    std::vector<TradeRecord> parse_trade_history_csv_export(
+    inline std::vector<TradeRecord> parse_trade_history_csv_export(
             const std::string& content,
             AccountType account_type) {
         std::vector<TradeRecord> records;
@@ -882,7 +882,7 @@ namespace optionx::platforms::intrade_bar {
     /// \brief Parses active trades from the authenticated main page.
     /// \param content Raw HTML of the authenticated main page.
     /// \return Active trades found in the trade_active block.
-    std::vector<ActiveTradeInfo> parse_active_trades_snapshot(const std::string& content) {
+    inline std::vector<ActiveTradeInfo> parse_active_trades_snapshot(const std::string& content) {
         std::vector<ActiveTradeInfo> trades;
 
         std::string active_html;
@@ -953,7 +953,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param status_code HTTP status code.
     /// \param operation_name Human-readable settings operation name.
     /// \return Typed switch result with retry diagnostics on broker rejection.
-    SettingsSwitchResult parse_settings_switch_response(
+    inline SettingsSwitchResult parse_settings_switch_response(
             const std::string& content,
             long status_code,
             const std::string& operation_name) {
@@ -981,7 +981,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param user_id [out] The extracted user_id.
     /// \param user_hash [out] The extracted user_hash.
     /// \return True if both user_id and user_hash are found, otherwise false.
-    bool parse_cookies(const std::string& cookies, std::string& user_id, std::string& user_hash) {
+    inline bool parse_cookies(const std::string& cookies, std::string& user_id, std::string& user_hash) {
         std::unordered_map<std::string, std::string> cookie_map;
         std::istringstream cookie_stream(cookies);
         std::string cookie;
@@ -1016,7 +1016,7 @@ namespace optionx::platforms::intrade_bar {
         return false;
     }
 
-    std::optional<std::tuple<std::string, std::string>> parse_cookies(const std::string& cookies) {
+    inline std::optional<std::tuple<std::string, std::string>> parse_cookies(const std::string& cookies) {
         std::unordered_map<std::string, std::string> cookie_map;
         std::istringstream cookie_stream(cookies);
         std::string cookie;
@@ -1054,7 +1054,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param request A shared pointer to the TradeRequest containing request details.
     /// \param result A shared pointer to the TradeResult where the parsed result will be stored.
     /// \return True if the response was successfully parsed, false otherwise.
-    bool parse_execute_trade(
+    inline bool parse_execute_trade(
             const std::string& content,
             std::shared_ptr<TradeRequest> request,
             std::shared_ptr<TradeResult> result) {
@@ -1204,7 +1204,7 @@ namespace optionx::platforms::intrade_bar {
     ///        - open_date: The trade open date as a timestamp.
     ///        - open_price: The trade open price.
     ///        - error_desc: A description of the error if parsing fails.
-    void parse_execute_trade(
+    inline void parse_execute_trade(
             const std::string& content,
             long status_code,
             std::function<void(
@@ -1297,7 +1297,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param message The JSON-formatted string containing the tick data.
     /// \param tick_data Reference to the TickData structure to be updated.
     /// \return true if parsing is successful and the symbol matches BTCUSDT; false otherwise.
-    bool parse_btcusdt_tick(const std::string& message, TickData& tick_data) {
+    inline bool parse_btcusdt_tick(const std::string& message, TickData& tick_data) {
         auto j = nlohmann::json::parse(message);
 
         if (j.contains("data")) {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
@@ -14,7 +14,7 @@ namespace optionx::platforms::intrade_bar {
     /// \param callback The callback to invoke if the validation fails. The callback is called with a failure flag, a reason message, and cloned authorization data.
     /// \param auth_data The authorization data to pass to the callback upon failure.
     /// \return True if the response is valid; otherwise, false. If false, the callback is invoked.
-    bool validate_response(
+    inline bool validate_response(
             const kurlyk::HttpResponsePtr& response,
             const connection_callback_t& callback,
             const std::shared_ptr<AuthData>& auth_data) {

--- a/include/optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/http_parsers.hpp
@@ -18,7 +18,7 @@ namespace optionx::platforms::tradeup {
     /// \param content The raw JSON response body.
     /// \param headers The HTTP headers returned with the response (used to extract cookies).
     /// \return Optional tuple (user_id, token, affs_id, cookie_string); std::nullopt if parsing fails.
-    std::optional<std::tuple<std::string, std::string, std::string, std::string>> 
+    inline std::optional<std::tuple<std::string, std::string, std::string, std::string>>
         parse_signin_response(
             const std::string& content,
             const kurlyk::Headers& headers) {

--- a/include/optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/TradeUpPlatform/http_utils.hpp
@@ -31,7 +31,7 @@ namespace optionx::platforms::tradeup {
         return {};
     }
     
-    void collect_set_cookie(const Headers& headers, ::kurlyk::Cookies& out) {
+    inline void collect_set_cookie(const Headers& headers, ::kurlyk::Cookies& out) {
         auto [it, end] = headers.equal_range("set-cookie");
         for (; it != end; ++it) {
             ::kurlyk::Cookies c = ::kurlyk::utils::parse_cookie(it->second);

--- a/include/optionx_cpp/utils/Base36.hpp
+++ b/include/optionx_cpp/utils/Base36.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <random>
 #include <atomic>
+#include <stdexcept>
 
 namespace optionx::utils {
 
@@ -108,7 +109,9 @@ namespace optionx::utils {
         static std::string encode_string(const std::string& input) {
             std::string result;
             for (unsigned char c : input) {
-                result += encode_int(static_cast<long long>(c));
+                std::string encoded = encode_int(static_cast<long long>(c));
+                if (encoded.size() == 1) encoded.insert(encoded.begin(), '0');
+                result += encoded;
             }
             return result;
         }
@@ -118,6 +121,10 @@ namespace optionx::utils {
         /// \return The decoded original string.
         /// \throws std::invalid_argument If the input contains invalid Base36 characters.
         static std::string decode_string(const std::string& input) {
+            if (input.size() % 2 != 0) {
+                throw std::invalid_argument("Invalid Base36 string length for decoding.");
+            }
+
             std::string result;
             size_t i = 0;
             while (i < input.size()) {
@@ -162,22 +169,18 @@ namespace optionx::utils {
             return random_offset++;
         }
 
-        static const int BASE36 = 36; ///< Base36 numeric base.
-        static const char BASE36_INVALID = '?'; ///< Character for invalid Base36 values.
-        static const char BASE36_MAP[36]; ///< Map of Base36 characters.
-        static const std::map<char, int> BASE36_CHAR_MAP; ///< Map of Base36 character values.
+        static constexpr int BASE36 = 36; ///< Base36 numeric base.
+        static constexpr char BASE36_INVALID = '?'; ///< Character for invalid Base36 values.
+        inline static constexpr char BASE36_MAP[36] = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+            'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+            'u', 'v', 'w', 'x', 'y', 'z'
+        }; ///< Map of Base36 characters.
+        inline static const std::map<char, int> BASE36_CHAR_MAP = init_char_map(); ///< Map of Base36 character values.
 
         inline static std::atomic<uint64_t> random_offset{0}; ///< Random offset for random string generation.
     };
-
-    const char Base36::BASE36_MAP[36] = {
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-        'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
-        'u', 'v', 'w', 'x', 'y', 'z'
-    };
-
-    const std::map<char, int> Base36::BASE36_CHAR_MAP = Base36::init_char_map();
 
 } // namespace optionx
 

--- a/include/optionx_cpp/utils/enum_utils.hpp
+++ b/include/optionx_cpp/utils/enum_utils.hpp
@@ -8,11 +8,28 @@
 #include <string>
 #include <map>
 #include <stdexcept>
+#include <vector>
 
 namespace optionx {
 
     template <typename EnumType>
     EnumType to_enum(const std::string& str);
+
+    namespace utils {
+
+        /// \brief Returns an enum string by index or a stable UNKNOWN fallback.
+        /// \param values Dense string table whose first entry is UNKNOWN.
+        /// \param index Enum value converted to an index.
+        /// \return Matching string, or UNKNOWN when the enum value is out of range.
+        inline const std::string& enum_string_or_unknown(
+                const std::vector<std::string>& values,
+                std::size_t index) noexcept {
+            static const std::string unknown = "UNKNOWN";
+            if (values.empty()) return unknown;
+            return index < values.size() ? values[index] : values.front();
+        }
+
+    } // namespace utils
 
 } // namespace optionx
 

--- a/include/optionx_cpp/utils/fixed_point.hpp
+++ b/include/optionx_cpp/utils/fixed_point.hpp
@@ -19,7 +19,7 @@ namespace optionx::utils {
     /// \param digits Number of decimal places to preserve (0-18)
     /// \return Normalized value with specified precision
     /// \throw std::invalid_argument If digits exceed maximum supported precision
-    const double normalize_double(double value, size_t digits) {
+    inline const double normalize_double(double value, size_t digits) {
         if (digits > 18) {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }
@@ -52,7 +52,7 @@ namespace optionx::utils {
     /// \param digits Number of significant decimal places (0-18)
     /// \return Tolerance value for floating-point comparisons
     /// \throw std::invalid_argument If digits exceed maximum supported precision
-    double precision_tolerance(size_t digits) {
+    inline double precision_tolerance(size_t digits) {
         if (digits > 18) {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }

--- a/include/optionx_cpp/utils/http_utils.hpp
+++ b/include/optionx_cpp/utils/http_utils.hpp
@@ -33,7 +33,7 @@ namespace optionx::utils {
     /// \brief Removes the first occurrence of "https://" or "http://" from the given URL.
     /// \param url The URL from which to remove the substring.
     /// \return std::string The modified URL with the first occurrence of "https://" or "http://" removed.
-    std::string remove_http_prefix(const std::string& url) {
+    inline std::string remove_http_prefix(const std::string& url) {
         const std::string https_prefix = "https://";
         const std::string http_prefix = "http://";
 
@@ -61,7 +61,7 @@ namespace optionx::utils {
     /// \param response The HTTP response object.
     /// \param fallback Fallback text used when the response has no detailed error.
     /// \return Detailed error text suitable for callbacks and logs.
-    std::string describe_response_error(
+    inline std::string describe_response_error(
             const kurlyk::HttpResponsePtr& response,
             const std::string& fallback = "HTTP request failed.") {
         if (!response) {
@@ -90,7 +90,7 @@ namespace optionx::utils {
     /// \param response The HTTP response object.
     /// \param log_message A message to log in case of an unexpected status code.
     /// \return True if the response status code is 200; otherwise, false.
-    bool validate_status(
+    inline bool validate_status(
             const kurlyk::HttpResponsePtr& response,
             const std::string& log_message) {
         if (!response || response->status_code != 200) {
@@ -119,7 +119,7 @@ namespace optionx::utils {
     /// \details Logs an error if the response is null or the status code is not 200.
     /// \param response The HTTP response object.
     /// \return True if the response status code is 200; otherwise, false.
-    bool validate_status(const kurlyk::HttpResponsePtr& response) {
+    inline bool validate_status(const kurlyk::HttpResponsePtr& response) {
         return validate_status(response, "HTTP request failed.");
     }
     
@@ -127,7 +127,7 @@ namespace optionx::utils {
     /// \details Logs an error if "DDoS-GUARD" is detected in the response content.
     /// \param response The HTTP response object.
     /// \return True if no DDoS protection is detected; otherwise, false.
-    bool validate_ddos_protection(const kurlyk::HttpResponsePtr& response) {
+    inline bool validate_ddos_protection(const kurlyk::HttpResponsePtr& response) {
         const std::string ddos_marker = "DDoS-GUARD";
         if (response && response->content.find(ddos_marker) != std::string::npos) {
 #           ifdef OPTIONX_LOG_UNIQUE_FILE_INDEX
@@ -151,7 +151,7 @@ namespace optionx::utils {
     /// \param callback The callback to invoke if validation fails. It receives an error message as a parameter.
     /// \return True if the response is valid; otherwise, false. If false, the callback is invoked.
     template <typename Callback>
-    bool validate_response(
+    inline bool validate_response(
             const kurlyk::HttpResponsePtr& response,
             Callback callback) {
         if (!response) {
@@ -173,7 +173,7 @@ namespace optionx::utils {
     /// \brief Validates the HTTP response for status and DDoS protection.
     /// \param response The HTTP response to validate.
     /// \return True if the response is valid; otherwise, false. If false, the callback is invoked.
-    bool validate_response(
+    inline bool validate_response(
         const kurlyk::HttpResponsePtr& response) {
         if (!response) {
             LOGIT_ERROR("No response received from the server.");

--- a/include/optionx_cpp/utils/path_utils.hpp
+++ b/include/optionx_cpp/utils/path_utils.hpp
@@ -27,7 +27,7 @@ namespace optionx::utils {
     ///          - Linux/Unix: readlink("/proc/self/exe") 
     /// \return UTF-8 encoded path to executable directory
     /// \throw std::runtime_error If path resolution fails
-    std::string get_exec_dir() {
+    inline std::string get_exec_dir() {
 #       ifdef _WIN32
         std::vector<wchar_t> buffer(MAX_PATH);
         HMODULE hModule = GetModuleHandle(NULL);
@@ -69,7 +69,7 @@ namespace optionx::utils {
     /// \param file_path Full path to process (UTF-8 encoded)
     /// \return Filename component including extension. Returns input string if
     ///         no directory separators found.
-    std::string get_file_name(const std::string& file_path) {
+    inline std::string get_file_name(const std::string& file_path) {
         std::size_t pos = file_path.find_last_of("/\\");
         return (pos == std::string::npos) ? file_path : file_path.substr(pos + 1);
     }
@@ -93,7 +93,7 @@ namespace optionx::utils {
     /// \param relative_path Path component to append to executable directory
     /// \return Absolute path constructed as: exec_dir/relative_path
     /// \see get_exec_dir()
-    std::string resolve_exec_path(const std::string& relative_path) {
+    inline std::string resolve_exec_path(const std::string& relative_path) {
         return std::filesystem::absolute(get_exec_dir() + "/" + relative_path).string();
     }
 
@@ -101,7 +101,7 @@ namespace optionx::utils {
     /// \param path Directory path to create (UTF-8 encoded)
     /// \throw std::runtime_error If directory creation fails
     /// \note No-op if directory already exists
-    void create_directories(const std::string& path) {
+    inline void create_directories(const std::string& path) {
         std::filesystem::path dir(path);
         if (!std::filesystem::exists(dir)) {
             std::error_code ec;

--- a/include/optionx_cpp/utils/string_utils.hpp
+++ b/include/optionx_cpp/utils/string_utils.hpp
@@ -20,7 +20,7 @@ namespace optionx::utils {
     /// \brief Converts a hexadecimal string to a byte array.
     /// \param source Hexadecimal string.
     /// \return Byte array represented by the hex string.
-    std::vector<uint8_t> str_hex_to_vector(const std::string &source) noexcept {
+    inline std::vector<uint8_t> str_hex_to_vector(const std::string &source) noexcept {
         if (source.find_first_not_of("0123456789ABCDEFabcdef") != std::string::npos) {
             return {};
         }
@@ -68,7 +68,7 @@ namespace optionx::utils {
     /// \brief Converts a byte vector to a hexadecimal string.
     /// \param source Byte vector.
     /// \return Hexadecimal string.
-    std::string vector_to_str_hex(const std::vector<uint8_t> &source) noexcept {
+    inline std::string vector_to_str_hex(const std::vector<uint8_t> &source) noexcept {
         std::string temp;
         for (const auto& byte : source) {
             temp += n2hexstr(byte);
@@ -88,7 +88,7 @@ namespace optionx::utils {
     /// \brief Converts a string to uppercase.
     /// \param str Input string.
     /// \return Uppercase version of the string.
-    std::string to_upper_case(std::string str) {
+    inline std::string to_upper_case(std::string str) {
         std::transform(str.begin(), str.end(), str.begin(), [](unsigned char ch) {
             return std::toupper(ch);
         });
@@ -98,7 +98,7 @@ namespace optionx::utils {
     /// \brief Converts a string to lowercase.
     /// \param str Input string.
     /// \return Lowercase version of the string.
-    std::string to_lower_case(std::string str) {
+    inline std::string to_lower_case(std::string str) {
         std::transform(str.begin(), str.end(), str.begin(), [](unsigned char ch) {
             return std::tolower(ch);
         });
@@ -109,7 +109,7 @@ namespace optionx::utils {
     /// \param inout String to be modified.
     /// \param what Substring to find.
     /// \param with Substring to replace with.
-    void replace_all(std::string& inout, const std::string &what, const std::string &with) {
+    inline void replace_all(std::string& inout, const std::string &what, const std::string &with) {
         for (std::string::size_type pos{};
              (pos = inout.find(what, pos)) != std::string::npos;
              pos += with.length()) {
@@ -122,7 +122,7 @@ namespace optionx::utils {
     /// \param delimiter Starting delimiter.
     /// \param out Output substring.
     /// \return Position of the delimiter in the source string.
-    std::size_t extract_after(const std::string &source, const std::string &delimiter, std::string &out) {
+    inline std::size_t extract_after(const std::string &source, const std::string &delimiter, std::string &out) {
         std::size_t beg_pos = source.find(delimiter);
         if (beg_pos != std::string::npos) {
             out = source.substr(beg_pos + delimiter.size());
@@ -138,7 +138,7 @@ namespace optionx::utils {
     /// \param out Output substring.
     /// \param start_pos Starting position for search.
     /// \return Position of the ending delimiter in the source string.
-    std::size_t extract_between(
+    inline std::size_t extract_between(
         const std::string &source,
         const std::string &start_delimiter,
         const std::string &end_delimiter,
@@ -159,7 +159,7 @@ namespace optionx::utils {
     /// \brief Parses a comma-separated list into a vector of strings.
     /// \param value Comma-separated string.
     /// \param items Vector to store parsed items.
-    void parse_list(std::string value, std::vector<std::string> &items) noexcept {
+    inline void parse_list(std::string value, std::vector<std::string> &items) noexcept {
         if (value.back() != ',') value += ",";
         std::size_t start_pos = 0;
         while (true) {
@@ -175,7 +175,7 @@ namespace optionx::utils {
     /// \brief Formats a string using a printf-style format.
     /// \param fmt Format string.
     /// \return Formatted string.
-    std::string format(const char *fmt, ...) {
+    inline std::string format(const char *fmt, ...) {
         va_list args;
         va_start(args, fmt);
         std::vector<char> buffer(1024);

--- a/tests/header_only_odr_companion.cc
+++ b/tests/header_only_odr_companion.cc
@@ -1,0 +1,11 @@
+#include <optionx_cpp/platforms.hpp>
+
+int optionx_header_odr_companion() {
+    const auto platform = optionx::to_str(optionx::PlatformType::INTRADE_BAR);
+    const auto host = optionx::utils::remove_http_prefix("https://intrade.bar");
+    const auto encoded = optionx::utils::Base36::encode_string("Az");
+
+    return platform == "INTRADE_BAR" &&
+           host == "intrade.bar" &&
+           optionx::utils::Base36::decode_string(encoded) == "Az";
+}

--- a/tests/header_only_odr_test.cpp
+++ b/tests/header_only_odr_test.cpp
@@ -33,6 +33,18 @@ TEST(HeaderOnlyOdrTest, Base36StringEncodingRoundTripsSingleDigitBytes) {
     EXPECT_EQ(optionx::utils::Base36::decode_string(encoded), input);
 }
 
+TEST(HeaderOnlyOdrTest, Base36StringDecodingRejectsInvalidChunks) {
+    EXPECT_THROW(
+        optionx::utils::Base36::decode_string("0"),
+        std::invalid_argument);
+    EXPECT_THROW(
+        optionx::utils::Base36::decode_string("??"),
+        std::invalid_argument);
+    EXPECT_THROW(
+        optionx::utils::Base36::decode_string("zz"),
+        std::invalid_argument);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/header_only_odr_test.cpp
+++ b/tests/header_only_odr_test.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/platforms.hpp>
+
+int optionx_header_odr_companion();
+
+TEST(HeaderOnlyOdrTest, LinksMultipleTranslationUnitsIncludingPlatformUmbrella) {
+    EXPECT_EQ(optionx_header_odr_companion(), 1);
+}
+
+TEST(HeaderOnlyOdrTest, InvalidEnumValuesUseUnknownFallback) {
+    EXPECT_EQ(
+        optionx::to_str(static_cast<optionx::PlatformType>(999)),
+        std::string("UNKNOWN"));
+    EXPECT_EQ(
+        optionx::to_str(static_cast<optionx::TradeState>(999)),
+        std::string("UNKNOWN"));
+    EXPECT_EQ(
+        optionx::to_str(static_cast<optionx::AccountUpdateStatus>(999)),
+        std::string("UNKNOWN"));
+}
+
+TEST(HeaderOnlyOdrTest, Base36StringEncodingRoundTripsSingleDigitBytes) {
+    std::string input;
+    input.push_back(static_cast<char>(0));
+    input.push_back(static_cast<char>(1));
+    input.push_back(static_cast<char>(35));
+    input.push_back(static_cast<char>(36));
+    input.push_back(static_cast<char>(255));
+    const std::string encoded = optionx::utils::Base36::encode_string(input);
+
+    EXPECT_EQ(encoded.size(), input.size() * 2);
+    EXPECT_EQ(optionx::utils::Base36::decode_string(encoded), input);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
﻿## What Changed
- Marked public header helper functions, parser functions, and out-of-class module method definitions as `inline` where they are defined in headers.
- Made enum string conversion safe for invalid enum values and inlined stream operators.
- Moved enum utility include context back to the nearest domain aggregate headers instead of leaf `data/*/enums.hpp` headers.
- Converted `Base36` static data to C++17 inline static members and fixed ambiguous byte string encoding by using fixed two-character base36 chunks.
- Added a two-translation-unit `header_only_odr_test` to catch duplicate-symbol regressions through the platform umbrella header and Base36 invalid-chunk coverage.

## Why
The library is header-only, so non-inline namespace-scope functions, explicit specializations, static data definitions, and out-of-class member definitions in public headers can produce duplicate symbols when included from multiple translation units. Some enum helpers also indexed string tables without range checks.

`Base36::encode_string()` now emits fixed two-character chunks per byte. This intentionally changes previously ambiguous encodings for byte values `0..35` (for example, `w` becomes `0w`) so `decode_string()` can parse byte strings unambiguously.

## Validation
- `cmake -S . -B build-codex -DBUILD_TESTS=ON -DBUILD_DEPS=ON`
- `cmake --build build-codex --parallel`
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe`
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe`
- `cmake --build build-codex --target utils_task_manager_test -- -j1`
- `./build-codex/utils_task_manager_test.exe`
- `git diff --check`

Note: external libmdbx/AES warnings are unrelated to this PR.
