### PR TITLE
[codex] Normalize trade record include paths

### DIFF
--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <string>
 
-#include "data/trading/enums.hpp"
+#include "enums.hpp"
 
 namespace optionx {
 

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
@@ -9,7 +9,7 @@
 #include <set>
 #include <vector>
 
-#include "data/trading/TradeStats.hpp"
+#include "data/trading.hpp"
 #include "TradeStatsCalculator.hpp"
 
 namespace optionx::storage {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -11,8 +11,7 @@
 
 #include <time_shield.hpp>
 
-#include "data/trading/TradeRecordQuery.hpp"
-#include "data/trading/TradeRecordFilter.hpp"
+#include "data/trading.hpp"
 #include "utils/trade_state_utils.hpp"
 
 namespace optionx::storage {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
@@ -11,8 +11,7 @@
 #include <algorithm>
 #include <limits>
 
-#include "data/trading/TradeRecord.hpp"
-#include "data/trading/TradeResult.hpp"
+#include "data/trading.hpp"
 #include "utils/trade_state_utils.hpp"
 
 namespace optionx::storage {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -15,9 +15,8 @@
 
 #include <time_shield.hpp>
 
-#include "data/trading/TradeStats.hpp"
-#include "data/trading/TradeRecordQuery.hpp"
-#include "storages/TradeRecordDB/TradeRecordFilterMatcher.hpp"
+#include "data/trading.hpp"
+#include "TradeRecordFilterMatcher.hpp"
 #include "utils/trade_state_utils.hpp"
 
 namespace optionx::storage {


### PR DESCRIPTION
﻿## What Changed
- Normalized a small set of internal include paths around trade-record storage/statistics.
- Same-domain trading include now uses the local header name.
- TradeRecordDB internals now include the trading domain via `data/trading.hpp` instead of rebuilding leaf trading dependencies.
- Neighboring TradeRecordDB helper include now uses the local path.

## Why
This addresses F-054 from the refactor audit: keep public aggregate headers as domain entry points and avoid unnecessary root-relative leaf includes inside neighboring implementation headers.

## Validation
- `cmake --build build-codex --target trade_record_db_test -- -j1`
- `.\build-codex\trade_record_db_test.exe`
- `cmake --build build-codex --target trade_result_query_test -- -j1`
- `.\build-codex\trade_result_query_test.exe`
- `cmake --build build-codex --target trade_record_stats_test -- -j1`
- `.\build-codex\trade_record_stats_test.exe`
- `git diff --check`

Note: build still prints the existing libmdbx MinGW `%zu` warning; unrelated to this include-only change.
