### PR TITLE
[codex] Harden lifecycle and event dispatch

### DIFF
--- a/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
+++ b/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
@@ -169,11 +169,23 @@ namespace optionx::platforms {
         /// \details Adds initialization and periodic update tasks.
         ///          If start_worker_thread is true (default), TaskManager launches its own worker thread.
         ///          Otherwise, the caller must periodically call process() manually.
+        ///          Repeated calls before shutdown are ignored to avoid duplicate module initialization
+        ///          and duplicate processing loops.
         /// \param start_worker_thread  Whether to use an internal background thread for updates.
         void run(bool start_worker_thread  = true) {
             if (m_stopping.load(std::memory_order_acquire) ||
                 m_stopped .load(std::memory_order_acquire)) {
                 LOGIT_WARN("run() after shutdown()");
+                return;
+            }
+
+            bool expected = false;
+            if (!m_running.compare_exchange_strong(
+                    expected,
+                    true,
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+                LOGIT_WARN("run() called while platform is already running.");
                 return;
             }
             
@@ -225,6 +237,7 @@ namespace optionx::platforms {
 
             m_event_bus.drain();
             m_stopped.store(true, std::memory_order_release);
+            m_running.store(false, std::memory_order_release);
         };
 
         /// \brief Returns a reference to the event bus.
@@ -247,6 +260,7 @@ namespace optionx::platforms {
         utils::TaskManager                   m_task_manager;
         modules::BaseAccountInfoHandler      m_account_info_handler;
         std::vector<modules::BaseModule*>    m_modules;
+        std::atomic<bool>                    m_running{false};
         std::atomic<bool>                    m_stopping{false};
         std::atomic<bool>                    m_stopped{false};
 

--- a/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
+++ b/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
@@ -173,43 +173,62 @@ namespace optionx::platforms {
         ///          and duplicate processing loops.
         /// \param start_worker_thread  Whether to use an internal background thread for updates.
         void run(bool start_worker_thread  = true) {
+            std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
+
             if (m_stopping.load(std::memory_order_acquire) ||
                 m_stopped .load(std::memory_order_acquire)) {
                 LOGIT_WARN("run() after shutdown()");
                 return;
             }
 
-            bool expected = false;
-            if (!m_running.compare_exchange_strong(
-                    expected,
-                    true,
-                    std::memory_order_acq_rel,
-                    std::memory_order_acquire)) {
+            if (m_running.load(std::memory_order_acquire)) {
                 LOGIT_WARN("run() called while platform is already running.");
                 return;
             }
-            
-            m_task_manager.add_single_task("initialize", [this](
-                    std::shared_ptr<utils::Task> task){
-                if (task->is_shutdown()) return;
-                LOGIT_TRACE0();
-                for (auto* module : m_modules) module->initialize();
-                on_once();
-            });
-            
-            m_task_manager.add_periodic_task("loop", 1, [this](
-                    std::shared_ptr<utils::Task> task){
-                m_event_bus.process();
-                if (task->is_shutdown()) {
+
+            bool initialize_scheduled = false;
+            bool loop_scheduled = false;
+
+            try {
+                initialize_scheduled = m_task_manager.add_single_task("initialize", [this](
+                        std::shared_ptr<utils::Task> task){
+                    if (task->is_shutdown()) return;
                     LOGIT_TRACE0();
+                    for (auto* module : m_modules) module->initialize();
+                    on_once();
+                });
+
+                loop_scheduled = m_task_manager.add_periodic_task("loop", 1, [this](
+                        std::shared_ptr<utils::Task> task){
+                    m_event_bus.process();
+                    if (task->is_shutdown()) {
+                        LOGIT_TRACE0();
+                        return;
+                    }
+                    for (auto* module : m_modules) module->process();
+                    on_loop();
+                });
+
+                if (!initialize_scheduled || !loop_scheduled) {
+                    LOGIT_WARN("run() failed to schedule lifecycle tasks.");
+                    if (initialize_scheduled || loop_scheduled) {
+                        m_task_manager.shutdown();
+                    }
+                    m_running.store(false, std::memory_order_release);
                     return;
                 }
-                for (auto* module : m_modules) module->process();
-                on_loop();
-            });
             
-            if (start_worker_thread) {
-                m_task_manager.run();
+                if (start_worker_thread) {
+                    m_task_manager.run();
+                }
+
+                m_running.store(true, std::memory_order_release);
+            } catch (...) {
+                if (initialize_scheduled || loop_scheduled) {
+                    m_task_manager.shutdown();
+                }
+                m_running.store(false, std::memory_order_release);
+                throw;
             }
         };
         
@@ -222,9 +241,13 @@ namespace optionx::platforms {
         /// \brief Shuts down the platform, stopping the event loop and tasks.
         /// \details Always calls shutdown() on TaskManager, regardless of internal thread usage.
         void shutdown() noexcept {
-            if (m_stopped.load(std::memory_order_acquire)) return;
-            
-            if (m_stopping.exchange(true, std::memory_order_acq_rel)) return;
+            {
+                std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
+
+                if (m_stopped.load(std::memory_order_acquire)) return;
+
+                if (m_stopping.exchange(true, std::memory_order_acq_rel)) return;
+            }
             
             m_task_manager.shutdown();
             
@@ -236,8 +259,10 @@ namespace optionx::platforms {
             on_shutdown();
 
             m_event_bus.drain();
-            m_stopped.store(true, std::memory_order_release);
+
+            std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
             m_running.store(false, std::memory_order_release);
+            m_stopped.store(true, std::memory_order_release);
         };
 
         /// \brief Returns a reference to the event bus.
@@ -260,6 +285,7 @@ namespace optionx::platforms {
         utils::TaskManager                   m_task_manager;
         modules::BaseAccountInfoHandler      m_account_info_handler;
         std::vector<modules::BaseModule*>    m_modules;
+        std::mutex                           m_lifecycle_mutex;
         std::atomic<bool>                    m_running{false};
         std::atomic<bool>                    m_stopping{false};
         std::atomic<bool>                    m_stopped{false};

--- a/include/optionx_cpp/utils/pubsub/EventAwaiter.hpp
+++ b/include/optionx_cpp/utils/pubsub/EventAwaiter.hpp
@@ -54,9 +54,8 @@ namespace optionx::utils {
                 predicate_t predicate,
                 callback_t on_match,
                 bool single_shot = true) {
-            auto self = std::make_shared<EventAwaiter>(
-                bus, std::move(predicate), std::move(on_match), single_shot
-            );
+            auto self = std::shared_ptr<EventAwaiter>(new EventAwaiter(
+                bus, std::move(predicate), std::move(on_match), single_shot));
             self->subscribe_internal();
             return self;
         }

--- a/include/optionx_cpp/utils/pubsub/EventBus.hpp
+++ b/include/optionx_cpp/utils/pubsub/EventBus.hpp
@@ -13,11 +13,18 @@
 #include <functional>
 #include <typeindex>
 #include <algorithm>
+#include <logit_cpp/logit.hpp>
 
 namespace optionx::utils {
 
     /// \class EventBus
     /// \brief Manages subscriptions and notifications for event-based communication.
+    ///
+    /// \details Event dispatch copies current subscribers under an internal lock
+    /// and invokes user callbacks after releasing it. Listener objects must stay
+    /// alive while they are subscribed; platform/modules code normally enforces
+    /// this by owning subscription and destruction on the same event-loop
+    /// lifecycle. Null events are ignored defensively.
     class EventBus {
     public:
         using callback_t = std::function<void(const Event* const)>;
@@ -63,6 +70,7 @@ namespace optionx::utils {
 
         /// \brief Notifies all subscribers of an event by raw pointer.
         /// \param event Raw pointer to the event to notify subscribers of.
+        ///              If null, the call is ignored.
         void notify(const Event* const event) const;
 
         /// \brief Notifies subscribers of an event by reference.
@@ -71,6 +79,7 @@ namespace optionx::utils {
 
         /// \brief Queues an event for asynchronous processing.
         /// \param event Unique pointer to the event.
+        ///              If null, the call is ignored.
         void notify_async(std::unique_ptr<Event> event);
 
         /// \brief Processes queued events.

--- a/include/optionx_cpp/utils/pubsub/EventBus.ipp
+++ b/include/optionx_cpp/utils/pubsub/EventBus.ipp
@@ -78,6 +78,11 @@ namespace optionx::utils {
     }
 
     inline void EventBus::notify(const Event* const event) const {
+        if (!event) {
+            LOGIT_WARN("EventBus::notify ignored null event.");
+            return;
+        }
+
         auto type = std::type_index(typeid(*event));
         
         callback_list_t callbacks_copy;
@@ -100,6 +105,7 @@ namespace optionx::utils {
         }
 
         for (auto* listener : listeners_copy) {
+            if (!listener) continue;
             listener->on_event(event);
         }
     }
@@ -109,6 +115,11 @@ namespace optionx::utils {
     }
 
     inline void EventBus::notify_async(std::unique_ptr<Event> event) {
+        if (!event) {
+            LOGIT_WARN("EventBus::notify_async ignored null event.");
+            return;
+        }
+
         std::lock_guard<std::mutex> lock(m_queue_mutex);
         m_event_queue.push(std::move(event));
     }

--- a/include/optionx_cpp/utils/pubsub/EventMediator.hpp
+++ b/include/optionx_cpp/utils/pubsub/EventMediator.hpp
@@ -15,6 +15,8 @@ namespace optionx::utils {
     public:
         /// \brief Constructs EventMediator with a raw pointer to an EventBus instance.
         /// \param bus Pointer to the EventBus instance.
+        /// \details A null bus is accepted for defensive construction; public
+        /// methods become no-ops until a valid bus-backed mediator is used.
         explicit EventMediator(EventBus* bus) : m_event_bus(bus) {}
 
         /// \brief Constructs EventMediator with a reference to an EventBus instance.
@@ -23,6 +25,7 @@ namespace optionx::utils {
 
         /// \brief Constructs EventMediator with a unique pointer to an EventBus instance.
         /// \param bus Unique pointer to the EventBus instance.
+        /// \details If the unique pointer is empty, public methods become no-ops.
         explicit EventMediator(std::unique_ptr<EventBus>& bus) : m_event_bus(bus.get()) {}
 
         ~EventMediator() noexcept override {
@@ -35,6 +38,7 @@ namespace optionx::utils {
         /// \param callback Callback function accepting a const reference to the event.
         template <typename EventType>
         void subscribe(std::function<void(const EventType&)> callback) {
+            if (!ensure_event_bus("subscribe")) return;
             m_event_bus->subscribe<EventType>(this, std::move(callback));
         }
 
@@ -43,6 +47,7 @@ namespace optionx::utils {
         /// \param callback Callback function accepting a const pointer to the base event.
         template <typename EventType>
         void subscribe(std::function<void(const Event* const)> callback) {
+            if (!ensure_event_bus("subscribe")) return;
             m_event_bus->subscribe<EventType>(this, std::move(callback));
         }
 
@@ -50,6 +55,7 @@ namespace optionx::utils {
         /// \tparam EventType Type of the event to subscribe to.
         template <typename EventType>
         void subscribe() {
+            if (!ensure_event_bus("subscribe")) return;
             m_event_bus->subscribe<EventType>(this);
         }
         
@@ -57,41 +63,48 @@ namespace optionx::utils {
         /// \tparam EventType Type of the event to unsubscribe from.
         template <typename EventType>
         void unsubscribe() {
+            if (!ensure_event_bus("unsubscribe")) return;
             m_event_bus->unsubscribe<EventType>(this);
         }
         
         /// \brief Unsubscribes this mediator from all event types.
         void unsubscribe_all() {
+            if (!ensure_event_bus("unsubscribe_all")) return;
             m_event_bus->unsubscribe_all(this);
         }
 
         /// \brief Notifies all subscribers of an event (shared pointer dereferenced).
         /// \param event Shared pointer to the event.
         void notify(const std::shared_ptr<Event>& event) const {
+            if (!ensure_event_bus("notify")) return;
             m_event_bus->notify(event.get());
         }
         
         /// \brief Notifies all subscribers of an event (unique pointer dereferenced).
         /// \param event Unique pointer to the event.
         void notify(const std::unique_ptr<Event>& event) const {
+            if (!ensure_event_bus("notify")) return;
             m_event_bus->notify(event.get());
         }
 
         /// \brief Notifies all subscribers of an event (raw pointer).
         /// \param event Raw pointer to the event.
         void notify(const Event* const event) const {
+            if (!ensure_event_bus("notify")) return;
             m_event_bus->notify(event);
         }
 
         /// \brief Notifies all subscribers of an event (reference).
         /// \param event Reference to the event.
         void notify(const Event& event) const {
+            if (!ensure_event_bus("notify")) return;
             m_event_bus->notify(event);
         }
 
         /// \brief Queues an event for asynchronous processing.
         /// \param event Unique pointer to the event.
         void notify_async(std::unique_ptr<Event> event) {
+            if (!ensure_event_bus("notify_async")) return;
             m_event_bus->notify_async(std::move(event));
         }
 
@@ -103,6 +116,7 @@ namespace optionx::utils {
         /// \param cb   Callback executed once when predicate returns true.
         template <typename EventType, typename Pred, typename Cb>
         void await_once(Pred&& pred, Cb&& cb) {
+            if (!ensure_event_bus("await_once")) return;
             prune_dead_awaiters();
 
             using AW = EventAwaiter<EventType>;
@@ -134,6 +148,12 @@ namespace optionx::utils {
         EventBus* m_event_bus; ///< Associated EventBus instance.
         std::mutex m_mutex;
         std::vector<std::weak_ptr<IAwaiter>> m_awaiters; ///< Weak list of active awaiters.
+
+        bool ensure_event_bus(const char* operation) const noexcept {
+            (void)operation;
+            if (m_event_bus) return true;
+            return false;
+        }
     
          void prune_dead_awaiters() {
             std::lock_guard<std::mutex> lk(m_mutex);

--- a/include/optionx_cpp/utils/pubsub/EventMediator.hpp
+++ b/include/optionx_cpp/utils/pubsub/EventMediator.hpp
@@ -16,7 +16,7 @@ namespace optionx::utils {
         /// \brief Constructs EventMediator with a raw pointer to an EventBus instance.
         /// \param bus Pointer to the EventBus instance.
         /// \details A null bus is accepted for defensive construction; public
-        /// methods become no-ops until a valid bus-backed mediator is used.
+        /// methods remain no-ops for the mediator lifetime.
         explicit EventMediator(EventBus* bus) : m_event_bus(bus) {}
 
         /// \brief Constructs EventMediator with a reference to an EventBus instance.
@@ -25,7 +25,8 @@ namespace optionx::utils {
 
         /// \brief Constructs EventMediator with a unique pointer to an EventBus instance.
         /// \param bus Unique pointer to the EventBus instance.
-        /// \details If the unique pointer is empty, public methods become no-ops.
+        /// \details If the unique pointer is empty, public methods remain no-ops
+        /// for the mediator lifetime.
         explicit EventMediator(std::unique_ptr<EventBus>& bus) : m_event_bus(bus.get()) {}
 
         ~EventMediator() noexcept override {
@@ -38,7 +39,7 @@ namespace optionx::utils {
         /// \param callback Callback function accepting a const reference to the event.
         template <typename EventType>
         void subscribe(std::function<void(const EventType&)> callback) {
-            if (!ensure_event_bus("subscribe")) return;
+            if (!has_event_bus()) return;
             m_event_bus->subscribe<EventType>(this, std::move(callback));
         }
 
@@ -47,7 +48,7 @@ namespace optionx::utils {
         /// \param callback Callback function accepting a const pointer to the base event.
         template <typename EventType>
         void subscribe(std::function<void(const Event* const)> callback) {
-            if (!ensure_event_bus("subscribe")) return;
+            if (!has_event_bus()) return;
             m_event_bus->subscribe<EventType>(this, std::move(callback));
         }
 
@@ -55,7 +56,7 @@ namespace optionx::utils {
         /// \tparam EventType Type of the event to subscribe to.
         template <typename EventType>
         void subscribe() {
-            if (!ensure_event_bus("subscribe")) return;
+            if (!has_event_bus()) return;
             m_event_bus->subscribe<EventType>(this);
         }
         
@@ -63,48 +64,48 @@ namespace optionx::utils {
         /// \tparam EventType Type of the event to unsubscribe from.
         template <typename EventType>
         void unsubscribe() {
-            if (!ensure_event_bus("unsubscribe")) return;
+            if (!has_event_bus()) return;
             m_event_bus->unsubscribe<EventType>(this);
         }
         
         /// \brief Unsubscribes this mediator from all event types.
         void unsubscribe_all() {
-            if (!ensure_event_bus("unsubscribe_all")) return;
+            if (!has_event_bus()) return;
             m_event_bus->unsubscribe_all(this);
         }
 
         /// \brief Notifies all subscribers of an event (shared pointer dereferenced).
         /// \param event Shared pointer to the event.
         void notify(const std::shared_ptr<Event>& event) const {
-            if (!ensure_event_bus("notify")) return;
+            if (!has_event_bus()) return;
             m_event_bus->notify(event.get());
         }
         
         /// \brief Notifies all subscribers of an event (unique pointer dereferenced).
         /// \param event Unique pointer to the event.
         void notify(const std::unique_ptr<Event>& event) const {
-            if (!ensure_event_bus("notify")) return;
+            if (!has_event_bus()) return;
             m_event_bus->notify(event.get());
         }
 
         /// \brief Notifies all subscribers of an event (raw pointer).
         /// \param event Raw pointer to the event.
         void notify(const Event* const event) const {
-            if (!ensure_event_bus("notify")) return;
+            if (!has_event_bus()) return;
             m_event_bus->notify(event);
         }
 
         /// \brief Notifies all subscribers of an event (reference).
         /// \param event Reference to the event.
         void notify(const Event& event) const {
-            if (!ensure_event_bus("notify")) return;
+            if (!has_event_bus()) return;
             m_event_bus->notify(event);
         }
 
         /// \brief Queues an event for asynchronous processing.
         /// \param event Unique pointer to the event.
         void notify_async(std::unique_ptr<Event> event) {
-            if (!ensure_event_bus("notify_async")) return;
+            if (!has_event_bus()) return;
             m_event_bus->notify_async(std::move(event));
         }
 
@@ -116,7 +117,7 @@ namespace optionx::utils {
         /// \param cb   Callback executed once when predicate returns true.
         template <typename EventType, typename Pred, typename Cb>
         void await_once(Pred&& pred, Cb&& cb) {
-            if (!ensure_event_bus("await_once")) return;
+            if (!has_event_bus()) return;
             prune_dead_awaiters();
 
             using AW = EventAwaiter<EventType>;
@@ -149,10 +150,8 @@ namespace optionx::utils {
         std::mutex m_mutex;
         std::vector<std::weak_ptr<IAwaiter>> m_awaiters; ///< Weak list of active awaiters.
 
-        bool ensure_event_bus(const char* operation) const noexcept {
-            (void)operation;
-            if (m_event_bus) return true;
-            return false;
+        bool has_event_bus() const noexcept {
+            return m_event_bus != nullptr;
         }
     
          void prune_dead_awaiters() {

--- a/tests/lifecycle_event_safety_test.cpp
+++ b/tests/lifecycle_event_safety_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -74,6 +75,76 @@ TEST(BaseTradingPlatformLifecycle, RepeatedRunDoesNotDuplicateLifecycleTasks) {
     EXPECT_EQ(platform.loop_count(), 1);
 
     platform.shutdown();
+}
+
+TEST(BaseTradingPlatformLifecycle, ConcurrentRunDoesNotDuplicateLifecycleTasks) {
+    for (int attempt = 0; attempt < 64; ++attempt) {
+        TestPlatform platform;
+        std::atomic<bool> start{false};
+
+        auto run_platform = [&]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            platform.run(false);
+        };
+
+        std::thread first(run_platform);
+        std::thread second(run_platform);
+
+        start.store(true, std::memory_order_release);
+        first.join();
+        second.join();
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        platform.process();
+
+        EXPECT_EQ(platform.initialize_count(), 1);
+        EXPECT_EQ(platform.loop_count(), 1);
+
+        platform.shutdown();
+    }
+}
+
+TEST(BaseTradingPlatformLifecycle, ShutdownBeforeProcessSkipsLifecycleCallbacks) {
+    TestPlatform platform;
+
+    platform.run(false);
+    platform.shutdown();
+    platform.process();
+
+    EXPECT_EQ(platform.initialize_count(), 0);
+    EXPECT_EQ(platform.loop_count(), 0);
+}
+
+TEST(BaseTradingPlatformLifecycle, ConcurrentRunAndShutdownDoNotRunAfterStop) {
+    for (int attempt = 0; attempt < 64; ++attempt) {
+        TestPlatform platform;
+        std::atomic<bool> start{false};
+
+        std::thread run_thread([&]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            platform.run(false);
+        });
+
+        std::thread shutdown_thread([&]() {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            platform.shutdown();
+        });
+
+        start.store(true, std::memory_order_release);
+        run_thread.join();
+        shutdown_thread.join();
+
+        platform.process();
+
+        EXPECT_EQ(platform.initialize_count(), 0);
+        EXPECT_EQ(platform.loop_count(), 0);
+    }
 }
 
 TEST(EventBusSafety, NullEventsAreIgnored) {

--- a/tests/lifecycle_event_safety_test.cpp
+++ b/tests/lifecycle_event_safety_test.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <typeindex>
+
+#include <optionx_cpp/platforms.hpp>
+
+namespace {
+
+class TestEvent final : public optionx::utils::Event {
+public:
+    std::type_index type() const override {
+        return typeid(TestEvent);
+    }
+
+    const char* name() const override {
+        return "TestEvent";
+    }
+};
+
+class TestMediator final : public optionx::utils::EventMediator {
+public:
+    using optionx::utils::EventMediator::EventMediator;
+
+    void on_event(const optionx::utils::Event* const) override {}
+};
+
+class TestPlatform final : public optionx::platforms::BaseTradingPlatform {
+public:
+    TestPlatform()
+        : optionx::platforms::BaseTradingPlatform(
+              std::make_shared<
+                  optionx::platforms::intrade_bar::AccountInfoData>()) {}
+
+    optionx::PlatformType platform_type() const override {
+        return optionx::PlatformType::INTRADE_BAR;
+    }
+
+    int initialize_count() const noexcept {
+        return m_initialize_count;
+    }
+
+    int loop_count() const noexcept {
+        return m_loop_count;
+    }
+
+private:
+    void on_once() override {
+        ++m_initialize_count;
+    }
+
+    void on_loop() override {
+        ++m_loop_count;
+    }
+
+    int m_initialize_count = 0;
+    int m_loop_count = 0;
+};
+
+} // namespace
+
+TEST(BaseTradingPlatformLifecycle, RepeatedRunDoesNotDuplicateLifecycleTasks) {
+    TestPlatform platform;
+
+    platform.run(false);
+    platform.run(false);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    platform.process();
+
+    EXPECT_EQ(platform.initialize_count(), 1);
+    EXPECT_EQ(platform.loop_count(), 1);
+
+    platform.shutdown();
+}
+
+TEST(EventBusSafety, NullEventsAreIgnored) {
+    optionx::utils::EventBus bus;
+    TestMediator mediator(bus);
+    int callback_count = 0;
+
+    mediator.subscribe<TestEvent>(
+        [&callback_count](const TestEvent&) {
+            ++callback_count;
+        });
+
+    EXPECT_NO_THROW(bus.notify(static_cast<const optionx::utils::Event*>(nullptr)));
+    EXPECT_NO_THROW(bus.notify_async(nullptr));
+    EXPECT_NO_THROW(bus.process());
+
+    TestEvent event;
+    bus.notify(event);
+
+    EXPECT_EQ(callback_count, 1);
+}
+
+TEST(EventMediatorSafety, NullBusIsANoop) {
+    TestEvent event;
+
+    EXPECT_NO_THROW({
+        TestMediator mediator(static_cast<optionx::utils::EventBus*>(nullptr));
+        mediator.subscribe<TestEvent>(
+            [](const TestEvent&) {});
+        mediator.subscribe<TestEvent>();
+        mediator.unsubscribe<TestEvent>();
+        mediator.unsubscribe_all();
+        mediator.notify(static_cast<const optionx::utils::Event*>(nullptr));
+        mediator.notify(event);
+        mediator.notify_async(std::make_unique<TestEvent>());
+        mediator.await_once<TestEvent>(
+            [](const TestEvent&) {});
+    });
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
﻿## Summary
- make repeated `BaseTradingPlatform::run()` calls before shutdown a guarded no-op to avoid duplicate initialize/loop tasks
- synchronize `run()` and `shutdown()` lifecycle transitions with a mutex, and set `m_running` only after lifecycle tasks are scheduled successfully
- defensively ignore null events in `EventBus::notify()` and `notify_async()`
- make `EventMediator` constructed with a null bus safe to destroy and call as an inactive no-op
- fix `EventAwaiter::create()` so `EventMediator::await_once()` can instantiate despite the private awaiter constructor
- add focused lifecycle/pub-sub regression tests, including concurrent `run()` and `run()`/`shutdown()` scenarios

## Root Cause
`BaseTradingPlatform::run()` only checked shutdown state, so repeated calls could enqueue multiple lifecycle tasks. The first PR revision added a running guard, but did not synchronize `run()` against concurrent `shutdown()`. This follow-up serializes lifecycle state transitions so a run cannot enqueue tasks after shutdown has started.

The pub-sub layer also assumed non-null events and bus pointers, which turned bad construction or null dispatch into immediate undefined behavior/crashes.

## Validation
- `cmake -S . -B build-codex -DBUILD_TESTS=ON -DBUILD_DEPS=ON`
- `cmake --build build-codex --target lifecycle_event_safety_test -- -j1`
- `./build-codex/lifecycle_event_safety_test.exe --gtest_brief=1` (6/6 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --parallel`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` (36/36 passed)
- `git diff --check`

Notes:
- CMake still prints existing external libmdbx/AES warnings unrelated to this PR.
