### PR TITLE
[codex] Ignore stale Intrade async callbacks

### DIFF
--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -50,6 +50,24 @@ namespace optionx::platforms::intrade_bar {
         std::shared_ptr<BaseAccountInfoData> m_account_info; ///< Shared pointer to account information.
         std::unique_ptr<AuthData> m_temp_auth_data;        ///< Temporary authentication data storage.
         std::shared_ptr<AuthData> m_auth_data; ///< Currently active authentication data.
+        std::uint64_t m_auth_generation = 0; ///< Monotonic auth flow generation for stale callback filtering.
+
+        /// \brief Starts a new authentication generation and invalidates older callbacks.
+        /// \param reason Human-readable trigger for diagnostics.
+        /// \return Generation token to capture in async callbacks.
+        std::uint64_t begin_auth_generation(const char* reason);
+
+        /// \brief Invalidates active authentication callbacks.
+        /// \param reason Human-readable trigger for diagnostics.
+        void invalidate_auth_generation(const char* reason);
+
+        /// \brief Checks whether a callback still belongs to the active auth flow.
+        /// \param generation Generation token captured when the request was sent.
+        /// \param reason Human-readable callback context for diagnostics.
+        /// \return True if the callback may continue the auth flow.
+        bool is_auth_generation_current(
+            std::uint64_t generation,
+            const char* reason) const;
 
         /// \brief Stores authentication credentials after a successful login.
         /// \param user_id The user ID obtained after login.
@@ -66,79 +84,107 @@ namespace optionx::platforms::intrade_bar {
         /// \param callback Callback to be invoked with the result of the authentication process.
         /// \param auth_func Function to perform the actual authentication (email/password or token).
         void handle_auto_domain_and_auth(
+                std::uint64_t generation,
                 connection_callback_t callback,
-                std::function<void(connection_callback_t)> auth_func);
+                std::function<void(std::uint64_t, connection_callback_t)> auth_func);
 
         /// \brief Initiates email/password validation for authentication.
+        /// \param generation Auth flow generation token.
         /// \param connect_callback The callback function to notify the result.
-        void validate_email_pass(connection_callback_t connect_callback);
+        void validate_email_pass(
+            std::uint64_t generation,
+            connection_callback_t connect_callback);
 
         /// \brief Initiates user token validation for authentication.
+        /// \param generation Auth flow generation token.
         /// \param connect_callback The callback function to notify the result.
-        void validate_user_token(connection_callback_t connect_callback);
+        void validate_user_token(
+            std::uint64_t generation,
+            connection_callback_t connect_callback);
 
         /// \brief Completes the authentication process after login.
+        /// \param generation Auth flow generation token.
         /// \param connect_callback The callback function to notify the result.
-        void finalize_authentication(connection_callback_t connect_callback);
+        void finalize_authentication(
+            std::uint64_t generation,
+            connection_callback_t connect_callback);
 
         /// \brief Starts the authentication process.
+        /// \param generation Auth flow generation token.
         /// \param callback The callback function to notify the result.
-        void start_authentication(connection_callback_t callback);
+        void start_authentication(
+            std::uint64_t generation,
+            connection_callback_t callback);
 
         /// \brief Handles authentication failure.
+        /// \param generation Auth flow generation token.
         /// \param reason The reason for the failure.
         /// \param callback The callback function to notify the result.
         void handle_auth_failure(
+            std::uint64_t generation,
             const std::string& reason,
             connection_callback_t callback);
 
         /// \brief Executes the authentication process, handling necessary steps.
+        /// \param generation Auth flow generation token.
         /// \param callback The callback function to notify the result.
-        void execute_authentication_flow(connection_callback_t callback);
+        void execute_authentication_flow(
+            std::uint64_t generation,
+            connection_callback_t callback);
 
         /// \brief Handles an account type switch (e.g., Demo to Real).
+        /// \param generation Auth flow generation token.
         /// \param account_type The new account type.
         /// \param currency The currency type.
         /// \param callback The callback function to notify the result.
         void handle_account_type_switch(
+            std::uint64_t generation,
             AccountType account_type,
             CurrencyType currency,
             connection_callback_t callback);
 
         /// \brief Attempts an account type switch and retries while broker reports active trades.
+        /// \param generation Auth flow generation token.
         /// \param currency Current currency from the profile response.
         /// \param callback The callback function to notify the result.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Attempt number.
         void handle_account_type_switch_attempt(
+            std::uint64_t generation,
             CurrencyType currency,
             connection_callback_t callback,
             int64_t started_ms,
             int attempt);
 
         /// \brief Handles currency switch during authentication.
+        /// \param generation Auth flow generation token.
         /// \param currency The new currency type.
         /// \param callback The callback function to notify the result.
         void handle_currency_switch(
+            std::uint64_t generation,
             CurrencyType currency,
             connection_callback_t callback);
 
         /// \brief Attempts a currency switch and retries while broker reports active trades.
+        /// \param generation Auth flow generation token.
         /// \param callback The callback function to notify the result.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Attempt number.
         void handle_currency_switch_attempt(
+            std::uint64_t generation,
             connection_callback_t callback,
             int64_t started_ms,
             int attempt);
 
         /// \brief Schedules retry for a broker settings switch after inspecting active trades.
+        /// \param generation Auth flow generation token.
         /// \param operation_name Human-readable operation name.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Failed attempt number.
         /// \param callback The callback function to notify the result.
         /// \param retry Retry function.
         void schedule_settings_switch_retry(
+            std::uint64_t generation,
             std::string operation_name,
             int64_t started_ms,
             int attempt,
@@ -151,8 +197,10 @@ namespace optionx::platforms::intrade_bar {
         /// 2. Sends login credentials to obtain the user ID and hash.
         /// 3. Uses the obtained credentials to authenticate.
         /// If any step fails, the process stops and the callback is invoked with an error message.
+        /// \param generation Auth flow generation token.
         /// \param result_callback The callback function to be called upon success or failure.
         void perform_auth_flow(
+            std::uint64_t generation,
             std::function<void(
                 bool success,
                 const std::string& reason)> result_callback);
@@ -198,7 +246,43 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void AuthManager::shutdown() {
+        invalidate_auth_generation("shutdown");
         m_task_manager.shutdown();
+    }
+
+    inline std::uint64_t AuthManager::begin_auth_generation(const char* reason) {
+        const std::uint64_t generation = ++m_auth_generation;
+        LOGIT_DEBUG(
+            "Intrade Bar auth: generation started. reason=",
+            reason,
+            ", generation=",
+            generation);
+        return generation;
+    }
+
+    inline void AuthManager::invalidate_auth_generation(const char* reason) {
+        const std::uint64_t generation = ++m_auth_generation;
+        LOGIT_DEBUG(
+            "Intrade Bar auth: generation invalidated. reason=",
+            reason,
+            ", generation=",
+            generation);
+    }
+
+    inline bool AuthManager::is_auth_generation_current(
+            std::uint64_t generation,
+            const char* reason) const {
+        const bool current = generation == m_auth_generation;
+        if (!current) {
+            LOGIT_DEBUG(
+                "Intrade Bar auth: stale callback ignored. reason=",
+                reason,
+                ", callback_generation=",
+                generation,
+                ", current_generation=",
+                m_auth_generation);
+        }
+        return current;
     }
 
     inline void AuthManager::set_auth_credentials(
@@ -224,6 +308,7 @@ namespace optionx::platforms::intrade_bar {
 
     inline void AuthManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
+            invalidate_auth_generation("auth-data");
             LOGIT_TRACE0();
             auto [success, message] = auth_data->validate();
             if (success) {
@@ -238,9 +323,10 @@ namespace optionx::platforms::intrade_bar {
     inline void AuthManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_TRACE0();
         auto callback = event.callback;
+        const std::uint64_t generation = begin_auth_generation("connect-request");
         m_task_manager.add_single_task(
                 "event(ConnectRequestEvent)-single-1",
-                [this, callback](
+                [this, callback, generation](
                     std::shared_ptr<utils::Task> task) {
             LOGIT_TRACE0();
             m_request_manager.cancel_requests();
@@ -259,12 +345,15 @@ namespace optionx::platforms::intrade_bar {
                 }
                 return;
             }
+            if (!is_auth_generation_current(generation, "connect-request-stage-1")) {
+                return;
+            }
 
             // Обработаем подключение после получения результата всех HTTP запросов
             LOGIT_TRACE0();
             m_task_manager.add_single_task(
                     "event(ConnectRequestEvent)-single-2",
-                    [this, callback](
+                    [this, callback, generation](
                         std::shared_ptr<utils::Task> task) {
                 LOGIT_TRACE0();
                 using Status = events::AccountInfoUpdateEvent::Status;
@@ -279,6 +368,9 @@ namespace optionx::platforms::intrade_bar {
                             Status::DISCONNECTED,
                             "Shutdown."));
                     }
+                    return;
+                }
+                if (!is_auth_generation_current(generation, "connect-request-stage-2")) {
                     return;
                 }
 
@@ -301,7 +393,7 @@ namespace optionx::platforms::intrade_bar {
                 LOGIT_TRACE0();
                 if (!m_temp_auth_data) {
                     const std::string error_text("Authentication data is missing.");
-                    handle_auth_failure(error_text, std::move(callback));
+                    handle_auth_failure(generation, error_text, std::move(callback));
                     return;
                 }
 
@@ -325,20 +417,20 @@ namespace optionx::platforms::intrade_bar {
                             error_text));
                     } break;
                 case AuthMethod::EMAIL_PASSWORD:
-                    handle_auto_domain_and_auth(callback, [this](auto cb) {
+                    handle_auto_domain_and_auth(generation, callback, [this](auto gen, auto cb) {
                         // Process authentication via email and password
-                        validate_email_pass(std::move(cb));
+                        validate_email_pass(gen, std::move(cb));
                     });
                     break;
                 case AuthMethod::USER_TOKEN:
-                    handle_auto_domain_and_auth(callback, [this](auto cb) {
+                    handle_auto_domain_and_auth(generation, callback, [this](auto gen, auto cb) {
                         // Validate user authentication token
-                        validate_user_token(std::move(cb));
+                        validate_user_token(gen, std::move(cb));
                     });
                     break;
                 default: {
                         const std::string error_text("Unsupported authentication method.");
-                        handle_auth_failure(error_text, std::move(callback));
+                        handle_auth_failure(generation, error_text, std::move(callback));
                     } break;
                 };
             });
@@ -347,6 +439,7 @@ namespace optionx::platforms::intrade_bar {
 
     inline void AuthManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_TRACE0();
+        invalidate_auth_generation("disconnect-request");
         auto callback = event.callback;
         m_task_manager.add_single_task(
                 "event(DisconnectRequestEvent)-single-1",
@@ -394,7 +487,11 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void AuthManager::handle_event(const events::RestartAuthEvent& event) {
-        start_authentication([this](const ConnectionResult& result) {
+        const std::uint64_t generation = begin_auth_generation("restart-auth");
+        start_authentication(generation, [this, generation](const ConnectionResult& result) {
+            if (!is_auth_generation_current(generation, "restart-auth-profile")) {
+                return;
+            }
             if (!result.success) {
                 auto account_info = get_account_info();
                 if (account_info->connect) {
@@ -409,14 +506,16 @@ namespace optionx::platforms::intrade_bar {
             }
 
             finalize_authentication(
+                generation,
                 [this](const ConnectionResult& result) {
             });
         });
     }
     
     inline void AuthManager::handle_auto_domain_and_auth(
+            std::uint64_t generation,
             connection_callback_t callback,
-            std::function<void(connection_callback_t)> auth_func) {
+            std::function<void(std::uint64_t, connection_callback_t)> auth_func) {
 
         if (m_auth_data->auto_find_domain) {
             LOGIT_INFO(
@@ -425,7 +524,10 @@ namespace optionx::platforms::intrade_bar {
                 "-",
                 m_auth_data->domain_index_max);
             m_request_manager.request_find_working_domain(
-                [this, callback, auth_func](bool success, std::string& host) {
+                [this, callback, auth_func, generation](bool success, std::string& host) {
+                    if (!is_auth_generation_current(generation, "auto-domain")) {
+                        return;
+                    }
                     using Status = events::AccountInfoUpdateEvent::Status;
                     if (!success) {
                         const std::string error_text = "No working domain found.";
@@ -442,15 +544,20 @@ namespace optionx::platforms::intrade_bar {
                         host));
                     LOGIT_INFO("Intrade Bar auth: selected host=", host);
                             
-                    auth_func(std::move(callback));
+                    auth_func(generation, std::move(callback));
                 });
         } else {
             LOGIT_INFO("Intrade Bar auth: using configured host.");
-            auth_func(std::move(callback));
+            auth_func(generation, std::move(callback));
         }
     }
 
-    inline void AuthManager::validate_email_pass(connection_callback_t callback) {
+    inline void AuthManager::validate_email_pass(
+            std::uint64_t generation,
+            connection_callback_t callback) {
+        if (!is_auth_generation_current(generation, "validate-email-pass")) {
+            return;
+        }
         // Validate email and password
         if (m_auth_data->email.empty() ||
             m_auth_data->password.empty()) {
@@ -458,7 +565,7 @@ namespace optionx::platforms::intrade_bar {
             LOGIT_ERROR_IF(m_auth_data->password.empty(), "Validation failed: Password is missing.");
 
             const std::string error_text("Login failed: Please provide both email and password.");
-            handle_auth_failure(error_text, std::move(callback));
+            handle_auth_failure(generation, error_text, std::move(callback));
             return;
         }
 
@@ -470,7 +577,7 @@ namespace optionx::platforms::intrade_bar {
         if (!session) {
             LOGIT_INFO("Intrade Bar auth: saved session not found, starting fresh login flow.");
             LOGIT_TRACE("Session not found for configured Intrade Bar account.");
-            execute_authentication_flow(std::move(callback));
+            execute_authentication_flow(generation, std::move(callback));
             return;
         }
 
@@ -489,29 +596,38 @@ namespace optionx::platforms::intrade_bar {
 
             // Start authentication flow
             start_authentication(
-                    [this, callback](const ConnectionResult &result) {
+                    generation,
+                    [this, callback, generation](const ConnectionResult &result) {
+                if (!is_auth_generation_current(generation, "cached-session-profile")) {
+                    return;
+                }
                 if (!result.success) {
                     LOGIT_PRINT_ERROR("Authentication failed: ", result.reason);
-                    execute_authentication_flow(std::move(callback));
+                    execute_authentication_flow(generation, std::move(callback));
                     return;
                 }
 
-                finalize_authentication(std::move(callback));
+                finalize_authentication(generation, std::move(callback));
             });
         } else {
             LOGIT_PRINT_ERROR("Failed to parse cookies: ", utils::redact_secret_value(cookies));
-            execute_authentication_flow(std::move(callback));
+            execute_authentication_flow(generation, std::move(callback));
         }
     }
 
-    inline void AuthManager::validate_user_token(connection_callback_t callback) {
+    inline void AuthManager::validate_user_token(
+            std::uint64_t generation,
+            connection_callback_t callback) {
+        if (!is_auth_generation_current(generation, "validate-user-token")) {
+            return;
+        }
         // Validate user_id and token
         if (m_auth_data->user_id.empty() || m_auth_data->token.empty()) {
             LOGIT_ERROR_IF(m_auth_data->user_id.empty(), "Validation failed: User ID is missing.");
             LOGIT_ERROR_IF(m_auth_data->token.empty(), "Validation failed: Token is missing.");
 
             const std::string error_text("Validation failed: User ID or token is missing.");
-            handle_auth_failure(error_text, std::move(callback));
+            handle_auth_failure(generation, error_text, std::move(callback));
             return;
         }
 
@@ -520,20 +636,27 @@ namespace optionx::platforms::intrade_bar {
         // Set user ID, token, and cookies
         m_request_manager.set_auth_credentials(m_auth_data->user_id, m_auth_data->token);
         set_account_user_id(m_auth_data->user_id);
-        start_authentication([this, callback](const ConnectionResult& result) {
+        start_authentication(generation, [this, callback, generation](const ConnectionResult& result) {
+            if (!is_auth_generation_current(generation, "user-token-profile")) {
+                return;
+            }
             if (!result.success) {
                 const std::string error_text("Login failed: Please provide both User ID and token.");
-                handle_auth_failure(error_text, std::move(callback));
+                handle_auth_failure(generation, error_text, std::move(callback));
                 return;
             }
 
-            finalize_authentication(std::move(callback));
+            finalize_authentication(generation, std::move(callback));
         });
     }
 
     inline void AuthManager::handle_auth_failure(
+            std::uint64_t generation,
             const std::string& reason,
             connection_callback_t callback) {
+        if (!is_auth_generation_current(generation, "auth-failure")) {
+            return;
+        }
         using Status = events::AccountInfoUpdateEvent::Status;
         LOGIT_PRINTF_ERROR("Authentication failed: ", reason);
         callback({false, reason, m_auth_data ? m_auth_data->clone_unique() : nullptr});
@@ -544,27 +667,35 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void AuthManager::execute_authentication_flow(
+            std::uint64_t generation,
             connection_callback_t callback) {
-        perform_auth_flow([this, callback](
+        perform_auth_flow(generation, [this, callback, generation](
                 bool success,
                 const std::string& reason) {
+            if (!is_auth_generation_current(generation, "fresh-auth-flow")) {
+                return;
+            }
             if (!success) {
-                handle_auth_failure(reason, std::move(callback));
+                handle_auth_failure(generation, reason, std::move(callback));
                 return;
             }
 
-            start_authentication([this, callback](const ConnectionResult& result) {
+            start_authentication(generation, [this, callback, generation](const ConnectionResult& result) {
+                if (!is_auth_generation_current(generation, "fresh-auth-profile")) {
+                    return;
+                }
                 if (!result.success) {
-                    handle_auth_failure(result.reason, std::move(callback));
+                    handle_auth_failure(generation, result.reason, std::move(callback));
                     return;
                 }
 
-                finalize_authentication(std::move(callback));
+                finalize_authentication(generation, std::move(callback));
             });
         });
     }
 
     inline void AuthManager::perform_auth_flow(
+            std::uint64_t generation,
             std::function<void(
                 bool success,
                 const std::string& reason)> result_callback) {
@@ -572,12 +703,15 @@ namespace optionx::platforms::intrade_bar {
         LOGIT_TRACE0();
 
         // Step 3: Handle authentication response
-        auto handle_auth_response = [this, result_callback](
+        auto handle_auth_response = [this, result_callback, generation](
                     bool success,
                     const std::string& user_id,
                     const std::string& user_hash,
                     const std::string& cookies,
                     const std::string& reason) {
+            if (!is_auth_generation_current(generation, "auth-endpoint")) {
+                return;
+            }
             if (!success) {
                 LOGIT_WARN("Intrade Bar auth: auth endpoint rejected fresh credentials.");
                 result_callback(false, reason);
@@ -592,12 +726,15 @@ namespace optionx::platforms::intrade_bar {
         };
 
         // Step 2: Handle login response
-        auto handle_login_response = [this, handle_auth_response](
+        auto handle_login_response = [this, handle_auth_response, generation](
                 bool success,
                 const std::string& user_id,
                 const std::string& user_hash,
                 const std::string& cookies,
                 const std::string& reason) {
+            if (!is_auth_generation_current(generation, "login-endpoint")) {
+                return;
+            }
             if (!success) {
                 LOGIT_WARN("Intrade Bar auth: login step failed.");
                 handle_auth_response(false, std::string(), std::string(), std::string(), reason);
@@ -615,12 +752,15 @@ namespace optionx::platforms::intrade_bar {
         };
 
         // Step 1: Handle main page response
-        auto handle_main_page_response = [this, handle_login_response](
+        auto handle_main_page_response = [this, handle_login_response, generation](
                     bool success,
                     const std::string& req_id,
                     const std::string& req_value,
                     const std::string& cookies,
                     const std::string& reason) {
+            if (!is_auth_generation_current(generation, "main-page-challenge")) {
+                return;
+            }
             if (!success) {
                 LOGIT_WARN("Intrade Bar auth: main page challenge step failed.");
                 handle_login_response(false, std::string(), std::string(), std::string(), reason);
@@ -645,28 +785,37 @@ namespace optionx::platforms::intrade_bar {
         m_request_manager.request_main_page(m_auth_data, handle_main_page_response);
     }
 
-    inline void AuthManager::start_authentication(connection_callback_t callback) {
+    inline void AuthManager::start_authentication(
+            std::uint64_t generation,
+            connection_callback_t callback) {
         LOGIT_TRACE0();
         LOGIT_INFO("Intrade Bar auth: requesting profile.");
-        m_request_manager.request_profile([this, callback](
+        m_request_manager.request_profile([this, callback, generation](
                 bool success,
                 CurrencyType currency,
                 AccountType account_type) {
+            if (!is_auth_generation_current(generation, "profile")) {
+                return;
+            }
             if (!success) {
                 const std::string error_text = "Failed to retrieve profile information.";
                 LOGIT_ERROR(error_text);
                 callback({false, error_text, m_auth_data->clone_unique()});
                 return;
             }
-            handle_account_type_switch(account_type, currency, std::move(callback));
+            handle_account_type_switch(generation, account_type, currency, std::move(callback));
         });
     }
 
     inline void AuthManager::handle_account_type_switch(
+            std::uint64_t generation,
             AccountType account_type,
             CurrencyType currency,
             connection_callback_t callback) {
         LOGIT_TRACE0();
+        if (!is_auth_generation_current(generation, "account-type-switch")) {
+            return;
+        }
         if (m_auth_data->account_type != account_type) {
             LOGIT_INFO(
                 "Intrade Bar auth: switching account type from ",
@@ -674,16 +823,18 @@ namespace optionx::platforms::intrade_bar {
                 " to ",
                 to_str(m_auth_data->account_type));
             handle_account_type_switch_attempt(
+                generation,
                 currency,
                 std::move(callback),
                 OPTIONX_TIMESTAMP_MS,
                 1);
         } else {
-            handle_currency_switch(currency, std::move(callback));
+            handle_currency_switch(generation, currency, std::move(callback));
         }
     }
 
     inline void AuthManager::handle_account_type_switch_attempt(
+            std::uint64_t generation,
             CurrencyType currency,
             connection_callback_t callback,
             int64_t started_ms,
@@ -692,7 +843,10 @@ namespace optionx::platforms::intrade_bar {
             "Intrade Bar auth: account type switch attempt=",
             attempt);
         m_request_manager.request_switch_account_type_result(
-            [this, currency, callback, started_ms, attempt](SettingsSwitchResult result) {
+            [this, currency, callback, started_ms, attempt, generation](SettingsSwitchResult result) {
+                if (!is_auth_generation_current(generation, "account-type-switch-result")) {
+                    return;
+                }
                 if (!result) {
                     if (!result.value.should_retry()) {
                         const std::string error_text = result.error_message.empty()
@@ -715,12 +869,14 @@ namespace optionx::platforms::intrade_bar {
                         ", status_code=",
                         result.status_code);
                     schedule_settings_switch_retry(
+                        generation,
                         "account type",
                         started_ms,
                         attempt,
                         callback,
-                        [this, currency, callback, started_ms, attempt]() {
+                        [this, currency, callback, started_ms, attempt, generation]() {
                             handle_account_type_switch_attempt(
+                                generation,
                                 currency,
                                 callback,
                                 started_ms,
@@ -738,14 +894,18 @@ namespace optionx::platforms::intrade_bar {
                 account_info->account_type = m_auth_data->account_type;
                 notify(events::AccountInfoUpdateEvent(account_info, Status::ACCOUNT_TYPE_CHANGED));
 
-                handle_currency_switch(currency, std::move(callback));
+                handle_currency_switch(generation, currency, std::move(callback));
             });
     }
 
     inline void AuthManager::handle_currency_switch(
+            std::uint64_t generation,
             CurrencyType currency,
             connection_callback_t callback) {
         LOGIT_TRACE0();
+        if (!is_auth_generation_current(generation, "currency-switch")) {
+            return;
+        }
         if (m_auth_data->currency != currency) {
             LOGIT_INFO(
                 "Intrade Bar auth: switching currency from ",
@@ -753,6 +913,7 @@ namespace optionx::platforms::intrade_bar {
                 " to ",
                 to_str(m_auth_data->currency));
             handle_currency_switch_attempt(
+                generation,
                 std::move(callback),
                 OPTIONX_TIMESTAMP_MS,
                 1);
@@ -762,6 +923,7 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void AuthManager::handle_currency_switch_attempt(
+            std::uint64_t generation,
             connection_callback_t callback,
             int64_t started_ms,
             int attempt) {
@@ -769,7 +931,10 @@ namespace optionx::platforms::intrade_bar {
             "Intrade Bar auth: currency switch attempt=",
             attempt);
         m_request_manager.request_switch_currency_result(
-            [this, callback, started_ms, attempt](SettingsSwitchResult result) {
+            [this, callback, started_ms, attempt, generation](SettingsSwitchResult result) {
+                if (!is_auth_generation_current(generation, "currency-switch-result")) {
+                    return;
+                }
                 if (!result) {
                     if (!result.value.should_retry()) {
                         const std::string error_text = result.error_message.empty()
@@ -792,12 +957,14 @@ namespace optionx::platforms::intrade_bar {
                         ", status_code=",
                         result.status_code);
                     schedule_settings_switch_retry(
+                        generation,
                         "currency",
                         started_ms,
                         attempt,
                         callback,
-                        [this, callback, started_ms, attempt]() {
+                        [this, callback, started_ms, attempt, generation]() {
                             handle_currency_switch_attempt(
+                                generation,
                                 callback,
                                 started_ms,
                                 attempt + 1);
@@ -819,11 +986,15 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void AuthManager::schedule_settings_switch_retry(
+            std::uint64_t generation,
             std::string operation_name,
             int64_t started_ms,
             int attempt,
             connection_callback_t callback,
             std::function<void()> retry) {
+        if (!is_auth_generation_current(generation, "settings-switch-retry-schedule")) {
+            return;
+        }
         const int64_t now_ms = OPTIONX_TIMESTAMP_MS;
         const int64_t timeout_ms = m_auth_data->settings_switch_retry_timeout_ms;
         if ((now_ms - started_ms) >= timeout_ms) {
@@ -835,8 +1006,11 @@ namespace optionx::platforms::intrade_bar {
         }
 
         m_request_manager.request_active_trades_snapshot_result(
-            [this, operation_name = std::move(operation_name), started_ms, attempt, callback, retry = std::move(retry)](
+            [this, operation_name = std::move(operation_name), started_ms, attempt, callback, retry = std::move(retry), generation](
                     ActiveTradesSnapshotResult snapshot) mutable {
+                if (!is_auth_generation_current(generation, "settings-switch-active-trades")) {
+                    return;
+                }
                 const int64_t now_ms = OPTIONX_TIMESTAMP_MS;
                 const int64_t timeout_ms = m_auth_data->settings_switch_retry_timeout_ms;
                 int64_t delay_ms = m_auth_data->settings_switch_retry_delay_ms;
@@ -891,20 +1065,31 @@ namespace optionx::platforms::intrade_bar {
                 m_task_manager.add_delayed_task(
                     "settings-switch-retry",
                     delay_ms,
-                    [retry = std::move(retry)](std::shared_ptr<utils::Task> task) mutable {
+                    [this, retry = std::move(retry), generation](std::shared_ptr<utils::Task> task) mutable {
                         if (task->is_shutdown()) return;
+                        if (!is_auth_generation_current(generation, "settings-switch-retry-task")) {
+                            return;
+                        }
                         retry();
                     });
             });
     }
 
-    inline void AuthManager::finalize_authentication(connection_callback_t callback) {
+    inline void AuthManager::finalize_authentication(
+            std::uint64_t generation,
+            connection_callback_t callback) {
+        if (!is_auth_generation_current(generation, "finalize-authentication")) {
+            return;
+        }
         LOGIT_TRACE0();
         LOGIT_INFO("Intrade Bar auth: requesting final balance.");
-        m_request_manager.request_balance([this, callback](
+        m_request_manager.request_balance([this, callback, generation](
                 bool success,
                 double balance,
                 CurrencyType currency) {
+            if (!is_auth_generation_current(generation, "final-balance")) {
+                return;
+            }
             using Status = events::AccountInfoUpdateEvent::Status;
             if (!success) {
                 const std::string error_text("Failed to retrieve balance.");

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -51,15 +51,34 @@ namespace optionx::platforms::intrade_bar {
         std::unique_ptr<AuthData> m_temp_auth_data;        ///< Temporary authentication data storage.
         std::shared_ptr<AuthData> m_auth_data; ///< Currently active authentication data.
         std::uint64_t m_auth_generation = 0; ///< Monotonic auth flow generation for stale callback filtering.
+        std::uint64_t m_pending_connect_generation = 0; ///< Generation of the active public connect callback.
+        connection_callback_t m_pending_connect_callback; ///< Active public connect callback, if any.
 
         /// \brief Starts a new authentication generation and invalidates older callbacks.
         /// \param reason Human-readable trigger for diagnostics.
+        /// \param callback Public connect callback to complete or cancel.
         /// \return Generation token to capture in async callbacks.
-        std::uint64_t begin_auth_generation(const char* reason);
+        std::uint64_t begin_auth_generation(
+            const char* reason,
+            connection_callback_t callback = nullptr);
 
         /// \brief Invalidates active authentication callbacks.
         /// \param reason Human-readable trigger for diagnostics.
         void invalidate_auth_generation(const char* reason);
+
+        /// \brief Completes the active public connect callback if it belongs to a generation.
+        /// \param generation Generation token captured for the auth flow.
+        /// \param result Terminal connection result.
+        /// \param reason Human-readable completion context for diagnostics.
+        /// \return True if the auth flow is still current and terminal handling may continue.
+        bool complete_auth_generation(
+            std::uint64_t generation,
+            ConnectionResult result,
+            const char* reason);
+
+        /// \brief Cancels the active public connect callback, if any.
+        /// \param reason Human-readable cancellation reason.
+        void cancel_pending_connect_callback(const char* reason);
 
         /// \brief Checks whether a callback still belongs to the active auth flow.
         /// \param generation Generation token captured when the request was sent.
@@ -250,8 +269,15 @@ namespace optionx::platforms::intrade_bar {
         m_task_manager.shutdown();
     }
 
-    inline std::uint64_t AuthManager::begin_auth_generation(const char* reason) {
+    inline std::uint64_t AuthManager::begin_auth_generation(
+            const char* reason,
+            connection_callback_t callback) {
+        cancel_pending_connect_callback(reason);
         const std::uint64_t generation = ++m_auth_generation;
+        if (callback) {
+            m_pending_connect_generation = generation;
+            m_pending_connect_callback = std::move(callback);
+        }
         LOGIT_DEBUG(
             "Intrade Bar auth: generation started. reason=",
             reason,
@@ -262,11 +288,58 @@ namespace optionx::platforms::intrade_bar {
 
     inline void AuthManager::invalidate_auth_generation(const char* reason) {
         const std::uint64_t generation = ++m_auth_generation;
+        cancel_pending_connect_callback(reason);
         LOGIT_DEBUG(
             "Intrade Bar auth: generation invalidated. reason=",
             reason,
             ", generation=",
             generation);
+    }
+
+    inline bool AuthManager::complete_auth_generation(
+            std::uint64_t generation,
+            ConnectionResult result,
+            const char* reason) {
+        if (!is_auth_generation_current(generation, reason)) {
+            return false;
+        }
+
+        connection_callback_t callback;
+        if (m_pending_connect_generation == generation) {
+            callback = std::move(m_pending_connect_callback);
+            m_pending_connect_generation = 0;
+        }
+
+        ++m_auth_generation;
+        LOGIT_DEBUG(
+            "Intrade Bar auth: generation completed. reason=",
+            reason,
+            ", completed_generation=",
+            generation,
+            ", current_generation=",
+            m_auth_generation);
+
+        if (callback) {
+            callback(std::move(result));
+        }
+        return true;
+    }
+
+    inline void AuthManager::cancel_pending_connect_callback(const char* reason) {
+        if (!m_pending_connect_callback) {
+            m_pending_connect_generation = 0;
+            return;
+        }
+
+        auto callback = std::move(m_pending_connect_callback);
+        m_pending_connect_generation = 0;
+        const std::string message =
+            std::string("Authentication cancelled: ") + reason;
+        LOGIT_DEBUG("Intrade Bar auth: cancelling pending connect. reason=", reason);
+        callback(ConnectionResult(
+            false,
+            message,
+            m_auth_data ? m_auth_data->clone_unique() : nullptr));
     }
 
     inline bool AuthManager::is_auth_generation_current(
@@ -323,7 +396,8 @@ namespace optionx::platforms::intrade_bar {
     inline void AuthManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_TRACE0();
         auto callback = event.callback;
-        const std::uint64_t generation = begin_auth_generation("connect-request");
+        const std::uint64_t generation =
+            begin_auth_generation("connect-request", callback);
         m_task_manager.add_single_task(
                 "event(ConnectRequestEvent)-single-1",
                 [this, callback, generation](
@@ -410,11 +484,18 @@ namespace optionx::platforms::intrade_bar {
                 case AuthMethod::NONE: {
                         const std::string error_text("Authentication method is not specified.");
                         LOGIT_ERROR(error_text);
-                        callback({false, error_text, m_auth_data->clone_unique()});
-                        notify(events::AccountInfoUpdateEvent(
-                            account_info,
-                            Status::FAILED_TO_CONNECT,
-                            error_text));
+                        if (complete_auth_generation(
+                                generation,
+                                ConnectionResult(
+                                    false,
+                                    error_text,
+                                    m_auth_data->clone_unique()),
+                                "auth-method-none")) {
+                            notify(events::AccountInfoUpdateEvent(
+                                account_info,
+                                Status::FAILED_TO_CONNECT,
+                                error_text));
+                        }
                     } break;
                 case AuthMethod::EMAIL_PASSWORD:
                     handle_auto_domain_and_auth(generation, callback, [this](auto gen, auto cb) {
@@ -531,11 +612,18 @@ namespace optionx::platforms::intrade_bar {
                     using Status = events::AccountInfoUpdateEvent::Status;
                     if (!success) {
                         const std::string error_text = "No working domain found.";
-                        notify(events::AccountInfoUpdateEvent(
-                            get_account_info(),
-                            Status::FAILED_TO_CONNECT,
-                            error_text));
-                        callback({false, error_text, m_auth_data->clone_unique()});
+                        if (complete_auth_generation(
+                                generation,
+                                ConnectionResult(
+                                    false,
+                                    error_text,
+                                    m_auth_data->clone_unique()),
+                                "auto-domain-failed")) {
+                            notify(events::AccountInfoUpdateEvent(
+                                get_account_info(),
+                                Status::FAILED_TO_CONNECT,
+                                error_text));
+                        }
                         return;
                     }
 
@@ -659,11 +747,18 @@ namespace optionx::platforms::intrade_bar {
         }
         using Status = events::AccountInfoUpdateEvent::Status;
         LOGIT_PRINTF_ERROR("Authentication failed: ", reason);
-        callback({false, reason, m_auth_data ? m_auth_data->clone_unique() : nullptr});
-        notify(events::AccountInfoUpdateEvent(
-            get_account_info(),
-            Status::FAILED_TO_CONNECT,
-            reason));
+        if (complete_auth_generation(
+                generation,
+                ConnectionResult(
+                    false,
+                    reason,
+                    m_auth_data ? m_auth_data->clone_unique() : nullptr),
+                "auth-failure")) {
+            notify(events::AccountInfoUpdateEvent(
+                get_account_info(),
+                Status::FAILED_TO_CONNECT,
+                reason));
+        }
     }
 
     inline void AuthManager::execute_authentication_flow(
@@ -1094,7 +1189,15 @@ namespace optionx::platforms::intrade_bar {
             if (!success) {
                 const std::string error_text("Failed to retrieve balance.");
                 LOGIT_ERROR(error_text);
-                callback({false, error_text, m_auth_data->clone_unique()});
+                if (!complete_auth_generation(
+                        generation,
+                        ConnectionResult(
+                            false,
+                            error_text,
+                            m_auth_data->clone_unique()),
+                        "final-balance-failed")) {
+                    return;
+                }
 
                 auto account_info = get_account_info();
                 if (account_info->connect) {
@@ -1107,7 +1210,15 @@ namespace optionx::platforms::intrade_bar {
             }
 
             LOGIT_TRACE("Authentication successful. Connection established.");
-            callback({true, std::string(), m_auth_data->clone_unique()});
+            if (!complete_auth_generation(
+                    generation,
+                    ConnectionResult(
+                        true,
+                        std::string(),
+                        m_auth_data->clone_unique()),
+                    "final-balance-success")) {
+                return;
+            }
 
             auto account_info = get_account_info();
             account_info->account_type = m_auth_data->account_type;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AuthManager.hpp
@@ -54,6 +54,12 @@ namespace optionx::platforms::intrade_bar {
         std::uint64_t m_pending_connect_generation = 0; ///< Generation of the active public connect callback.
         connection_callback_t m_pending_connect_callback; ///< Active public connect callback, if any.
 
+        /// \brief Internal continuation between auth stages.
+        /// \details Stage callbacks propagate profile/switch state inside one
+        /// auth flow. Terminal public connect completion must go through
+        /// complete_auth_generation().
+        using auth_stage_callback_t = connection_callback_t;
+
         /// \brief Starts a new authentication generation and invalidates older callbacks.
         /// \param reason Human-readable trigger for diagnostics.
         /// \param callback Public connect callback to complete or cancel.
@@ -130,10 +136,10 @@ namespace optionx::platforms::intrade_bar {
 
         /// \brief Starts the authentication process.
         /// \param generation Auth flow generation token.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         void start_authentication(
             std::uint64_t generation,
-            connection_callback_t callback);
+            auth_stage_callback_t stage_callback);
 
         /// \brief Handles authentication failure.
         /// \param generation Auth flow generation token.
@@ -155,43 +161,43 @@ namespace optionx::platforms::intrade_bar {
         /// \param generation Auth flow generation token.
         /// \param account_type The new account type.
         /// \param currency The currency type.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         void handle_account_type_switch(
             std::uint64_t generation,
             AccountType account_type,
             CurrencyType currency,
-            connection_callback_t callback);
+            auth_stage_callback_t stage_callback);
 
         /// \brief Attempts an account type switch and retries while broker reports active trades.
         /// \param generation Auth flow generation token.
         /// \param currency Current currency from the profile response.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Attempt number.
         void handle_account_type_switch_attempt(
             std::uint64_t generation,
             CurrencyType currency,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             int64_t started_ms,
             int attempt);
 
         /// \brief Handles currency switch during authentication.
         /// \param generation Auth flow generation token.
         /// \param currency The new currency type.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         void handle_currency_switch(
             std::uint64_t generation,
             CurrencyType currency,
-            connection_callback_t callback);
+            auth_stage_callback_t stage_callback);
 
         /// \brief Attempts a currency switch and retries while broker reports active trades.
         /// \param generation Auth flow generation token.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Attempt number.
         void handle_currency_switch_attempt(
             std::uint64_t generation,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             int64_t started_ms,
             int attempt);
 
@@ -200,14 +206,14 @@ namespace optionx::platforms::intrade_bar {
         /// \param operation_name Human-readable operation name.
         /// \param started_ms First attempt timestamp.
         /// \param attempt Failed attempt number.
-        /// \param callback The callback function to notify the result.
+        /// \param stage_callback Internal stage continuation callback.
         /// \param retry Retry function.
         void schedule_settings_switch_retry(
             std::uint64_t generation,
             std::string operation_name,
             int64_t started_ms,
             int attempt,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             std::function<void()> retry);
 
         /// \brief Performs a multi-step authentication flow, making HTTP requests in sequence.
@@ -882,10 +888,10 @@ namespace optionx::platforms::intrade_bar {
 
     inline void AuthManager::start_authentication(
             std::uint64_t generation,
-            connection_callback_t callback) {
+            auth_stage_callback_t stage_callback) {
         LOGIT_TRACE0();
         LOGIT_INFO("Intrade Bar auth: requesting profile.");
-        m_request_manager.request_profile([this, callback, generation](
+        m_request_manager.request_profile([this, stage_callback, generation](
                 bool success,
                 CurrencyType currency,
                 AccountType account_type) {
@@ -895,10 +901,10 @@ namespace optionx::platforms::intrade_bar {
             if (!success) {
                 const std::string error_text = "Failed to retrieve profile information.";
                 LOGIT_ERROR(error_text);
-                callback({false, error_text, m_auth_data->clone_unique()});
+                stage_callback({false, error_text, m_auth_data->clone_unique()});
                 return;
             }
-            handle_account_type_switch(generation, account_type, currency, std::move(callback));
+            handle_account_type_switch(generation, account_type, currency, std::move(stage_callback));
         });
     }
 
@@ -906,7 +912,7 @@ namespace optionx::platforms::intrade_bar {
             std::uint64_t generation,
             AccountType account_type,
             CurrencyType currency,
-            connection_callback_t callback) {
+            auth_stage_callback_t stage_callback) {
         LOGIT_TRACE0();
         if (!is_auth_generation_current(generation, "account-type-switch")) {
             return;
@@ -920,25 +926,25 @@ namespace optionx::platforms::intrade_bar {
             handle_account_type_switch_attempt(
                 generation,
                 currency,
-                std::move(callback),
+                std::move(stage_callback),
                 OPTIONX_TIMESTAMP_MS,
                 1);
         } else {
-            handle_currency_switch(generation, currency, std::move(callback));
+            handle_currency_switch(generation, currency, std::move(stage_callback));
         }
     }
 
     inline void AuthManager::handle_account_type_switch_attempt(
             std::uint64_t generation,
             CurrencyType currency,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             int64_t started_ms,
             int attempt) {
         LOGIT_INFO(
             "Intrade Bar auth: account type switch attempt=",
             attempt);
         m_request_manager.request_switch_account_type_result(
-            [this, currency, callback, started_ms, attempt, generation](SettingsSwitchResult result) {
+            [this, currency, stage_callback, started_ms, attempt, generation](SettingsSwitchResult result) {
                 if (!is_auth_generation_current(generation, "account-type-switch-result")) {
                     return;
                 }
@@ -954,7 +960,7 @@ namespace optionx::platforms::intrade_bar {
                             settings_switch_failure_reason_to_string(result.value.failure_reason),
                             ", status_code=",
                             result.status_code);
-                        callback({false, error_text, m_auth_data->clone_unique()});
+                        stage_callback({false, error_text, m_auth_data->clone_unique()});
                         return;
                     }
 
@@ -968,12 +974,12 @@ namespace optionx::platforms::intrade_bar {
                         "account type",
                         started_ms,
                         attempt,
-                        callback,
-                        [this, currency, callback, started_ms, attempt, generation]() {
+                        stage_callback,
+                        [this, currency, stage_callback, started_ms, attempt, generation]() {
                             handle_account_type_switch_attempt(
                                 generation,
                                 currency,
-                                callback,
+                                stage_callback,
                                 started_ms,
                                 attempt + 1);
                         });
@@ -989,14 +995,14 @@ namespace optionx::platforms::intrade_bar {
                 account_info->account_type = m_auth_data->account_type;
                 notify(events::AccountInfoUpdateEvent(account_info, Status::ACCOUNT_TYPE_CHANGED));
 
-                handle_currency_switch(generation, currency, std::move(callback));
+                handle_currency_switch(generation, currency, std::move(stage_callback));
             });
     }
 
     inline void AuthManager::handle_currency_switch(
             std::uint64_t generation,
             CurrencyType currency,
-            connection_callback_t callback) {
+            auth_stage_callback_t stage_callback) {
         LOGIT_TRACE0();
         if (!is_auth_generation_current(generation, "currency-switch")) {
             return;
@@ -1009,24 +1015,24 @@ namespace optionx::platforms::intrade_bar {
                 to_str(m_auth_data->currency));
             handle_currency_switch_attempt(
                 generation,
-                std::move(callback),
+                std::move(stage_callback),
                 OPTIONX_TIMESTAMP_MS,
                 1);
         } else {
-            callback({true, std::string(), m_auth_data->clone_unique()});
+            stage_callback({true, std::string(), m_auth_data->clone_unique()});
         }
     }
 
     inline void AuthManager::handle_currency_switch_attempt(
             std::uint64_t generation,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             int64_t started_ms,
             int attempt) {
         LOGIT_INFO(
             "Intrade Bar auth: currency switch attempt=",
             attempt);
         m_request_manager.request_switch_currency_result(
-            [this, callback, started_ms, attempt, generation](SettingsSwitchResult result) {
+            [this, stage_callback, started_ms, attempt, generation](SettingsSwitchResult result) {
                 if (!is_auth_generation_current(generation, "currency-switch-result")) {
                     return;
                 }
@@ -1042,7 +1048,7 @@ namespace optionx::platforms::intrade_bar {
                             settings_switch_failure_reason_to_string(result.value.failure_reason),
                             ", status_code=",
                             result.status_code);
-                        callback({false, error_text, m_auth_data->clone_unique()});
+                        stage_callback({false, error_text, m_auth_data->clone_unique()});
                         return;
                     }
 
@@ -1056,11 +1062,11 @@ namespace optionx::platforms::intrade_bar {
                         "currency",
                         started_ms,
                         attempt,
-                        callback,
-                        [this, callback, started_ms, attempt, generation]() {
+                        stage_callback,
+                        [this, stage_callback, started_ms, attempt, generation]() {
                             handle_currency_switch_attempt(
                                 generation,
-                                callback,
+                                stage_callback,
                                 started_ms,
                                 attempt + 1);
                         });
@@ -1076,7 +1082,7 @@ namespace optionx::platforms::intrade_bar {
                 account_info->currency = m_auth_data->currency;
                 notify(events::AccountInfoUpdateEvent(account_info, Status::CURRENCY_CHANGED));
 
-                callback({true, std::string(), m_auth_data->clone_unique()});
+                stage_callback({true, std::string(), m_auth_data->clone_unique()});
             });
     }
 
@@ -1085,7 +1091,7 @@ namespace optionx::platforms::intrade_bar {
             std::string operation_name,
             int64_t started_ms,
             int attempt,
-            connection_callback_t callback,
+            auth_stage_callback_t stage_callback,
             std::function<void()> retry) {
         if (!is_auth_generation_current(generation, "settings-switch-retry-schedule")) {
             return;
@@ -1096,12 +1102,12 @@ namespace optionx::platforms::intrade_bar {
             const std::string error_text =
                 "Failed to switch " + operation_name + " before retry timeout.";
             LOGIT_ERROR(error_text);
-            callback({false, error_text, m_auth_data->clone_unique()});
+            stage_callback({false, error_text, m_auth_data->clone_unique()});
             return;
         }
 
         m_request_manager.request_active_trades_snapshot_result(
-            [this, operation_name = std::move(operation_name), started_ms, attempt, callback, retry = std::move(retry), generation](
+            [this, operation_name = std::move(operation_name), started_ms, attempt, stage_callback, retry = std::move(retry), generation](
                     ActiveTradesSnapshotResult snapshot) mutable {
                 if (!is_auth_generation_current(generation, "settings-switch-active-trades")) {
                     return;
@@ -1153,7 +1159,7 @@ namespace optionx::platforms::intrade_bar {
                     const std::string error_text =
                         "Failed to switch " + operation_name + " before retry timeout.";
                     LOGIT_ERROR(error_text);
-                    callback({false, error_text, m_auth_data->clone_unique()});
+                    stage_callback({false, error_text, m_auth_data->clone_unique()});
                     return;
                 }
 

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BalanceManager.hpp
@@ -60,6 +60,48 @@ namespace optionx::platforms::intrade_bar {
         int64_t m_disconnected_domain_retry_period_ms = time_shield::MS_PER_15_SEC; ///< Disconnected host/domain recovery period.
         bool m_has_balance_update = false;    ///< Flag indicating if a balance update is in progress.
         bool m_check_host_in_progress = false;
+        std::uint64_t m_balance_request_generation = 0; ///< Monotonic balance request generation.
+        std::uint64_t m_active_balance_request_generation = 0; ///< Currently active balance request generation.
+        std::uint64_t m_host_request_generation = 0; ///< Monotonic host/domain request generation.
+        std::uint64_t m_active_host_request_generation = 0; ///< Currently active host/domain request generation.
+
+        /// \brief Starts a balance request generation.
+        /// \param reason Human-readable trigger for diagnostics.
+        /// \return Generation token to capture in the request callback.
+        std::uint64_t begin_balance_request(const char* reason);
+
+        /// \brief Completes an active balance request if its generation is current.
+        /// \param generation Generation token captured when the request was sent.
+        /// \param reason Human-readable callback context for diagnostics.
+        /// \return True if the callback may apply its result.
+        bool finish_balance_request(
+            std::uint64_t generation,
+            const char* reason);
+
+        /// \brief Starts a host/domain request generation.
+        /// \param reason Human-readable trigger for diagnostics.
+        /// \return Generation token to capture in request callbacks.
+        std::uint64_t begin_host_request(const char* reason);
+
+        /// \brief Checks whether a host/domain callback belongs to the active chain.
+        /// \param generation Generation token captured when the request was sent.
+        /// \param reason Human-readable callback context for diagnostics.
+        /// \return True if the callback may continue the host/domain chain.
+        bool is_host_request_current(
+            std::uint64_t generation,
+            const char* reason) const;
+
+        /// \brief Completes an active host/domain request if its generation is current.
+        /// \param generation Generation token captured when the request was sent.
+        /// \param reason Human-readable callback context for diagnostics.
+        /// \return True if the callback may apply its result.
+        bool finish_host_request(
+            std::uint64_t generation,
+            const char* reason);
+
+        /// \brief Invalidates pending balance and host/domain callbacks.
+        /// \param reason Human-readable trigger for diagnostics.
+        void invalidate_async_requests(const char* reason);
 
          /// \brief Initiates a balance update request.
         void handle_balance_update();
@@ -139,20 +181,110 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void BalanceManager::shutdown() {
+        invalidate_async_requests("shutdown");
         m_task_manager.shutdown();
+    }
+
+    inline std::uint64_t BalanceManager::begin_balance_request(const char* reason) {
+        m_has_balance_update = true;
+        const std::uint64_t generation = ++m_balance_request_generation;
+        m_active_balance_request_generation = generation;
+        LOGIT_DEBUG(
+            "Intrade Bar balance: balance request started. reason=",
+            reason,
+            ", generation=",
+            generation);
+        return generation;
+    }
+
+    inline bool BalanceManager::finish_balance_request(
+            std::uint64_t generation,
+            const char* reason) {
+        if (generation != m_active_balance_request_generation) {
+            LOGIT_DEBUG(
+                "Intrade Bar balance: stale balance callback ignored. reason=",
+                reason,
+                ", callback_generation=",
+                generation,
+                ", active_generation=",
+                m_active_balance_request_generation);
+            return false;
+        }
+
+        m_active_balance_request_generation = 0;
+        m_has_balance_update = false;
+        return true;
+    }
+
+    inline std::uint64_t BalanceManager::begin_host_request(const char* reason) {
+        m_check_host_in_progress = true;
+        const std::uint64_t generation = ++m_host_request_generation;
+        m_active_host_request_generation = generation;
+        LOGIT_DEBUG(
+            "Intrade Bar balance: host/domain request started. reason=",
+            reason,
+            ", generation=",
+            generation);
+        return generation;
+    }
+
+    inline bool BalanceManager::is_host_request_current(
+            std::uint64_t generation,
+            const char* reason) const {
+        const bool current = generation == m_active_host_request_generation;
+        if (!current) {
+            LOGIT_DEBUG(
+                "Intrade Bar balance: stale host/domain callback ignored. reason=",
+                reason,
+                ", callback_generation=",
+                generation,
+                ", active_generation=",
+                m_active_host_request_generation);
+        }
+        return current;
+    }
+
+    inline bool BalanceManager::finish_host_request(
+            std::uint64_t generation,
+            const char* reason) {
+        if (!is_host_request_current(generation, reason)) {
+            return false;
+        }
+
+        m_active_host_request_generation = 0;
+        m_check_host_in_progress = false;
+        return true;
+    }
+
+    inline void BalanceManager::invalidate_async_requests(const char* reason) {
+        ++m_balance_request_generation;
+        ++m_host_request_generation;
+        m_active_balance_request_generation = 0;
+        m_active_host_request_generation = 0;
+        m_has_balance_update = false;
+        m_check_host_in_progress = false;
+        LOGIT_DEBUG(
+            "Intrade Bar balance: async callbacks invalidated. reason=",
+            reason,
+            ", balance_generation=",
+            m_balance_request_generation,
+            ", host_generation=",
+            m_host_request_generation);
     }
 
     // Handles balance updates.
     inline void BalanceManager::handle_balance_update() {
         if (m_has_balance_update) return;
-        m_has_balance_update = true;
+        const std::uint64_t generation =
+            begin_balance_request("balance-update");
         LOGIT_INFO("Intrade Bar balance: requesting balance snapshot.");
-        m_request_manager.request_balance([this](
+        m_request_manager.request_balance([this, generation](
                 bool success,
                 double balance,
                 CurrencyType currency) {
-            m_has_balance_update = false;
-            m_check_host_in_progress = false;
+            if (!finish_balance_request(generation, "balance-update")) {
+                return;
+            }
             auto account_info = get_account_info();
             if (!account_info) {
                 LOGIT_ERROR("Failed to get account info.");
@@ -220,6 +352,7 @@ namespace optionx::platforms::intrade_bar {
 
     inline void BalanceManager::handle_event(const events::AuthDataEvent& event) {
         if (auto auth_data = std::dynamic_pointer_cast<AuthData>(event.auth_data)) {
+            invalidate_async_requests("auth-data");
             if (auth_data->balance_check_period_ms > 0) {
                 m_balance_check_period_ms = auth_data->balance_check_period_ms;
                 LOGIT_INFO(
@@ -255,11 +388,13 @@ namespace optionx::platforms::intrade_bar {
 
     inline void BalanceManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_TRACE0();
+        invalidate_async_requests("connect-request");
         m_task_manager.shutdown();
     }
 
     inline void BalanceManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_TRACE0();
+        invalidate_async_requests("disconnect-request");
         m_task_manager.shutdown();
     }
 
@@ -278,6 +413,7 @@ namespace optionx::platforms::intrade_bar {
         LOGIT_TRACE0();
 
         m_task_manager.shutdown();
+        invalidate_async_requests("connected");
         
         LOGIT_INFO(
             "Intrade Bar balance: starting connected balance polling. period_ms=",
@@ -298,13 +434,16 @@ namespace optionx::platforms::intrade_bar {
                 [this](std::shared_ptr<utils::Task> task){
             if (task->is_shutdown()) return;
             if (m_check_host_in_progress) return;
-            m_check_host_in_progress = true;
+            const std::uint64_t generation =
+                begin_host_request("connected-host-check");
             
             LOGIT_TRACE0();
-            m_request_manager.request_check_current_host_available([this](
+            m_request_manager.request_check_current_host_available([this, generation](
                     bool success) {
                 LOGIT_TRACE0();
-                m_check_host_in_progress = false;
+                if (!finish_host_request(generation, "connected-host-check")) {
+                    return;
+                }
                 if (!success) {
                     auto account_info = get_account_info();
                     if (account_info->connect) {
@@ -324,6 +463,7 @@ namespace optionx::platforms::intrade_bar {
         LOGIT_TRACE0();
 
         m_task_manager.shutdown();
+        invalidate_async_requests("disconnected");
         LOGIT_INFO(
             "Intrade Bar balance: starting disconnected host recovery. period_ms=",
             m_disconnected_domain_retry_period_ms);
@@ -334,20 +474,29 @@ namespace optionx::platforms::intrade_bar {
             LOGIT_TRACE0();
             if (task->is_shutdown()) return;
             if (m_check_host_in_progress) return;
-            m_check_host_in_progress = true;
+            const std::uint64_t generation =
+                begin_host_request("disconnected-domain-retry");
             
             LOGIT_TRACE0();
-            m_request_manager.request_check_current_host_available([this](
+            m_request_manager.request_check_current_host_available([this, generation](
                     bool success) {
+                if (!is_host_request_current(generation, "disconnected-host-check")) {
+                    return;
+                }
                 if (success) {
+                    if (!finish_host_request(generation, "disconnected-host-check")) {
+                        return;
+                    }
                     handle_balance_update();
                     return;
                 }
                 
                 m_request_manager.request_find_working_domain(
-                        [this](bool success, std::string& host) {
+                        [this, generation](bool success, std::string& host) {
+                    if (!finish_host_request(generation, "disconnected-domain-find")) {
+                        return;
+                    }
                     if (!success) {
-                        m_check_host_in_progress = false;
                         return;
                     }
 

--- a/tests/intrade_auth_lifecycle_test.cpp
+++ b/tests/intrade_auth_lifecycle_test.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <optionx_cpp/platforms/IntradeBarPlatform.hpp>
+
+namespace {
+
+struct ConnectionCallbackState {
+    int count = 0;
+    bool success = true;
+    std::string reason;
+};
+
+void pump_platform(
+        optionx::platforms::IntradeBarPlatform& platform,
+        int iterations = 100) {
+    for (int i = 0; i < iterations; ++i) {
+        platform.process();
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+}
+
+} // namespace
+
+TEST(IntradeBarAuthLifecycle, SupersededConnectCallbackIsCancelledOnce) {
+    optionx::platforms::IntradeBarPlatform platform;
+    ConnectionCallbackState first;
+    ConnectionCallbackState second;
+
+    platform.run(false);
+    platform.connect([&first](optionx::ConnectionResult result) {
+        ++first.count;
+        first.success = result.success;
+        first.reason = std::move(result.reason);
+    });
+    platform.connect([&second](optionx::ConnectionResult result) {
+        ++second.count;
+        second.success = result.success;
+        second.reason = std::move(result.reason);
+    });
+
+    pump_platform(platform);
+    platform.shutdown();
+
+    EXPECT_EQ(first.count, 1);
+    EXPECT_FALSE(first.success);
+    EXPECT_NE(
+        first.reason.find("Authentication cancelled: connect-request"),
+        std::string::npos);
+
+    EXPECT_EQ(second.count, 1);
+    EXPECT_FALSE(second.success);
+    EXPECT_EQ(second.reason, "Authentication data is missing.");
+}
+
+TEST(IntradeBarAuthLifecycle, DisconnectCancelsPendingConnectCallbackOnce) {
+    optionx::platforms::IntradeBarPlatform platform;
+    ConnectionCallbackState connect;
+    ConnectionCallbackState disconnect;
+
+    platform.run(false);
+    platform.connect([&connect](optionx::ConnectionResult result) {
+        ++connect.count;
+        connect.success = result.success;
+        connect.reason = std::move(result.reason);
+    });
+    platform.disconnect([&disconnect](optionx::ConnectionResult result) {
+        ++disconnect.count;
+        disconnect.success = result.success;
+        disconnect.reason = std::move(result.reason);
+    });
+
+    pump_platform(platform);
+    platform.shutdown();
+
+    EXPECT_EQ(connect.count, 1);
+    EXPECT_FALSE(connect.success);
+    EXPECT_NE(
+        connect.reason.find("Authentication cancelled: disconnect-request"),
+        std::string::npos);
+
+    EXPECT_EQ(disconnect.count, 1);
+    EXPECT_FALSE(disconnect.success);
+    EXPECT_EQ(disconnect.reason, "Already disconnected.");
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/intrade_auth_lifecycle_test.cpp
+++ b/tests/intrade_auth_lifecycle_test.cpp
@@ -87,6 +87,62 @@ TEST(IntradeBarAuthLifecycle, DisconnectCancelsPendingConnectCallbackOnce) {
     EXPECT_EQ(disconnect.reason, "Already disconnected.");
 }
 
+TEST(IntradeBarAuthLifecycle, TerminalFailureIsNotCancelledAgainOnShutdown) {
+    optionx::platforms::IntradeBarPlatform platform;
+    ConnectionCallbackState connect;
+
+    platform.run(false);
+    platform.connect([&connect](optionx::ConnectionResult result) {
+        ++connect.count;
+        connect.success = result.success;
+        connect.reason = std::move(result.reason);
+    });
+
+    pump_platform(platform);
+    ASSERT_EQ(connect.count, 1);
+    EXPECT_FALSE(connect.success);
+    EXPECT_EQ(connect.reason, "Authentication data is missing.");
+
+    platform.shutdown();
+
+    EXPECT_EQ(connect.count, 1);
+    EXPECT_EQ(connect.reason, "Authentication data is missing.");
+}
+
+TEST(IntradeBarAuthLifecycle, TerminalFailureIsNotCancelledAgainOnDisconnect) {
+    optionx::platforms::IntradeBarPlatform platform;
+    ConnectionCallbackState connect;
+    ConnectionCallbackState disconnect;
+
+    platform.run(false);
+    platform.connect([&connect](optionx::ConnectionResult result) {
+        ++connect.count;
+        connect.success = result.success;
+        connect.reason = std::move(result.reason);
+    });
+
+    pump_platform(platform);
+    ASSERT_EQ(connect.count, 1);
+    EXPECT_FALSE(connect.success);
+    EXPECT_EQ(connect.reason, "Authentication data is missing.");
+
+    platform.disconnect([&disconnect](optionx::ConnectionResult result) {
+        ++disconnect.count;
+        disconnect.success = result.success;
+        disconnect.reason = std::move(result.reason);
+    });
+
+    pump_platform(platform);
+    platform.shutdown();
+
+    EXPECT_EQ(connect.count, 1);
+    EXPECT_EQ(connect.reason, "Authentication data is missing.");
+
+    EXPECT_EQ(disconnect.count, 1);
+    EXPECT_FALSE(disconnect.success);
+    EXPECT_EQ(disconnect.reason, "Already disconnected.");
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## What Changed

- Added monotonic auth-flow generation guards in `AuthManager` and threaded the token through domain discovery, cached/fresh login, profile, settings switch retry, and final balance callbacks.
- Added explicit terminal handling for superseded/cancelled public `connect()` callbacks, so every accepted connect callback receives success, failure, or cancellation exactly once.
- Clarified the internal profile/switch/retry continuation callbacks as auth stage callbacks; terminal public `connect()` completion remains centralized through `complete_auth_generation()`.
- Added separate generation guards in `BalanceManager` for balance requests and host/domain recovery chains so stale callbacks cannot update account state or reset flags for newer requests.
- Invalidated pending Intrade Bar auth/balance callbacks on auth data changes, connect/disconnect, restart auth, account state transitions, and shutdown.

## Why

F-016: long-running HTTP callbacks could arrive after disconnect, re-auth, or account context changes and apply stale state to the current broker session. The follow-up also preserves the async `connect(callback)` contract: stale flows are ignored for state updates, but their public callback is explicitly completed with cancellation, and already-completed terminal failures are not cancelled a second time by later shutdown/disconnect.

## Validation

- `cmake -S . -B build-codex -DBUILD_TESTS=ON`
- `cmake --build build-codex --target intrade_auth_lifecycle_test -- -j1`
- `./build-codex/intrade_auth_lifecycle_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` (36/36 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --target intrade_bar_smoke_cli -- -j1`
- `git diff --check`

Live broker smoke commands were not run for this PR; the change is lifecycle/callback hardening and was validated by offline lifecycle regression tests, compile, and existing parser/ODR tests.