### PR TITLE
[codex] Preserve Intrade trade history diagnostics

### DIFF
--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -379,18 +379,12 @@ namespace optionx::platforms::intrade_bar {
         void request_trade_history_csv(
             const TradeHistoryRequest& request,
             AccountType account_type,
-            std::function<void(
-                bool success,
-                long status_code,
-                std::vector<TradeRecord> records)> callback);
+            std::function<void(TradeHistoryApiResult)> callback);
 
         void request_trade_history_html(
             const TradeHistoryRequest& request,
             AccountType account_type,
-            std::function<void(
-                bool success,
-                long status_code,
-                std::vector<TradeRecord> records)> callback);
+            std::function<void(TradeHistoryApiResult)> callback);
     };
 	
     // ------------------------------------------------------------------------
@@ -1085,6 +1079,36 @@ namespace optionx::platforms::intrade_bar {
             if (!html_success) return html_status_code;
             return csv_status_code >= 0 ? csv_status_code : html_status_code;
         }
+
+        std::string trade_history_error_message(
+                const char* source,
+                const TradeHistoryApiResult& result) {
+            std::string message = "Failed to retrieve ";
+            message += source;
+            message += " trade history.";
+            if (!result.error_message.empty()) {
+                message += " ";
+                message += result.error_message;
+            }
+            return message;
+        }
+
+        std::string combined_trade_history_error_message(
+                const TradeHistoryApiResult& csv_result,
+                const TradeHistoryApiResult& html_result) {
+            if (!csv_result && !html_result) {
+                return trade_history_error_message("CSV", csv_result) +
+                    " " +
+                    trade_history_error_message("HTML", html_result);
+            }
+            if (!csv_result) {
+                return trade_history_error_message("CSV", csv_result);
+            }
+            if (!html_result) {
+                return trade_history_error_message("HTML", html_result);
+            }
+            return {};
+        }
     }
 
     inline void RequestManager::request_trade_history(
@@ -1094,8 +1118,28 @@ namespace optionx::platforms::intrade_bar {
                 bool success,
                 long status_code,
                 std::vector<TradeRecord> records)> callback) {
+        request_trade_history_result(
+            request,
+            account_type,
+            [callback = std::move(callback)](TradeHistoryApiResult result) mutable {
+                if (!callback) return;
+                callback(
+                    result.success,
+                    result.status_code,
+                    result.success ? std::move(result.value.records) : std::vector<TradeRecord>());
+            });
+    }
+
+    inline void RequestManager::request_trade_history_result(
+            const TradeHistoryRequest& request,
+            AccountType account_type,
+            std::function<void(TradeHistoryApiResult)> callback) {
         if (!request.has_valid_range() || account_type == AccountType::UNKNOWN) {
-            callback(false, -1, {});
+            if (callback) {
+                callback(TradeHistoryApiResult::fail(
+                    "Invalid trade history request range or account type.",
+                    TradeHistoryApiResult::NO_RESPONSE_STATUS));
+            }
             return;
         }
 
@@ -1118,40 +1162,38 @@ namespace optionx::platforms::intrade_bar {
             request,
             account_type,
             [this, request, account_type, callback = std::move(callback)](
-                    bool csv_success,
-                    long csv_status_code,
-                    std::vector<TradeRecord> csv_records) mutable {
+                    TradeHistoryApiResult csv_result) mutable {
                 request_trade_history_html(
                     request,
                     account_type,
                     [callback = std::move(callback),
-                     csv_success,
-                     csv_status_code,
-                     csv_records = std::move(csv_records)](
-                            bool html_success,
-                            long html_status_code,
-                            std::vector<TradeRecord> html_records) mutable {
-                        if (csv_success && html_success) {
+                     csv_result = std::move(csv_result)](
+                            TradeHistoryApiResult html_result) mutable {
+                        if (!callback) return;
+                        if (csv_result && html_result) {
                             callback(
-                                true,
-                                select_combined_trade_history_status(
-                                    csv_success,
-                                    csv_status_code,
-                                    html_success,
-                                    html_status_code),
-                                merge_trade_history_csv_with_html(
-                                    std::move(csv_records),
-                                    html_records));
+                                TradeHistoryApiResult::ok(
+                                    TradeHistory{
+                                        merge_trade_history_csv_with_html(
+                                            std::move(csv_result.value.records),
+                                            html_result.value.records)},
+                                    select_combined_trade_history_status(
+                                        csv_result.success,
+                                        csv_result.status_code,
+                                        html_result.success,
+                                        html_result.status_code)));
                             return;
                         }
                         callback(
-                            false,
+                            TradeHistoryApiResult::fail(
+                                combined_trade_history_error_message(
+                                    csv_result,
+                                    html_result),
                             select_combined_trade_history_status(
-                                csv_success,
-                                csv_status_code,
-                                html_success,
-                                html_status_code),
-                            {});
+                                csv_result.success,
+                                csv_result.status_code,
+                                html_result.success,
+                                html_result.status_code)));
                     });
             });
     }
@@ -1159,10 +1201,7 @@ namespace optionx::platforms::intrade_bar {
     inline void RequestManager::request_trade_history_csv(
             const TradeHistoryRequest& request,
             AccountType account_type,
-            std::function<void(
-                bool success,
-                long status_code,
-                std::vector<TradeRecord> records)> callback) {
+            std::function<void(TradeHistoryApiResult)> callback) {
         constexpr int64_t broker_offset_sec = 3 * time_shield::SEC_PER_HOUR;
         // The broker CSV export endpoint requires finite dates; 2000-01-01 is
         // used as a practical lower bound for "all available" history.
@@ -1199,7 +1238,11 @@ namespace optionx::platforms::intrade_bar {
         auto response_callback = [request, account_type, callback = std::move(callback)](
                 kurlyk::HttpResponsePtr response) {
             if (!validate_response(response)) {
-                callback(false, response ? response->status_code : -1, {});
+                if (callback) {
+                    callback(TradeHistoryApiResult::fail(
+                        "CSV trade history HTTP response failed validation.",
+                        response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
+                }
                 return;
             }
 
@@ -1208,10 +1251,18 @@ namespace optionx::platforms::intrade_bar {
                     parse_trade_history_csv_export(response->content, account_type),
                     request);
                 apply_trade_history_request_metadata(records, request);
-                callback(true, response->status_code, std::move(records));
+                if (callback) {
+                    callback(TradeHistoryApiResult::ok(
+                        TradeHistory{std::move(records)},
+                        response->status_code));
+                }
             } catch (const std::exception& ex) {
                 LOGIT_ERROR("Error parsing trade history CSV export: ", ex.what());
-                callback(false, response ? response->status_code : -1, {});
+                if (callback) {
+                    callback(TradeHistoryApiResult::fail(
+                        std::string("Failed to parse CSV trade history: ") + ex.what(),
+                        response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
+                }
             }
         };
 
@@ -1221,16 +1272,13 @@ namespace optionx::platforms::intrade_bar {
     inline void RequestManager::request_trade_history_html(
             const TradeHistoryRequest& request,
             AccountType account_type,
-            std::function<void(
-                bool success,
-                long status_code,
-                std::vector<TradeRecord> records)> callback) {
+            std::function<void(TradeHistoryApiResult)> callback) {
         struct HtmlHistoryState {
             TradeHistoryRequest request;
             AccountType account_type = AccountType::UNKNOWN;
             std::vector<TradeRecord> records;
             std::vector<std::string> requested_last_values;
-            std::function<void(bool, long, std::vector<TradeRecord>)> callback;
+            std::function<void(TradeHistoryApiResult)> callback;
             int page_count = 0;
             bool completed = false;
         };
@@ -1241,13 +1289,13 @@ namespace optionx::platforms::intrade_bar {
         state->callback = std::move(callback);
 
         constexpr int max_html_history_pages = 200;
-        auto complete = std::make_shared<std::function<void(bool, long)>>();
-        *complete = [state](bool success, long status_code) {
+        auto complete = std::make_shared<std::function<void(TradeHistoryApiResult)>>();
+        *complete = [state](TradeHistoryApiResult result) {
             if (state->completed) return;
             state->completed = true;
 
-            if (!success) {
-                state->callback(false, status_code, {});
+            if (!result.success) {
+                if (state->callback) state->callback(std::move(result));
                 return;
             }
 
@@ -1255,7 +1303,11 @@ namespace optionx::platforms::intrade_bar {
                 std::move(state->records),
                 state->request);
             apply_trade_history_request_metadata(records, state->request);
-            state->callback(true, status_code, std::move(records));
+            if (state->callback) {
+                state->callback(TradeHistoryApiResult::ok(
+                    TradeHistory{std::move(records)},
+                    result.status_code));
+            }
         };
 
         auto load_more = std::make_shared<std::function<void(std::string)>>();
@@ -1288,7 +1340,7 @@ namespace optionx::platforms::intrade_bar {
                 return;
             }
 
-            (*complete)(true, status_code);
+            (*complete)(TradeHistoryApiResult::ok(TradeHistory{}, status_code));
         };
 
         const std::weak_ptr<std::function<void(TradeHistoryHtmlPage, long)>> weak_process_page =
@@ -1296,13 +1348,17 @@ namespace optionx::platforms::intrade_bar {
 
         *load_more = [this, state, weak_process_page, complete](std::string last) {
             if (last.empty() || state->completed) {
-                (*complete)(true, TradeHistoryApiResult::NO_HTTP_STATUS);
+                (*complete)(TradeHistoryApiResult::ok(
+                    TradeHistory{},
+                    TradeHistoryApiResult::NO_HTTP_STATUS));
                 return;
             }
 
             auto process_page_ref = weak_process_page.lock();
             if (!process_page_ref) {
-                (*complete)(false, -1);
+                (*complete)(TradeHistoryApiResult::fail(
+                    "HTML trade history parser state expired.",
+                    TradeHistoryApiResult::NO_RESPONSE_STATUS));
                 return;
             }
 
@@ -1329,7 +1385,9 @@ namespace optionx::platforms::intrade_bar {
                                       complete](
                     kurlyk::HttpResponsePtr response) mutable {
                 if (!validate_response(response)) {
-                    (*complete)(false, response ? response->status_code : -1);
+                    (*complete)(TradeHistoryApiResult::fail(
+                        "HTML trade history load-more HTTP response failed validation.",
+                        response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
                     return;
                 }
 
@@ -1347,7 +1405,9 @@ namespace optionx::platforms::intrade_bar {
                     (*process_page_ref)(std::move(page), response->status_code);
                 } catch (const std::exception& ex) {
                     LOGIT_ERROR("Error parsing trade history load-more HTML: ", ex.what());
-                    (*complete)(false, response ? response->status_code : -1);
+                    (*complete)(TradeHistoryApiResult::fail(
+                        std::string("Failed to parse HTML trade history load-more: ") + ex.what(),
+                        response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
                 }
             };
 
@@ -1369,7 +1429,9 @@ namespace optionx::platforms::intrade_bar {
         auto response_callback = [state, process_page, complete](
                 kurlyk::HttpResponsePtr response) {
             if (!validate_response(response)) {
-                (*complete)(false, response ? response->status_code : -1);
+                (*complete)(TradeHistoryApiResult::fail(
+                    "HTML trade history HTTP response failed validation.",
+                    response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
                 return;
             }
 
@@ -1399,7 +1461,9 @@ namespace optionx::platforms::intrade_bar {
                 (*process_page)(std::move(page), response->status_code);
             } catch (const std::exception& ex) {
                 LOGIT_ERROR("Error parsing trade history HTML: ", ex.what());
-                (*complete)(false, response ? response->status_code : -1);
+                (*complete)(TradeHistoryApiResult::fail(
+                    std::string("Failed to parse HTML trade history: ") + ex.what(),
+                    response ? response->status_code : TradeHistoryApiResult::NO_RESPONSE_STATUS));
             }
         };
 
@@ -1740,27 +1804,6 @@ namespace optionx::platforms::intrade_bar {
             });
     }
 
-    inline void RequestManager::request_trade_history_result(
-            const TradeHistoryRequest& request,
-            AccountType account_type,
-            std::function<void(TradeHistoryApiResult)> callback) {
-        request_trade_history(
-            request,
-            account_type,
-            [callback = std::move(callback)](
-                    bool success,
-                    long status_code,
-                    std::vector<TradeRecord> records) mutable {
-                if (!callback) return;
-                if (!success) {
-                    callback(TradeHistoryApiResult::fail(
-                        "Failed to retrieve trade history.",
-                        status_code));
-                    return;
-                }
-                callback(TradeHistoryApiResult::ok(TradeHistory{std::move(records)}, status_code));
-            });
-    }
     inline void RequestManager::request_trade_check_result(
             int64_t deal_id,
             int retry_attempts,

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeHistorySource.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeHistorySource.hpp
@@ -9,9 +9,9 @@ namespace optionx::platforms::intrade_bar {
 
     /// \brief Source used to load closed trade history.
     enum class TradeHistorySource {
-        HTML,    ///< Parse the authenticated HTML page history.
-        CSV,     ///< Use /stat_trade_export.php CSV export.
-        HTML_CSV ///< Return CSV/HTML intersection with CSV financial fields and HTML broker IDs.
+        HTML, ///< Parse the authenticated HTML page history.
+        CSV,  ///< Use /stat_trade_export.php CSV export.
+        HTML_CSV ///< Strict CSV+HTML intersection; both sources must succeed and unmatched rows are omitted.
     };
 
     /// \brief Converts trade history source to a stable config string.

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -628,6 +628,12 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsHtmlFailureStatus
     ASSERT_EQ(call.callback_count, 1);
     EXPECT_FALSE(call.result);
     EXPECT_EQ(call.result.status_code, 451);
+    EXPECT_NE(
+        call.result.error_message.find("HTML trade history"),
+        std::string::npos);
+    EXPECT_NE(
+        call.result.error_message.find("failed validation"),
+        std::string::npos);
     EXPECT_EQ(server.csv_requests.load(), 1);
     EXPECT_EQ(server.html_requests.load(), 1);
 }
@@ -646,6 +652,12 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsCsvFailureStatus)
     ASSERT_EQ(call.callback_count, 1);
     EXPECT_FALSE(call.result);
     EXPECT_EQ(call.result.status_code, 500);
+    EXPECT_NE(
+        call.result.error_message.find("CSV trade history"),
+        std::string::npos);
+    EXPECT_NE(
+        call.result.error_message.find("failed validation"),
+        std::string::npos);
     EXPECT_EQ(server.csv_requests.load(), 1);
     EXPECT_EQ(server.html_requests.load(), 1);
 }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -185,14 +185,18 @@ std::string empty_trade_history_html() {
     )HTML";
 }
 
-CombinedHistoryTestResult request_combined_trade_history(LocalTradeHistoryServer& server) {
+CombinedHistoryTestResult request_trade_history(
+        LocalTradeHistoryServer& server,
+        TradeHistorySource source = TradeHistorySource::HTML_CSV,
+        TradeHistoryRequest request = TradeHistoryRequest::all(),
+        AccountType account_type = AccountType::DEMO) {
     TestPlatform platform;
     HttpClientModule http_client(platform);
     RequestManager request_manager(platform, http_client);
 
     auto auth_data = std::make_shared<AuthData>();
     auth_data->host = server.host();
-    auth_data->trade_history_source = TradeHistorySource::HTML_CSV;
+    auth_data->trade_history_source = source;
 
     events::AuthDataEvent auth_event(auth_data);
     request_manager.on_event(&auth_event);
@@ -203,8 +207,8 @@ CombinedHistoryTestResult request_combined_trade_history(LocalTradeHistoryServer
     std::atomic<int> callback_count{0};
 
     request_manager.request_trade_history_result(
-        TradeHistoryRequest::all(),
-        AccountType::DEMO,
+        request,
+        account_type,
         [&call, &callback_count](TradeHistoryApiResult history_result) {
             call.result = std::move(history_result);
             ++callback_count;
@@ -225,6 +229,30 @@ CombinedHistoryTestResult request_combined_trade_history(LocalTradeHistoryServer
     }
 
     call.callback_count = callback_count.load();
+    platform.shutdown();
+    return call;
+}
+
+CombinedHistoryTestResult request_trade_history_without_http(
+        TradeHistoryRequest request,
+        AccountType account_type) {
+    TestPlatform platform;
+    HttpClientModule http_client(platform);
+    RequestManager request_manager(platform, http_client);
+
+    CombinedHistoryTestResult call;
+    int callback_count = 0;
+
+    request_manager.request_trade_history_result(
+        request,
+        account_type,
+        [&call, &callback_count](TradeHistoryApiResult history_result) {
+            call.result = std::move(history_result);
+            ++callback_count;
+        });
+
+    call.callback_count = callback_count;
+    call.callback_received = callback_count != 0;
     platform.shutdown();
     return call;
 }
@@ -622,7 +650,7 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsHtmlFailureStatus
         "blocked");
     ASSERT_TRUE(server.start());
 
-    const auto call = request_combined_trade_history(server);
+    const auto call = request_trade_history(server);
 
     ASSERT_TRUE(call.callback_received);
     ASSERT_EQ(call.callback_count, 1);
@@ -646,7 +674,7 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsCsvFailureStatus)
         empty_trade_history_html());
     ASSERT_TRUE(server.start());
 
-    const auto call = request_combined_trade_history(server);
+    const auto call = request_trade_history(server);
 
     ASSERT_TRUE(call.callback_received);
     ASSERT_EQ(call.callback_count, 1);
@@ -660,6 +688,110 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsCsvFailureStatus)
         std::string::npos);
     EXPECT_EQ(server.csv_requests.load(), 1);
     EXPECT_EQ(server.html_requests.load(), 1);
+}
+
+TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsBothFailureMessages) {
+    LocalTradeHistoryServer server(
+        500,
+        "csv failed",
+        451,
+        "blocked");
+    ASSERT_TRUE(server.start());
+
+    const auto call = request_trade_history(server);
+
+    ASSERT_TRUE(call.callback_received);
+    ASSERT_EQ(call.callback_count, 1);
+    EXPECT_FALSE(call.result);
+    EXPECT_EQ(call.result.status_code, 500);
+    EXPECT_NE(
+        call.result.error_message.find("CSV trade history"),
+        std::string::npos);
+    EXPECT_NE(
+        call.result.error_message.find("HTML trade history"),
+        std::string::npos);
+    EXPECT_NE(
+        call.result.error_message.find("failed validation"),
+        std::string::npos);
+    EXPECT_EQ(server.csv_requests.load(), 1);
+    EXPECT_EQ(server.html_requests.load(), 1);
+}
+
+TEST(IntradeBarApiResponses, CsvTradeHistoryRequestReportsDirectFailure) {
+    LocalTradeHistoryServer server(
+        500,
+        "server error",
+        200,
+        empty_trade_history_html());
+    ASSERT_TRUE(server.start());
+
+    const auto call = request_trade_history(server, TradeHistorySource::CSV);
+
+    ASSERT_TRUE(call.callback_received);
+    ASSERT_EQ(call.callback_count, 1);
+    EXPECT_FALSE(call.result);
+    EXPECT_EQ(call.result.status_code, 500);
+    EXPECT_EQ(
+        call.result.error_message,
+        "CSV trade history HTTP response failed validation.");
+    EXPECT_EQ(server.csv_requests.load(), 1);
+    EXPECT_EQ(server.html_requests.load(), 0);
+}
+
+TEST(IntradeBarApiResponses, HtmlTradeHistoryRequestReportsDirectFailure) {
+    LocalTradeHistoryServer server(
+        200,
+        valid_trade_history_csv(),
+        451,
+        "blocked");
+    ASSERT_TRUE(server.start());
+
+    const auto call = request_trade_history(server, TradeHistorySource::HTML);
+
+    ASSERT_TRUE(call.callback_received);
+    ASSERT_EQ(call.callback_count, 1);
+    EXPECT_FALSE(call.result);
+    EXPECT_EQ(call.result.status_code, 451);
+    EXPECT_EQ(
+        call.result.error_message,
+        "HTML trade history HTTP response failed validation.");
+    EXPECT_EQ(server.csv_requests.load(), 0);
+    EXPECT_EQ(server.html_requests.load(), 1);
+}
+
+TEST(IntradeBarApiResponses, TradeHistoryRequestRejectsInvalidRangeOrAccount) {
+    TradeHistoryRequest invalid_range = TradeHistoryRequest::all();
+    invalid_range.range_mode = TimeRangeMode::CLOSED;
+    invalid_range.start_ms = 2000;
+    invalid_range.stop_ms = 1000;
+
+    const auto invalid_range_call = request_trade_history_without_http(
+        invalid_range,
+        AccountType::DEMO);
+
+    ASSERT_TRUE(invalid_range_call.callback_received);
+    ASSERT_EQ(invalid_range_call.callback_count, 1);
+    EXPECT_FALSE(invalid_range_call.result);
+    EXPECT_EQ(
+        invalid_range_call.result.status_code,
+        TradeHistoryApiResult::NO_RESPONSE_STATUS);
+    EXPECT_EQ(
+        invalid_range_call.result.error_message,
+        "Invalid trade history request range or account type.");
+
+    const auto unknown_account_call = request_trade_history_without_http(
+        TradeHistoryRequest::all(),
+        AccountType::UNKNOWN);
+
+    ASSERT_TRUE(unknown_account_call.callback_received);
+    ASSERT_EQ(unknown_account_call.callback_count, 1);
+    EXPECT_FALSE(unknown_account_call.result);
+    EXPECT_EQ(
+        unknown_account_call.result.status_code,
+        TradeHistoryApiResult::NO_RESPONSE_STATUS);
+    EXPECT_EQ(
+        unknown_account_call.result.error_message,
+        "Invalid trade history request range or account type.");
 }
 
 TEST(IntradeBarApiResponses, HistoryRangeFilterExcludesRecordsWithoutSelectedTimestamp) {


### PR DESCRIPTION
## What Changed

- Made the typed Intrade Bar trade-history path (`request_trade_history_result`) the primary implementation.
- Kept the legacy bool/status/records `request_trade_history` API as a thin adapter over the typed result.
- Preserved source-specific error messages for CSV, HTML, HTML load-more, parse failures, invalid requests, and strict `HTML_CSV` combined failures.
- Documented `HTML_CSV` as a strict intersection mode where both sources must succeed and unmatched rows are omitted.
- Extended history request tests to assert that CSV/HTML failure diagnostics reach `TradeHistoryApiResult::error_message` for combined, direct CSV, direct HTML, double-failure, and invalid-request paths.

## Why

F-017/F-018: trade history failures previously collapsed to a generic `Failed to retrieve trade history.` message, so callers could not distinguish CSV HTTP/parse failures, HTML HTTP/parse failures, or strict `HTML_CSV` source failures without reading logs. The `HTML_CSV` source contract was also easy to misread as a fallback/union mode.

## Validation

- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` (40/40 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --target intrade_bar_smoke_cli -- -j1`
- `git diff --check`

Live broker smoke was not run; this PR changes offline request/result diagnostics and is covered by local HTTP fixture tests.