### PR TITLE
[codex] Harden core utility helpers

### DIFF
--- a/include/optionx_cpp/utils/fixed_point.hpp
+++ b/include/optionx_cpp/utils/fixed_point.hpp
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <array>
 #include <stdexcept>
-#include <limits>
 
 namespace optionx::utils {
 
@@ -49,8 +48,8 @@ namespace optionx::utils {
     }
 
     /// \brief Computes comparison tolerance for specified decimal precision.
-    /// \details Returns 10^(-digits), a full decimal step at the selected
-    /// precision, to account for floating-point and broker tick rounding noise.
+    /// \details Returns 0.5 * 10^(-digits), the half-step boundary used when
+    /// rounding values to the selected decimal precision.
     /// \param digits Number of significant decimal places (0-18)
     /// \return Tolerance value for floating-point comparisons
     /// \throw std::invalid_argument If digits exceed maximum supported precision
@@ -59,25 +58,25 @@ namespace optionx::utils {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }
         static const std::array<double, 19> tolerance = {
-            1.0,                // 10^0
-            0.1,                // 10^1
-            0.01,               // 10^2
-            0.001,              // 10^3
-            0.0001,             // 10^4
-            0.00001,            // 10^5
-            0.000001,           // 10^6
-            0.0000001,          // 10^7
-            0.00000001,         // 10^8
-            0.000000001,        // 10^9
-            0.0000000001,       // 10^10
-            0.00000000001,      // 10^11
-            0.000000000001,     // 10^12
-            0.0000000000001,    // 10^13
-            0.00000000000001,   // 10^14
-            0.000000000000001,  // 10^15
-            0.0000000000000001, // 10^16
-            0.00000000000000001,// 10^17
-            0.000000000000000001// 10^18
+            0.5,                 // 0.5 * 10^0
+            0.05,                // 0.5 * 10^-1
+            0.005,               // 0.5 * 10^-2
+            0.0005,              // 0.5 * 10^-3
+            0.00005,             // 0.5 * 10^-4
+            0.000005,            // 0.5 * 10^-5
+            0.0000005,           // 0.5 * 10^-6
+            0.00000005,          // 0.5 * 10^-7
+            0.000000005,         // 0.5 * 10^-8
+            0.0000000005,        // 0.5 * 10^-9
+            0.00000000005,       // 0.5 * 10^-10
+            0.000000000005,      // 0.5 * 10^-11
+            0.0000000000005,     // 0.5 * 10^-12
+            0.00000000000005,    // 0.5 * 10^-13
+            0.000000000000005,   // 0.5 * 10^-14
+            0.0000000000000005,  // 0.5 * 10^-15
+            0.00000000000000005, // 0.5 * 10^-16
+            0.000000000000000005,// 0.5 * 10^-17
+            0.0000000000000000005// 0.5 * 10^-18
         };
         return tolerance[digits];
     }
@@ -117,13 +116,7 @@ namespace optionx::utils {
         if (digits > 18) {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }
-        const double tolerance = precision_tolerance(digits);
-        const double delta = std::fabs(value1 - value2);
-        const double epsilon =
-            std::numeric_limits<double>::epsilon() *
-            (delta > tolerance ? delta : tolerance) *
-            8.0;
-        return delta <= tolerance + epsilon;
+        return normalize_double(value1, digits) == normalize_double(value2, digits);
     }
 
 } // namespace optionx::utils

--- a/include/optionx_cpp/utils/fixed_point.hpp
+++ b/include/optionx_cpp/utils/fixed_point.hpp
@@ -117,12 +117,13 @@ namespace optionx::utils {
         if (digits > 18) {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }
-        double tolerance = precision_tolerance(digits);
+        const double tolerance = precision_tolerance(digits);
+        const double delta = std::fabs(value1 - value2);
         const double epsilon =
             std::numeric_limits<double>::epsilon() *
-            (std::fabs(value1) + std::fabs(value2) + 1.0) *
+            (delta > tolerance ? delta : tolerance) *
             8.0;
-        return std::fabs(value1 - value2) <= tolerance + epsilon;
+        return delta <= tolerance + epsilon;
     }
 
 } // namespace optionx::utils

--- a/include/optionx_cpp/utils/fixed_point.hpp
+++ b/include/optionx_cpp/utils/fixed_point.hpp
@@ -105,12 +105,14 @@ namespace optionx::utils {
 		return static_cast<double>(value) / static_cast<double>(scale);
 	}
 
-	/// \brief Compares two floating-point values with specified precision.
-    /// \details Uses precomputed tolerance values to account for rounding errors.
+	/// \brief Compares two floating-point values after decimal rounding.
+    /// \details Each value is rounded with normalize_double(value, digits),
+    ///          then the rounded values are compared. A one-step price move at
+    ///          the selected precision is therefore treated as a real change.
     /// \param value1 First comparison operand
     /// \param value2 Second comparison operand
-    /// \param digits Number of decimal places to consider
-    /// \return true if |value1 - value2| <= tolerance, false otherwise
+    /// \param digits Number of decimal places to compare
+    /// \return true if both values round to the same value; false otherwise
     /// \throw std::invalid_argument If digits exceed maximum supported precision
     inline bool compare_with_precision(double value1, double value2, size_t digits) {
         if (digits > 18) {

--- a/include/optionx_cpp/utils/fixed_point.hpp
+++ b/include/optionx_cpp/utils/fixed_point.hpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <array>
 #include <stdexcept>
+#include <limits>
 
 namespace optionx::utils {
 
@@ -48,7 +49,8 @@ namespace optionx::utils {
     }
 
     /// \brief Computes comparison tolerance for specified decimal precision.
-    /// \details Returns 0.5 * 10^(-digits) to account for rounding errors.
+    /// \details Returns 10^(-digits), a full decimal step at the selected
+    /// precision, to account for floating-point and broker tick rounding noise.
     /// \param digits Number of significant decimal places (0-18)
     /// \return Tolerance value for floating-point comparisons
     /// \throw std::invalid_argument If digits exceed maximum supported precision
@@ -116,9 +118,13 @@ namespace optionx::utils {
             throw std::invalid_argument("Digits exceed maximum precision (18).");
         }
         double tolerance = precision_tolerance(digits);
-        return std::fabs(value1 - value2) <= tolerance;
+        const double epsilon =
+            std::numeric_limits<double>::epsilon() *
+            (std::fabs(value1) + std::fabs(value2) + 1.0) *
+            8.0;
+        return std::fabs(value1 - value2) <= tolerance + epsilon;
     }
 
-} // namespace dfh::utils
+} // namespace optionx::utils
 
 #endif // _OPTIONX_FIXED_POINT_HPP_INCLUDED

--- a/include/optionx_cpp/utils/http_utils.hpp
+++ b/include/optionx_cpp/utils/http_utils.hpp
@@ -30,31 +30,20 @@
 
 namespace optionx::utils {
 
-    /// \brief Removes the first occurrence of "https://" or "http://" from the given URL.
-    /// \param url The URL from which to remove the substring.
-    /// \return std::string The modified URL with the first occurrence of "https://" or "http://" removed.
+    /// \brief Removes an "https://" or "http://" prefix from the given URL.
+    /// \param url The URL from which to remove the scheme prefix.
+    /// \return The URL without a leading "https://" or "http://" scheme.
     inline std::string remove_http_prefix(const std::string& url) {
         const std::string https_prefix = "https://";
         const std::string http_prefix = "http://";
 
-        std::string modified_url = url;
-
-        // Find the position of "https://" or "http://"
-        std::size_t pos = modified_url.find(https_prefix);
-        if (pos == std::string::npos) {
-            pos = modified_url.find(http_prefix);
+        if (url.compare(0, https_prefix.length(), https_prefix) == 0) {
+            return url.substr(https_prefix.length());
         }
-
-        // If found, erase the substring
-        if (pos != std::string::npos) {
-            if (modified_url.compare(pos, https_prefix.length(), https_prefix) == 0) {
-                modified_url.erase(pos, https_prefix.length());
-            } else if (modified_url.compare(pos, http_prefix.length(), http_prefix) == 0) {
-                modified_url.erase(pos, http_prefix.length());
-            }
+        if (url.compare(0, http_prefix.length(), http_prefix) == 0) {
+            return url.substr(http_prefix.length());
         }
-
-        return modified_url;
+        return url;
     }
 
     /// \brief Builds a user-facing error string from an HTTP response.

--- a/include/optionx_cpp/utils/string_utils.hpp
+++ b/include/optionx_cpp/utils/string_utils.hpp
@@ -160,6 +160,7 @@ namespace optionx::utils {
     /// \param value Comma-separated string.
     /// \param items Vector to store parsed items.
     inline void parse_list(std::string value, std::vector<std::string> &items) noexcept {
+        if (value.empty()) return;
         if (value.back() != ',') value += ",";
         std::size_t start_pos = 0;
         while (true) {

--- a/tests/utils_core_test.cpp
+++ b/tests/utils_core_test.cpp
@@ -40,10 +40,11 @@ TEST(HttpUtilsTest, RemoveHttpPrefixOnlyRemovesLeadingScheme) {
         "prefixhttps://intrade.bar");
 }
 
-TEST(FixedPointUtilsTest, PrecisionToleranceUsesFullDecimalStep) {
-    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(0), 1.0);
-    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(2), 0.01);
-    EXPECT_TRUE(optionx::utils::compare_with_precision(1.00, 1.01, 2));
+TEST(FixedPointUtilsTest, PrecisionToleranceUsesHalfDecimalStep) {
+    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(0), 0.5);
+    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(2), 0.005);
+    EXPECT_TRUE(optionx::utils::compare_with_precision(1.00, 1.004, 2));
+    EXPECT_FALSE(optionx::utils::compare_with_precision(1.00, 1.01, 2));
     EXPECT_FALSE(optionx::utils::compare_with_precision(1.00, 1.02, 2));
     EXPECT_FALSE(optionx::utils::compare_with_precision(1e14, 1e14 + 0.25, 2));
     EXPECT_THROW(

--- a/tests/utils_core_test.cpp
+++ b/tests/utils_core_test.cpp
@@ -45,6 +45,7 @@ TEST(FixedPointUtilsTest, PrecisionToleranceUsesFullDecimalStep) {
     EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(2), 0.01);
     EXPECT_TRUE(optionx::utils::compare_with_precision(1.00, 1.01, 2));
     EXPECT_FALSE(optionx::utils::compare_with_precision(1.00, 1.02, 2));
+    EXPECT_FALSE(optionx::utils::compare_with_precision(1e14, 1e14 + 0.25, 2));
     EXPECT_THROW(
         optionx::utils::precision_tolerance(19),
         std::invalid_argument);

--- a/tests/utils_core_test.cpp
+++ b/tests/utils_core_test.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <optionx_cpp/utils.hpp>
+
+TEST(StringUtilsTest, ParseListIgnoresEmptyInput) {
+    std::vector<std::string> items{"existing"};
+
+    optionx::utils::parse_list("", items);
+
+    ASSERT_EQ(items.size(), 1u);
+    EXPECT_EQ(items[0], "existing");
+}
+
+TEST(StringUtilsTest, ParseListSkipsEmptyItems) {
+    std::vector<std::string> items;
+
+    optionx::utils::parse_list("one,,two,", items);
+
+    ASSERT_EQ(items.size(), 2u);
+    EXPECT_EQ(items[0], "one");
+    EXPECT_EQ(items[1], "two");
+}
+
+TEST(HttpUtilsTest, RemoveHttpPrefixOnlyRemovesLeadingScheme) {
+    EXPECT_EQ(
+        optionx::utils::remove_http_prefix("https://intrade.bar"),
+        "intrade.bar");
+    EXPECT_EQ(
+        optionx::utils::remove_http_prefix("http://intrade.bar"),
+        "intrade.bar");
+    EXPECT_EQ(
+        optionx::utils::remove_http_prefix("wss://intrade.bar"),
+        "wss://intrade.bar");
+    EXPECT_EQ(
+        optionx::utils::remove_http_prefix("prefixhttps://intrade.bar"),
+        "prefixhttps://intrade.bar");
+}
+
+TEST(FixedPointUtilsTest, PrecisionToleranceUsesFullDecimalStep) {
+    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(0), 1.0);
+    EXPECT_DOUBLE_EQ(optionx::utils::precision_tolerance(2), 0.01);
+    EXPECT_TRUE(optionx::utils::compare_with_precision(1.00, 1.01, 2));
+    EXPECT_FALSE(optionx::utils::compare_with_precision(1.00, 1.02, 2));
+    EXPECT_THROW(
+        optionx::utils::precision_tolerance(19),
+        std::invalid_argument);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What Changed

- Made `utils::parse_list()` safely ignore empty input instead of reading `back()` on an empty string.
- Made `utils::remove_http_prefix()` remove only leading `http://` / `https://` schemes, matching the helper name and docs.
- Restored `precision_tolerance()` to the documented half-step tolerance and made `compare_with_precision()` compare values after rounding to the requested decimal precision.
- Updated `compare_with_precision()` docs to describe the rounded-value comparison semantics.
- Added `utils_core_test` coverage for list parsing, URL prefix removal, and fixed-point comparison semantics, including the important one-tick price-change case.

## Why

This addresses the next small refactor-audit batch:

- F-019: empty `parse_list()` input was undefined behavior.
- F-020: fixed-point tolerance docs did not match the implementation; one full tick should be treated as a price update by `PriceManager`.
- F-021: `remove_http_prefix()` removed embedded schemes even though it is a prefix helper.

## Validation

- `cmake -S . -B build-codex -DBUILD_TESTS=ON`
- `cmake --build build-codex --target utils_core_test -- -j1`
- `./build-codex/utils_core_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `cmake --build build-codex --target utils_task_manager_test -- -j1`
- `./build-codex/utils_task_manager_test.exe --gtest_brief=1` (7/7 passed)
- `git diff --check`

CMake still reports the existing external libmdbx/AES warnings; no new project warnings were introduced by this PR.