### PR TITLE
[codex] Keep account-info duration width

### DIFF
--- a/include/optionx_cpp/data/account/AccountInfoRequest.hpp
+++ b/include/optionx_cpp/data/account/AccountInfoRequest.hpp
@@ -21,7 +21,7 @@ namespace optionx {
         CurrencyType    currency    = CurrencyType::UNKNOWN;    ///< Account currency, if supported.
         OptionType      option_type = OptionType::UNKNOWN;      ///< Option type.
         OrderType       order_type  = OrderType::UNKNOWN;       ///< Order type.
-        int             duration    = 0;                        ///< Option duration.
+        int64_t         duration    = 0;                        ///< Option duration in seconds.
         int64_t         expiry_time = 0;                        ///< Expiration timestamp (Unix, sec).
         int64_t         timestamp   = 0;                        ///< General timestamp (Unix, sec).
 

--- a/include/optionx_cpp/modules.hpp
+++ b/include/optionx_cpp/modules.hpp
@@ -3,7 +3,7 @@
 #define _OPTIONX_MODULES_HPP_INCLUDED
 
 /// \file modules.hpp
-/// \brief
+/// \brief Public aggregate header for reusable platform modules.
 
 #include "utils.hpp"
 #include "data.hpp"
@@ -11,17 +11,5 @@
 #include "modules/BaseTradeExecutionModule.hpp"
 #include "modules/BaseHttpClientModule.hpp"
 #include "modules/BaseAccountInfoHandler.hpp"
-/*
-#include "utils.hpp"
-#include "pubsub.hpp"
-#include "interfaces.hpp"
-#include "modules/events.hpp"
-#include "modules/base.hpp"
-#include "modules/BaseAuthManagerModule.hpp"
-#include "modules/BaseAccountInfoModule.hpp"
-#include "modules/BaseConnectionManagerModule.hpp"
-#include "modules/BaseHttpClientModule.hpp"
-#include "modules/TradeManagerModule.hpp"
-*/
 
 #endif // _OPTIONX_MODULES_HPP_INCLUDED

--- a/include/optionx_cpp/storages/ServiceSessionDB.hpp
+++ b/include/optionx_cpp/storages/ServiceSessionDB.hpp
@@ -44,7 +44,7 @@
 namespace optionx::storage {
 
     /// \class ServiceSessionDB
-    /// \brief Manages session data storage and retrieval using an SQLite database.
+    /// \brief Manages encrypted broker session data using an MDBX key-value table.
     class ServiceSessionDB {
     public:
 
@@ -177,7 +177,7 @@ namespace optionx::storage {
     private:
         mutable std::mutex m_mutex; ///< Mutex for thread safety.
         crypto::AESCrypt m_aes;   ///< AES encryption and decryption instance.
-        std::unique_ptr<mdbxc::KeyValueTable<std::string, std::string>> m_db; ///< The SQLite KeyValueDB instance.
+        std::unique_ptr<mdbxc::KeyValueTable<std::string, std::string>> m_db; ///< MDBX-backed session key-value table.
 
         /// \brief Private constructor for singleton pattern.
         ServiceSessionDB() : m_aes(crypto::AesMode::CBC_256) {

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <string>
 #include <thread>
@@ -425,6 +426,22 @@ TEST(IntradeBarAccountInfo, AcceptsBtcAliasAndUsesBtcDurationRules) {
     EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.start_time);
     request.type = AccountInfoType::END_TIME;
     EXPECT_EQ(account.get_info<int64_t>(request), day_start + account.end_time);
+}
+
+TEST(IntradeBarAccountInfo, AccountInfoRequestKeepsTradeDurationWidth) {
+    TradeRequest trade_request;
+    trade_request.duration =
+        static_cast<int64_t>(std::numeric_limits<int>::max()) + 42;
+
+    const AccountInfoRequest by_reference(
+        trade_request,
+        AccountInfoType::DURATION_AVAILABLE);
+    EXPECT_EQ(by_reference.duration, trade_request.duration);
+
+    const AccountInfoRequest by_pointer(
+        &trade_request,
+        AccountInfoType::DURATION_AVAILABLE);
+    EXPECT_EQ(by_pointer.duration, trade_request.duration);
 }
 
 TEST(IntradeBarTradeExecution, NormalizesBtcAliasBeforeQueueProcessing) {


### PR DESCRIPTION
## What Changed

- Changed `AccountInfoRequest::duration` from `int` to `int64_t` so it preserves the width of `TradeRequest::duration`.
- Added a regression test that copies a duration larger than `int::max()` through `AccountInfoRequest` constructors.
- Updated stale public docs in `ServiceSessionDB` from SQLite wording to MDBX key-value storage.
- Cleaned the `modules.hpp` public aggregate brief and removed the old commented include block.

## Why

F-028: `AccountInfoRequest::set_data()` silently narrowed `TradeRequest::duration` from `int64_t` to `int`, which could truncate defensive or future long-duration validation requests.

The documentation cleanup also addresses the still-current parts of F-002 and F-024 without changing runtime behavior.

## Validation

- `cmake --build build-codex --target intrade_bar_api_response_test -- -j1`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` (41/41 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `git diff --check`

CMake/build still reports existing external libmdbx/AES warnings only.