### PR TITLE
[codex] Make trade statistics populations consistent

### DIFF
--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -69,15 +69,35 @@ namespace optionx {
         std::string metadata_json;                          ///< Future extension data.
 
         // Flags
-        std::uint8_t flags = 0;                             ///< Bit flags (bit 0 = last_in_group).
+        std::uint8_t flags = 0;                             ///< Bit flags for grouping and optional snapshots.
         static constexpr std::uint8_t FLAG_LAST_IN_GROUP = 0x01;
+        static constexpr std::uint8_t FLAG_HAS_OPEN_BALANCE = 0x02;
+        static constexpr std::uint8_t FLAG_HAS_CLOSE_BALANCE = 0x04;
 
         /// \brief Returns true if this record is the last in its money-management group.
         bool last_in_group() const noexcept { return (flags & FLAG_LAST_IN_GROUP) != 0; }
 
+        /// \brief Returns true when open_balance contains an explicit snapshot.
+        bool has_open_balance() const noexcept { return (flags & FLAG_HAS_OPEN_BALANCE) != 0; }
+
+        /// \brief Returns true when close_balance contains a close-equivalent value.
+        bool has_close_balance() const noexcept { return (flags & FLAG_HAS_CLOSE_BALANCE) != 0; }
+
         /// \brief Sets or clears the last-in-group flag.
         void set_last_in_group(bool v) noexcept {
             flags = v ? (flags | FLAG_LAST_IN_GROUP) : (flags & ~FLAG_LAST_IN_GROUP);
+        }
+
+        /// \brief Stores the account balance before opening the trade.
+        void set_open_balance(double value) noexcept {
+            open_balance = value;
+            flags |= FLAG_HAS_OPEN_BALANCE;
+        }
+
+        /// \brief Stores the known or estimated close-equivalent balance.
+        void set_close_balance(double value) noexcept {
+            close_balance = value;
+            flags |= FLAG_HAS_CLOSE_BALANCE;
         }
 
         // Spread
@@ -117,15 +137,13 @@ namespace optionx {
             if (result.amount > 0.0) amount = result.amount;
             payout = result.payout;
             profit = result.profit;
-            open_balance = result.open_balance;
-            if (result.close_balance != 0.0) {
-                close_balance = result.close_balance;
-            } else if (result.balance != 0.0) {
-                close_balance = result.balance;
-            } else if (result.open_balance != 0.0) {
-                close_balance = result.open_balance + result.profit;
-            } else {
-                close_balance = 0.0;
+            if (result.has_open_balance()) {
+                set_open_balance(result.open_balance);
+            }
+            if (result.has_close_balance()) {
+                set_close_balance(result.close_balance);
+            } else if (has_open_balance() && result_has_balance_projection(result)) {
+                set_close_balance(open_balance + result.profit);
             }
             open_price = result.open_price;
             close_price = result.close_price;
@@ -322,15 +340,12 @@ namespace optionx {
             if (version == 1 || version == 2) {
                 legacy_balance = reader.read<double>();
                 if (version == 1) {
-                    record.close_balance = legacy_balance;
+                    record.set_close_balance(legacy_balance);
                 }
             }
             if (version >= 2) {
                 record.open_balance = reader.read<double>();
                 record.close_balance = reader.read<double>();
-                if (record.close_balance == 0.0) {
-                    record.close_balance = legacy_balance;
-                }
             }
 
             record.trade_state = reader.read_enum8<TradeState>();
@@ -358,6 +373,17 @@ namespace optionx {
             record.metadata_json = reader.read_string();
 
             record.flags = reader.read<std::uint8_t>();
+            if (version < 3) {
+                if (record.open_balance != 0.0) {
+                    record.flags |= FLAG_HAS_OPEN_BALANCE;
+                }
+                if (version == 1 || record.close_balance != 0.0 || legacy_balance != 0.0) {
+                    record.flags |= FLAG_HAS_CLOSE_BALANCE;
+                    if (version == 2 && record.close_balance == 0.0) {
+                        record.close_balance = legacy_balance;
+                    }
+                }
+            }
 
             record.spread.raw = reader.read<std::uint64_t>();
             record.spread.digits = reader.read<std::uint8_t>();
@@ -430,6 +456,13 @@ namespace optionx {
 
         static bool same_known(const std::string& lhs, const std::string& rhs) noexcept {
             return lhs.empty() || rhs.empty() || lhs == rhs;
+        }
+
+        static bool result_has_balance_projection(const TradeResult& result) noexcept {
+            return result.trade_state == TradeState::WIN ||
+                   result.trade_state == TradeState::LOSS ||
+                   result.trade_state == TradeState::STANDOFF ||
+                   result.trade_state == TradeState::REFUND;
         }
 
         template<typename T>

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -38,9 +38,8 @@ namespace optionx {
         double min_payout = 0.0;                            ///< Minimum acceptable payout.
         double payout = 0.0;                                ///< Actual payout ratio.
         double profit = 0.0;                                ///< Final or current profit/loss.
-        double balance = 0.0;                               ///< Legacy latest/final account balance snapshot.
-        double open_balance = 0.0;                          ///< Account balance snapshot near trade opening.
-        double close_balance = 0.0;                         ///< Account balance snapshot after trade close/result.
+        double open_balance = 0.0;                          ///< Account balance before opening the trade.
+        double close_balance = 0.0;                         ///< Known or estimated close-equivalent balance.
 
         // State and error details
         TradeState trade_state = TradeState::UNKNOWN;       ///< Current trade lifecycle state.
@@ -118,11 +117,16 @@ namespace optionx {
             if (result.amount > 0.0) amount = result.amount;
             payout = result.payout;
             profit = result.profit;
-            balance = result.balance != 0.0 ? result.balance : result.close_balance;
             open_balance = result.open_balance;
-            close_balance = result.close_balance != 0.0
-                ? result.close_balance
-                : balance;
+            if (result.close_balance != 0.0) {
+                close_balance = result.close_balance;
+            } else if (result.balance != 0.0) {
+                close_balance = result.balance;
+            } else if (result.open_balance != 0.0) {
+                close_balance = result.open_balance + result.profit;
+            } else {
+                close_balance = 0.0;
+            }
             open_price = result.open_price;
             close_price = result.close_price;
             delay = result.delay;
@@ -243,7 +247,6 @@ namespace optionx {
             append_value(bytes, min_payout);
             append_value(bytes, payout);
             append_value(bytes, profit);
-            append_value(bytes, balance);
             append_value(bytes, open_balance);
             append_value(bytes, close_balance);
 
@@ -288,7 +291,7 @@ namespace optionx {
             }
 
             const auto version = reader.read<std::uint16_t>();
-            if (version != 1 && version != kBinaryVersion) {
+            if (version < 1 || version > kBinaryVersion) {
                 throw std::runtime_error("TradeRecord::from_bytes: unsupported version");
             }
 
@@ -315,12 +318,19 @@ namespace optionx {
             record.min_payout = reader.read<double>();
             record.payout = reader.read<double>();
             record.profit = reader.read<double>();
-            record.balance = reader.read<double>();
+            double legacy_balance = 0.0;
+            if (version == 1 || version == 2) {
+                legacy_balance = reader.read<double>();
+                if (version == 1) {
+                    record.close_balance = legacy_balance;
+                }
+            }
             if (version >= 2) {
                 record.open_balance = reader.read<double>();
                 record.close_balance = reader.read<double>();
-            } else {
-                record.close_balance = record.balance;
+                if (record.close_balance == 0.0) {
+                    record.close_balance = legacy_balance;
+                }
             }
 
             record.trade_state = reader.read_enum8<TradeState>();
@@ -377,7 +387,6 @@ namespace optionx {
                    min_payout == other.min_payout &&
                    payout == other.payout &&
                    profit == other.profit &&
-                   balance == other.balance &&
                    open_balance == other.open_balance &&
                    close_balance == other.close_balance &&
                    trade_state == other.trade_state &&
@@ -412,7 +421,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 2;
+        static constexpr std::uint16_t kBinaryVersion = 3;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -38,7 +38,9 @@ namespace optionx {
         double min_payout = 0.0;                            ///< Minimum acceptable payout.
         double payout = 0.0;                                ///< Actual payout ratio.
         double profit = 0.0;                                ///< Final or current profit/loss.
-        double balance = 0.0;                               ///< Account balance snapshot.
+        double balance = 0.0;                               ///< Legacy latest/final account balance snapshot.
+        double open_balance = 0.0;                          ///< Account balance snapshot near trade opening.
+        double close_balance = 0.0;                         ///< Account balance snapshot after trade close/result.
 
         // State and error details
         TradeState trade_state = TradeState::UNKNOWN;       ///< Current trade lifecycle state.
@@ -116,7 +118,11 @@ namespace optionx {
             if (result.amount > 0.0) amount = result.amount;
             payout = result.payout;
             profit = result.profit;
-            balance = result.balance;
+            balance = result.balance != 0.0 ? result.balance : result.close_balance;
+            open_balance = result.open_balance;
+            close_balance = result.close_balance != 0.0
+                ? result.close_balance
+                : balance;
             open_price = result.open_price;
             close_price = result.close_price;
             delay = result.delay;
@@ -238,6 +244,8 @@ namespace optionx {
             append_value(bytes, payout);
             append_value(bytes, profit);
             append_value(bytes, balance);
+            append_value(bytes, open_balance);
+            append_value(bytes, close_balance);
 
             append_enum8(bytes, trade_state);
             append_enum8(bytes, live_state);
@@ -280,7 +288,7 @@ namespace optionx {
             }
 
             const auto version = reader.read<std::uint16_t>();
-            if (version != kBinaryVersion) {
+            if (version != 1 && version != kBinaryVersion) {
                 throw std::runtime_error("TradeRecord::from_bytes: unsupported version");
             }
 
@@ -308,6 +316,12 @@ namespace optionx {
             record.payout = reader.read<double>();
             record.profit = reader.read<double>();
             record.balance = reader.read<double>();
+            if (version >= 2) {
+                record.open_balance = reader.read<double>();
+                record.close_balance = reader.read<double>();
+            } else {
+                record.close_balance = record.balance;
+            }
 
             record.trade_state = reader.read_enum8<TradeState>();
             record.live_state = reader.read_enum8<TradeState>();
@@ -364,6 +378,8 @@ namespace optionx {
                    payout == other.payout &&
                    profit == other.profit &&
                    balance == other.balance &&
+                   open_balance == other.open_balance &&
+                   close_balance == other.close_balance &&
                    trade_state == other.trade_state &&
                    live_state == other.live_state &&
                    error_code == other.error_code &&
@@ -396,7 +412,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 1;
+        static constexpr std::uint16_t kBinaryVersion = 2;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -96,8 +96,8 @@ namespace optionx {
         double max_payout = 0.0;
         double min_profit = 0.0;
         double max_profit = 0.0;
-        double min_balance = 0.0;
-        double max_balance = 0.0;
+        double min_balance = 0.0; ///< Minimum close-equivalent balance.
+        double max_balance = 0.0; ///< Maximum close-equivalent balance.
 
         std::int64_t min_ping = 0;
         std::int64_t max_ping = 0;

--- a/include/optionx_cpp/data/trading/TradeResult.hpp
+++ b/include/optionx_cpp/data/trading/TradeResult.hpp
@@ -6,6 +6,7 @@
 /// \brief Contains the TradeResult class representing the result of a trade request.
 
 #include <nlohmann/json.hpp>
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -35,6 +36,10 @@ namespace optionx {
         double balance = 0.0;       ///< Latest known account balance snapshot.
         double open_balance = 0.0;  ///< Account balance before opening the trade.
         double close_balance = 0.0; ///< Known or estimated close-equivalent balance.
+        std::uint8_t balance_flags = 0; ///< Presence flags for balance snapshots.
+        static constexpr std::uint8_t BALANCE_FLAG_HAS_BALANCE = 0x01;
+        static constexpr std::uint8_t BALANCE_FLAG_HAS_OPEN_BALANCE = 0x02;
+        static constexpr std::uint8_t BALANCE_FLAG_HAS_CLOSE_BALANCE = 0x04;
 
         // Price information
         double open_price = 0.0;    ///< Entry price at position opening
@@ -59,6 +64,39 @@ namespace optionx {
 
         // Spread
         SpreadPack spread;                                     ///< Packed open/close spread data
+
+        /// \brief Returns true when balance contains an explicit latest snapshot.
+        bool has_balance() const noexcept {
+            return (balance_flags & BALANCE_FLAG_HAS_BALANCE) != 0;
+        }
+
+        /// \brief Returns true when open_balance contains an explicit snapshot.
+        bool has_open_balance() const noexcept {
+            return (balance_flags & BALANCE_FLAG_HAS_OPEN_BALANCE) != 0;
+        }
+
+        /// \brief Returns true when close_balance contains an explicit close-equivalent value.
+        bool has_close_balance() const noexcept {
+            return (balance_flags & BALANCE_FLAG_HAS_CLOSE_BALANCE) != 0;
+        }
+
+        /// \brief Stores the latest known account balance snapshot.
+        void set_balance(double value) noexcept {
+            balance = value;
+            balance_flags |= BALANCE_FLAG_HAS_BALANCE;
+        }
+
+        /// \brief Stores the account balance before opening the trade.
+        void set_open_balance(double value) noexcept {
+            open_balance = value;
+            balance_flags |= BALANCE_FLAG_HAS_OPEN_BALANCE;
+        }
+
+        /// \brief Stores the known or estimated close-equivalent balance.
+        void set_close_balance(double value) noexcept {
+            close_balance = value;
+            balance_flags |= BALANCE_FLAG_HAS_CLOSE_BALANCE;
+        }
 
         /// \brief Creates a unique pointer to a copy of this TradeResult
         virtual std::unique_ptr<TradeResult> clone_unique() const {
@@ -86,6 +124,7 @@ namespace optionx {
             balance,
             open_balance,
             close_balance,
+            balance_flags,
             open_price,
             close_price,
             delay,

--- a/include/optionx_cpp/data/trading/TradeResult.hpp
+++ b/include/optionx_cpp/data/trading/TradeResult.hpp
@@ -32,7 +32,9 @@ namespace optionx {
         double amount = 0.0;        ///< Total investment amount
         double payout = 0.0;        ///< Payout ratio (0.0-1.0)
         double profit = 0.0;        ///< Calculated profit/loss
-        double balance = 0.0;       ///< Current account balance
+        double balance = 0.0;       ///< Legacy latest account balance snapshot.
+        double open_balance = 0.0;  ///< Account balance snapshot near trade opening.
+        double close_balance = 0.0; ///< Account balance snapshot after trade close/result.
 
         // Price information
         double open_price = 0.0;    ///< Entry price at position opening
@@ -82,6 +84,8 @@ namespace optionx {
             payout,
             profit,
             balance,
+            open_balance,
+            close_balance,
             open_price,
             close_price,
             delay,

--- a/include/optionx_cpp/data/trading/TradeResult.hpp
+++ b/include/optionx_cpp/data/trading/TradeResult.hpp
@@ -32,9 +32,9 @@ namespace optionx {
         double amount = 0.0;        ///< Total investment amount
         double payout = 0.0;        ///< Payout ratio (0.0-1.0)
         double profit = 0.0;        ///< Calculated profit/loss
-        double balance = 0.0;       ///< Legacy latest account balance snapshot.
-        double open_balance = 0.0;  ///< Account balance snapshot near trade opening.
-        double close_balance = 0.0; ///< Account balance snapshot after trade close/result.
+        double balance = 0.0;       ///< Latest known account balance snapshot.
+        double open_balance = 0.0;  ///< Account balance before opening the trade.
+        double close_balance = 0.0; ///< Known or estimated close-equivalent balance.
 
         // Price information
         double open_price = 0.0;    ///< Entry price at position opening

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -142,6 +142,7 @@ namespace optionx {
         TradeChartData equity_curve;
         TradeChartData free_funds_curve;
         TradeChartData profit_curve;
+        TradeChartData profit_percent_curve; ///< Cumulative net PnL as percent of start_balance when start_balance > 0.
         TradeChartData daily_profit;
         TradeChartData hourly_profit;
 
@@ -157,10 +158,10 @@ namespace optionx {
     };
 
     /// \enum TradeStatsInputOrder
-    /// \brief Hint about the order of input records.
+    /// \brief Legacy hint about the order of input records.
     enum class TradeStatsInputOrder {
         AS_IS,           ///< Records may be in any order; realized curves and series are sorted internally.
-        PLACE_DATE_ASC   ///< Records are already in the caller's intended chronological order.
+        PLACE_DATE_ASC   ///< Deprecated hint; realized statistics are still ordered by result timestamp.
     };
 
     /// \class TradeStatsConfig

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "enums.hpp"
@@ -151,10 +152,55 @@ namespace optionx {
     };
 
     /// \enum TradeStatsBalanceMode
-    /// \brief Controls how equity / drawdown curves are computed.
+    /// \brief Controls optional free-funds curve computation.
     enum class TradeStatsBalanceMode {
-        SIMPLE,     ///< Classic realized-profit curve (balance += profit on close).
-        SWEEP_LINE  ///< Event-driven free-funds curve (locks amount on open, releases on close).
+        SIMPLE,     ///< Do not build an event-driven free-funds curve.
+        SWEEP_LINE  ///< Build free funds from open/close cash-lock events.
+    };
+
+    /// \enum TradeStatsEquityMode
+    /// \brief Selects the source used for equity/profit/drawdown curves.
+    enum class TradeStatsEquityMode {
+        SYNTHETIC_PROFIT, ///< start_balance plus cumulative realized profit.
+        RECORD_BALANCE,   ///< Single-account curve from TradeRecord close balance snapshots.
+        PORTFOLIO_BALANCE ///< Multi-account curve from per-account balance snapshots.
+    };
+
+    /// \class TradeCurrencyConversionMatrix
+    /// \brief Static currency conversion rates for portfolio statistics.
+    class TradeCurrencyConversionMatrix {
+    public:
+        CurrencyType base_currency = CurrencyType::UNKNOWN; ///< Reporting currency for converted values.
+        std::map<std::pair<CurrencyType, CurrencyType>, double> rates; ///< Pair(from, to) -> multiplier.
+
+        /// \brief Sets a direct conversion multiplier.
+        void set_rate(CurrencyType from, CurrencyType to, double rate) {
+            rates[{from, to}] = rate;
+        }
+
+        /// \brief Converts a value between currencies, using inverse rates when possible.
+        double convert(double value, CurrencyType from, CurrencyType to) const {
+            if (from == to || from == CurrencyType::UNKNOWN || to == CurrencyType::UNKNOWN) {
+                return value;
+            }
+
+            const auto direct = rates.find({from, to});
+            if (direct != rates.end()) {
+                return value * direct->second;
+            }
+
+            const auto inverse = rates.find({to, from});
+            if (inverse != rates.end() && inverse->second != 0.0) {
+                return value / inverse->second;
+            }
+
+            return value;
+        }
+
+        /// \brief Converts a value to base_currency when it is configured.
+        double convert_to_base(double value, CurrencyType from) const {
+            return convert(value, from, base_currency);
+        }
     };
 
     /// \enum TradeStatsInputOrder
@@ -175,6 +221,10 @@ namespace optionx {
         bool include_errors = false;
         bool include_non_terminal = false;
         std::function<double(double value, CurrencyType from)> convert; ///< Optional currency converter.
+        std::function<double(double value, CurrencyType from, CurrencyType to, std::int64_t timestamp_ms)>
+            convert_currency; ///< Optional timestamp-aware converter.
+        TradeCurrencyConversionMatrix currency_matrix; ///< Static rates for multi-currency statistics.
+        TradeStatsEquityMode equity_mode = TradeStatsEquityMode::SYNTHETIC_PROFIT;
         TradeStatsBalanceMode balance_mode = TradeStatsBalanceMode::SWEEP_LINE;
         TradeStatsInputOrder input_order = TradeStatsInputOrder::AS_IS;
     };

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -21,7 +21,7 @@
 namespace optionx {
 
     /// \enum TradeStatsSelection
-    /// \brief Controls which subset of trades contributes to outcome statistics.
+    /// \brief Controls which subset of trades contributes to selected result statistics.
     enum class TradeStatsSelection {
         ALL_TRADES,      ///< Include every trade.
         FIRST_MM_STEP,   ///< Include only trades with mm_step == 0.
@@ -124,9 +124,9 @@ namespace optionx {
         double gross_loss = 0.0;              ///< Sum of negative profits (absolute).
         double profit_factor = 0.0;           ///< gross_profit / gross_loss (0 when no loss).
 
-        double average_amount = 0.0;          ///< total_volume / total.trades.
-        double average_profit = 0.0;          ///< total_profit / result trades count.
-        double average_profit_per_trade = 0.0; ///< total_profit / total.trades.
+        double average_amount = 0.0;          ///< total_volume / selected monetary result trades count.
+        double average_profit = 0.0;          ///< total_profit / selected monetary result trades count.
+        double average_profit_per_trade = 0.0; ///< Alias-style per-trade average over selected monetary result trades.
 
         double max_profit_trade = 0.0;
         double max_loss_trade = 0.0;
@@ -159,8 +159,8 @@ namespace optionx {
     /// \enum TradeStatsInputOrder
     /// \brief Hint about the order of input records.
     enum class TradeStatsInputOrder {
-        AS_IS,           ///< Records may be in any order; sweep-line sorts internally.
-        PLACE_DATE_ASC   ///< Records are already sorted by place_date ascending.
+        AS_IS,           ///< Records may be in any order; realized curves and series are sorted internally.
+        PLACE_DATE_ASC   ///< Records are already in the caller's intended chronological order.
     };
 
     /// \class TradeStatsConfig

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
@@ -323,6 +323,7 @@ namespace optionx::modules {
                 result->trade_state = result->live_state = TradeState::WAITING_OPEN;
                 result->send_date   = OPTIONX_TIMESTAMP_MS;
                 result->balance     = m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request);
+                result->open_balance = result->balance;
                 result->payout      = m_account_info.get_for_trade<double>(AccountInfoType::PAYOUT, request, time_shield::ms_to_sec(result->send_date));
 
                 m_last_order_time = std::chrono::steady_clock::now();

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
@@ -157,6 +157,11 @@ namespace optionx::modules {
         int64_t                  m_snapshot_unknown_close_trades = 0; ///< Snapshot trades without a known close time.
         bool                     m_snapshot_refresh_requested = false; ///< True after emitting a refresh request for current snapshot state.
         std::vector<int64_t>     m_snapshot_close_due_times_ms; ///< Close timestamps with the configured safety buffer.
+        bool                     m_has_trade_storm_balance = false; ///< True when a local trade burst baseline is active.
+        double                   m_trade_storm_base_balance = 0.0; ///< Trusted balance captured before a local trade burst.
+        double                   m_trade_storm_realized_profit = 0.0; ///< Realized profit within the active local trade burst.
+        int64_t                  m_last_trade_activity_ms = 0; ///< Last local trade open/finalize timestamp.
+        static constexpr int64_t kTradeStormIdleMs = time_shield::MS_PER_15_SEC; ///< Quiet period before trusting a fresh balance.
 
         /// \brief Dispatches a trade event notification.
         /// \param transaction The trade transaction event to be dispatched.
@@ -178,6 +183,17 @@ namespace optionx::modules {
         /// \brief Requests a broker snapshot refresh once for the current snapshot state.
         /// \param reason Human-readable refresh reason.
         void request_snapshot_refresh(const char* reason);
+
+        /// \brief Returns the projected equity-like balance before opening the next local trade.
+        double next_open_balance(
+                int64_t timestamp_ms,
+                double account_balance);
+
+        /// \brief Adds realized result profit to the current local trade burst.
+        void add_realized_profit_to_storm(const std::shared_ptr<TradeResult>& result);
+
+        /// \brief Returns true if a trade state has a monetary result.
+        static bool is_result_state_for_balance(TradeState state) noexcept;
 
         /// \brief Adds a close buffer to a close timestamp without overflowing.
         /// \param close_time_ms Close timestamp in milliseconds.
@@ -322,8 +338,10 @@ namespace optionx::modules {
                 LOGIT_0TRACE();
                 result->trade_state = result->live_state = TradeState::WAITING_OPEN;
                 result->send_date   = OPTIONX_TIMESTAMP_MS;
-                result->balance     = m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request);
-                result->open_balance = result->balance;
+                const double account_balance =
+                    m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request);
+                result->set_balance(account_balance);
+                result->set_open_balance(next_open_balance(result->send_date, account_balance));
                 result->payout      = m_account_info.get_for_trade<double>(AccountInfoType::PAYOUT, request, time_shield::ms_to_sec(result->send_date));
 
                 m_last_order_time = std::chrono::steady_clock::now();
@@ -459,12 +477,17 @@ namespace optionx::modules {
         }
 
         m_has_sent_order = false;
+        m_has_trade_storm_balance = false;
+        m_trade_storm_base_balance = 0.0;
+        m_trade_storm_realized_profit = 0.0;
+        m_last_trade_activity_ms = timestamp;
     }
 
     inline void TradeQueueManager::increment_open_trades(
         const std::shared_ptr<TradeRequest>& request,
         const std::shared_ptr<TradeResult>& result) {
         m_local_open_trades++;
+        m_last_trade_activity_ms = OPTIONX_TIMESTAMP_MS;
         emit_open_trades(request, result);
     }
 
@@ -472,7 +495,9 @@ namespace optionx::modules {
         const std::shared_ptr<TradeRequest>& request,
         const std::shared_ptr<TradeResult>& result) {
         if (m_local_open_trades > 0) {
+            add_realized_profit_to_storm(result);
             m_local_open_trades--;
+            m_last_trade_activity_ms = OPTIONX_TIMESTAMP_MS;
             emit_open_trades(request, result);
         }
     }
@@ -544,6 +569,40 @@ namespace optionx::modules {
         if (m_snapshot_refresh_requested) return;
         m_snapshot_refresh_requested = true;
         notify(events::OpenTradesSnapshotRefreshRequestEvent(reason ? reason : ""));
+    }
+
+    inline double TradeQueueManager::next_open_balance(
+            int64_t timestamp_ms,
+            double account_balance) {
+        const bool local_queue_idle =
+            m_local_open_trades <= 0 && m_open_transactions.empty();
+        const bool idle_long_enough =
+            m_last_trade_activity_ms <= 0 ||
+            timestamp_ms - m_last_trade_activity_ms >= kTradeStormIdleMs;
+
+        if (!m_has_trade_storm_balance ||
+            (local_queue_idle && idle_long_enough)) {
+            m_has_trade_storm_balance = true;
+            m_trade_storm_base_balance = account_balance;
+            m_trade_storm_realized_profit = 0.0;
+        }
+
+        return m_trade_storm_base_balance + m_trade_storm_realized_profit;
+    }
+
+    inline void TradeQueueManager::add_realized_profit_to_storm(
+            const std::shared_ptr<TradeResult>& result) {
+        if (!result || !is_result_state_for_balance(result->trade_state)) {
+            return;
+        }
+        m_trade_storm_realized_profit += result->profit;
+    }
+
+    inline bool TradeQueueManager::is_result_state_for_balance(TradeState state) noexcept {
+        return state == TradeState::WIN ||
+               state == TradeState::LOSS ||
+               state == TradeState::STANDOFF ||
+               state == TradeState::REFUND;
     }
 
     inline int64_t TradeQueueManager::add_snapshot_close_buffer(

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
@@ -174,6 +174,8 @@ namespace optionx::modules {
         result->open_date = timestamp;
         result->close_date = timestamp;
         result->balance = m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request, timestamp);
+        result->open_balance = result->balance;
+        result->close_balance = result->balance;
         result->payout = m_account_info.get_for_trade<double>(AccountInfoType::PAYOUT, request, timestamp);
         result->trade_state = result->live_state = state;
     }

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeStateManager.hpp
@@ -173,9 +173,11 @@ namespace optionx::modules {
         result->send_date = timestamp;
         result->open_date = timestamp;
         result->close_date = timestamp;
-        result->balance = m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request, timestamp);
-        result->open_balance = result->balance;
-        result->close_balance = result->balance;
+        const double balance =
+            m_account_info.get_for_trade<double>(AccountInfoType::BALANCE, request, timestamp);
+        result->set_balance(balance);
+        result->set_open_balance(balance);
+        result->set_close_balance(balance);
         result->payout = m_account_info.get_for_trade<double>(AccountInfoType::PAYOUT, request, timestamp);
         result->trade_state = result->live_state = state;
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
@@ -234,6 +234,7 @@ namespace optionx::platforms::intrade_bar {
                             using Status = events::AccountInfoUpdateEvent::Status;
                             const double previous_balance = account_info->balance;
                             shared_result->balance = balance;
+                            shared_result->close_balance = balance;
                             if (shared_result->currency == CurrencyType::UNKNOWN) {
                                 shared_result->currency = currency;
                             }
@@ -250,6 +251,7 @@ namespace optionx::platforms::intrade_bar {
                             }
                         } else if (shared_result->balance == 0.0) {
                             shared_result->balance = account_info->balance;
+                            shared_result->close_balance = account_info->balance;
                         }
 
                         if (*callback_ptr) {
@@ -336,6 +338,7 @@ namespace optionx::platforms::intrade_bar {
                 auto account_info = get_account_info();
                 if (success) {
                     result->balance = balance;
+                    result->open_balance = balance;
                     result->trade_state = TradeState::OPEN_SUCCESS;
 
                     using Status = events::AccountInfoUpdateEvent::Status;
@@ -353,6 +356,7 @@ namespace optionx::platforms::intrade_bar {
                     }
                 } else {
                     result->balance = account_info->balance;
+                    result->open_balance = account_info->balance;
                     result->trade_state = TradeState::OPEN_SUCCESS;
                 }
             });
@@ -465,8 +469,10 @@ namespace optionx::platforms::intrade_bar {
         set_zero_spread_for_symbol(result->spread, request->symbol);
         if (!success) {
             result->balance = account_info->balance;
+            result->close_balance = account_info->balance;
         } else {
             result->balance = balance;
+            result->close_balance = balance;
         }
         if (!apply_trade_check_info_to_result(TradeCheckInfo{price, profit}, *result)) {
             return;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
@@ -233,8 +233,7 @@ namespace optionx::platforms::intrade_bar {
                         if (success) {
                             using Status = events::AccountInfoUpdateEvent::Status;
                             const double previous_balance = account_info->balance;
-                            shared_result->balance = balance;
-                            shared_result->close_balance = balance;
+                            shared_result->set_balance(balance);
                             if (shared_result->currency == CurrencyType::UNKNOWN) {
                                 shared_result->currency = currency;
                             }
@@ -249,16 +248,14 @@ namespace optionx::platforms::intrade_bar {
                                 account_info->balance = balance;
                                 notify(events::AccountInfoUpdateEvent(account_info, Status::BALANCE_UPDATED));
                             }
-                        } else {
-                            if (shared_result->balance == 0.0) {
-                                shared_result->balance = account_info->balance;
-                            }
-                            if (shared_result->close_balance == 0.0) {
-                                shared_result->close_balance =
-                                    shared_result->open_balance != 0.0
-                                        ? shared_result->open_balance + shared_result->profit
-                                        : shared_result->balance;
-                            }
+                        } else if (!shared_result->has_balance()) {
+                            shared_result->set_balance(account_info->balance);
+                        }
+                        if (!shared_result->has_close_balance() &&
+                            shared_result->has_open_balance() &&
+                            optionx::is_result_state(shared_result->trade_state)) {
+                            shared_result->set_close_balance(
+                                shared_result->open_balance + shared_result->profit);
                         }
 
                         if (*callback_ptr) {
@@ -348,9 +345,9 @@ namespace optionx::platforms::intrade_bar {
 
                     using Status = events::AccountInfoUpdateEvent::Status;
                     const double previous_balance = account_info->balance;
-                    result->balance = balance;
-                    if (result->open_balance == 0.0) {
-                        result->open_balance = previous_balance;
+                    result->set_balance(balance);
+                    if (!result->has_open_balance()) {
+                        result->set_open_balance(previous_balance);
                     }
 
                     if (!account_info->connect) {
@@ -364,9 +361,9 @@ namespace optionx::platforms::intrade_bar {
                         notify(events::AccountInfoUpdateEvent(account_info, Status::BALANCE_UPDATED));
                     }
                 } else {
-                    result->balance = account_info->balance;
-                    if (result->open_balance == 0.0) {
-                        result->open_balance = account_info->balance;
+                    result->set_balance(account_info->balance);
+                    if (!result->has_open_balance()) {
+                        result->set_open_balance(account_info->balance);
                     }
                     result->trade_state = TradeState::OPEN_SUCCESS;
                 }
@@ -478,13 +475,13 @@ namespace optionx::platforms::intrade_bar {
         if (!request ||!result) return;
         auto account_info = get_account_info();
         set_zero_spread_for_symbol(result->spread, request->symbol);
-        result->balance = success ? balance : account_info->balance;
+        result->set_balance(success ? balance : account_info->balance);
         if (!apply_trade_check_info_to_result(TradeCheckInfo{price, profit}, *result)) {
             return;
         }
-        result->close_balance = success || result->open_balance == 0.0
-            ? result->balance
-            : result->open_balance + result->profit;
+        if (result->has_open_balance()) {
+            result->set_close_balance(result->open_balance + result->profit);
+        }
 
         if (result->trade_state == TradeState::STANDOFF ||
             result->trade_state == TradeState::LOSS) {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeManager.hpp
@@ -249,9 +249,16 @@ namespace optionx::platforms::intrade_bar {
                                 account_info->balance = balance;
                                 notify(events::AccountInfoUpdateEvent(account_info, Status::BALANCE_UPDATED));
                             }
-                        } else if (shared_result->balance == 0.0) {
-                            shared_result->balance = account_info->balance;
-                            shared_result->close_balance = account_info->balance;
+                        } else {
+                            if (shared_result->balance == 0.0) {
+                                shared_result->balance = account_info->balance;
+                            }
+                            if (shared_result->close_balance == 0.0) {
+                                shared_result->close_balance =
+                                    shared_result->open_balance != 0.0
+                                        ? shared_result->open_balance + shared_result->profit
+                                        : shared_result->balance;
+                            }
                         }
 
                         if (*callback_ptr) {
@@ -337,12 +344,14 @@ namespace optionx::platforms::intrade_bar {
                     CurrencyType currency) {
                 auto account_info = get_account_info();
                 if (success) {
-                    result->balance = balance;
-                    result->open_balance = balance;
                     result->trade_state = TradeState::OPEN_SUCCESS;
 
                     using Status = events::AccountInfoUpdateEvent::Status;
                     const double previous_balance = account_info->balance;
+                    result->balance = balance;
+                    if (result->open_balance == 0.0) {
+                        result->open_balance = previous_balance;
+                    }
 
                     if (!account_info->connect) {
                         account_info->connect = true;
@@ -356,7 +365,9 @@ namespace optionx::platforms::intrade_bar {
                     }
                 } else {
                     result->balance = account_info->balance;
-                    result->open_balance = account_info->balance;
+                    if (result->open_balance == 0.0) {
+                        result->open_balance = account_info->balance;
+                    }
                     result->trade_state = TradeState::OPEN_SUCCESS;
                 }
             });
@@ -467,16 +478,13 @@ namespace optionx::platforms::intrade_bar {
         if (!request ||!result) return;
         auto account_info = get_account_info();
         set_zero_spread_for_symbol(result->spread, request->symbol);
-        if (!success) {
-            result->balance = account_info->balance;
-            result->close_balance = account_info->balance;
-        } else {
-            result->balance = balance;
-            result->close_balance = balance;
-        }
+        result->balance = success ? balance : account_info->balance;
         if (!apply_trade_check_info_to_result(TradeCheckInfo{price, profit}, *result)) {
             return;
         }
+        result->close_balance = success || result->open_balance == 0.0
+            ? result->balance
+            : result->open_balance + result->profit;
 
         if (result->trade_state == TradeState::STANDOFF ||
             result->trade_state == TradeState::LOSS) {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -87,8 +87,8 @@ namespace optionx::storage {
             if (filter.max_payout > 0.0 && record.payout > filter.max_payout) return false;
             if (filter.min_profit > 0.0 && record.profit < filter.min_profit) return false;
             if (filter.max_profit > 0.0 && record.profit > filter.max_profit) return false;
-            if (filter.min_balance > 0.0 && record.balance < filter.min_balance) return false;
-            if (filter.max_balance > 0.0 && record.balance > filter.max_balance) return false;
+            if (filter.min_balance > 0.0 && record.close_balance < filter.min_balance) return false;
+            if (filter.max_balance > 0.0 && record.close_balance > filter.max_balance) return false;
 
             if (filter.min_ping > 0 && record.ping < filter.min_ping) return false;
             if (filter.max_ping > 0 && record.ping > filter.max_ping) return false;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
@@ -136,22 +136,18 @@ namespace optionx::storage {
                 record.profit = result.profit;
                 updated = true;
             }
-            if (result.balance != 0.0) {
-                if (record.close_balance == 0.0) {
-                    record.close_balance = result.balance;
-                }
+            if (result.has_open_balance()) {
+                record.set_open_balance(result.open_balance);
                 updated = true;
             }
-            if (result.open_balance != 0.0) {
-                record.open_balance = result.open_balance;
+            if (result.has_close_balance()) {
+                record.set_close_balance(result.close_balance);
                 updated = true;
             }
-            if (result.close_balance != 0.0) {
-                record.close_balance = result.close_balance;
-                updated = true;
-            }
-            if (record.close_balance == 0.0 && record.open_balance != 0.0) {
-                record.close_balance = record.open_balance + result.profit;
+            if (!record.has_close_balance() &&
+                    record.has_open_balance() &&
+                    optionx::is_result_state(result.trade_state)) {
+                record.set_close_balance(record.open_balance + result.profit);
                 updated = true;
             }
             if (result.open_price != 0.0) {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
@@ -138,6 +138,18 @@ namespace optionx::storage {
             }
             if (result.balance != 0.0) {
                 record.balance = result.balance;
+                if (record.close_balance == 0.0) {
+                    record.close_balance = result.balance;
+                }
+                updated = true;
+            }
+            if (result.open_balance != 0.0) {
+                record.open_balance = result.open_balance;
+                updated = true;
+            }
+            if (result.close_balance != 0.0) {
+                record.close_balance = result.close_balance;
+                record.balance = result.close_balance;
                 updated = true;
             }
             if (result.open_price != 0.0) {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordStatusFixer.hpp
@@ -137,7 +137,6 @@ namespace optionx::storage {
                 updated = true;
             }
             if (result.balance != 0.0) {
-                record.balance = result.balance;
                 if (record.close_balance == 0.0) {
                     record.close_balance = result.balance;
                 }
@@ -149,7 +148,10 @@ namespace optionx::storage {
             }
             if (result.close_balance != 0.0) {
                 record.close_balance = result.close_balance;
-                record.balance = result.close_balance;
+                updated = true;
+            }
+            if (record.close_balance == 0.0 && record.open_balance != 0.0) {
+                record.close_balance = record.open_balance + result.profit;
                 updated = true;
             }
             if (result.open_price != 0.0) {

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -302,30 +302,32 @@ namespace optionx::storage {
 
                 double free_funds = config.start_balance;
                 double peak_free = config.start_balance;
-                std::int64_t last_ts = events.front().ts;
 
-                for (const auto& ev : events) {
-                    if (ev.ts != last_ts) {
-                        stats.free_funds_curve.x_time.push_back(last_ts);
-                        stats.free_funds_curve.y_value.push_back(free_funds);
-                        last_ts = ev.ts;
-                    }
-                    free_funds += ev.delta;
+                for (std::size_t i = 0; i < events.size();) {
+                    const auto ts = events[i].ts;
+                    double delta = 0.0;
+
+                    do {
+                        delta += events[i].delta;
+                        ++i;
+                    } while (i < events.size() && events[i].ts == ts);
+
+                    free_funds += delta;
                     peak_free = std::max(peak_free, free_funds);
 
                     const auto dd = peak_free - free_funds;
                     if (dd > stats.max_absolute_drawdown_free) {
                         stats.max_absolute_drawdown_free = dd;
-                        stats.max_drawdown_date_free = ev.ts;
+                        stats.max_drawdown_date_free = ts;
                     }
                     if (peak_free > 0.0) {
                         stats.max_relative_drawdown_free = std::max(
                             stats.max_relative_drawdown_free, dd / peak_free);
                     }
+
+                    stats.free_funds_curve.x_time.push_back(ts);
+                    stats.free_funds_curve.y_value.push_back(free_funds);
                 }
-                // Push final point
-                stats.free_funds_curve.x_time.push_back(last_ts);
-                stats.free_funds_curve.y_value.push_back(free_funds);
             }
 
             return stats_ptr;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -36,9 +36,7 @@ namespace optionx::storage {
             auto stats_ptr = std::make_unique<optionx::TradeStats>();
             auto& stats = *stats_ptr;
 
-            double running_balance = config.start_balance;
-            double peak_balance = config.start_balance;
-
+            std::map<std::int64_t, double> realized_profit_by_ts;
             std::map<std::int64_t, double> daily_profit_map;
             std::map<std::int64_t, double> hourly_profit_map;
 
@@ -59,7 +57,7 @@ namespace optionx::storage {
                 }
             };
 
-            const auto ordered_records = make_ordered_records(records, config);
+            const auto ordered_records = make_ordered_records(records);
             std::vector<Event> events;
             events.reserve(records.size() * 2);
 
@@ -104,16 +102,12 @@ namespace optionx::storage {
                     stats.max_profit_trade = std::max(stats.max_profit_trade, profit);
                     stats.max_loss_trade = std::min(stats.max_loss_trade, profit);
 
-                    // Equity / profit curves (classic realized-profit mode)
+                    // Realized-profit curves are built after aggregation by
+                    // timestamp, so same-moment closes do not invent an order.
                     const auto curve_ts = rec.close_date > 0 ? rec.close_date : rec.open_date;
-                    running_balance += profit;
-                    peak_balance = std::max(peak_balance, running_balance);
 
                     if (curve_ts > 0) {
-                        stats.equity_curve.x_time.push_back(curve_ts);
-                        stats.equity_curve.y_value.push_back(running_balance);
-                        stats.profit_curve.x_time.push_back(curve_ts);
-                        stats.profit_curve.y_value.push_back(stats.total_profit);
+                        realized_profit_by_ts[curve_ts] += profit;
 
                         // Daily / hourly profit buckets
                         const auto day_utc =
@@ -123,16 +117,6 @@ namespace optionx::storage {
                         const auto hour_utc =
                             config.time_zone.start_of_local_hour_utc_ms(curve_ts);
                         hourly_profit_map[hour_utc] += profit;
-                    }
-
-                    // Drawdown (classic)
-                    const auto dd = peak_balance - running_balance;
-                    if (dd > stats.max_absolute_drawdown) {
-                        stats.max_absolute_drawdown = dd;
-                        stats.max_drawdown_date = curve_ts;
-                    }
-                    if (peak_balance > 0.0) {
-                        stats.max_relative_drawdown = std::max(stats.max_relative_drawdown, dd / peak_balance);
                     }
 
                     // Ping stats
@@ -280,6 +264,39 @@ namespace optionx::storage {
                     stats.total_profit / static_cast<double>(volume_trade_count);
             }
 
+            // Realized synthetic equity/profit curves.
+            double running_balance = config.start_balance;
+            double peak_balance = config.start_balance;
+            double cumulative_profit = 0.0;
+            for (const auto& kv : realized_profit_by_ts) {
+                const auto ts = kv.first;
+                const auto delta = kv.second;
+                running_balance += delta;
+                cumulative_profit += delta;
+                peak_balance = std::max(peak_balance, running_balance);
+
+                stats.equity_curve.x_time.push_back(ts);
+                stats.equity_curve.y_value.push_back(running_balance);
+                stats.profit_curve.x_time.push_back(ts);
+                stats.profit_curve.y_value.push_back(cumulative_profit);
+                if (config.start_balance > 0.0) {
+                    stats.profit_percent_curve.x_time.push_back(ts);
+                    stats.profit_percent_curve.y_value.push_back(
+                        (cumulative_profit / config.start_balance) * 100.0);
+                }
+
+                const auto dd = peak_balance - running_balance;
+                if (dd > stats.max_absolute_drawdown) {
+                    stats.max_absolute_drawdown = dd;
+                    stats.max_drawdown_date = ts;
+                }
+                if (peak_balance > 0.0) {
+                    stats.max_relative_drawdown = std::max(
+                        stats.max_relative_drawdown,
+                        dd / peak_balance);
+                }
+            }
+
             // Fill chart data
             for (const auto& kv : daily_profit_map) {
                 stats.daily_profit.x_time.push_back(kv.first);
@@ -336,16 +353,11 @@ namespace optionx::storage {
         }
 
         static std::vector<const optionx::TradeRecord*> make_ordered_records(
-                const std::vector<optionx::TradeRecord>& records,
-                const optionx::TradeStatsConfig& config) {
+                const std::vector<optionx::TradeRecord>& records) {
             std::vector<const optionx::TradeRecord*> ordered;
             ordered.reserve(records.size());
             for (const auto& record : records) {
                 ordered.push_back(&record);
-            }
-
-            if (config.input_order == optionx::TradeStatsInputOrder::PLACE_DATE_ASC) {
-                return ordered;
             }
 
             std::stable_sort(

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -365,7 +365,7 @@ namespace optionx::storage {
 
         static double close_balance_snapshot(
                 const optionx::TradeRecord& rec) noexcept {
-            return rec.close_balance != 0.0 ? rec.close_balance : rec.balance;
+            return rec.close_balance;
         }
 
         static double convert_money(

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -105,8 +105,7 @@ namespace optionx::storage {
                     // timestamp, so same-moment closes do not invent an order.
                     if (curve_ts > 0) {
                         realized_profit_by_ts[curve_ts] += profit;
-                        const double close_balance = close_balance_snapshot(rec);
-                        if (close_balance != 0.0) {
+                        if (rec.has_close_balance()) {
                             balance_events.push_back({
                                 curve_ts,
                                 rec.open_date > 0 ? rec.open_date : curve_ts,
@@ -114,10 +113,11 @@ namespace optionx::storage {
                                     rec.platform_type,
                                     rec.account_type,
                                     rec.account_id,
-                                    rec.currency},
+                                rec.currency},
                                 rec.currency,
                                 rec.open_balance,
-                                close_balance,
+                                rec.has_open_balance(),
+                                close_balance_snapshot(rec),
                                 rec.profit});
                         }
 
@@ -352,6 +352,7 @@ namespace optionx::storage {
             AccountKey account;
             optionx::CurrencyType currency = optionx::CurrencyType::UNKNOWN;
             double open_balance = 0.0;
+            bool has_open_balance = false;
             double close_balance = 0.0;
             double profit = 0.0;
         };
@@ -389,7 +390,7 @@ namespace optionx::storage {
         static double initial_balance_for_event(
                 const BalanceSnapshotEvent& event,
                 const optionx::TradeStatsConfig& config) {
-            if (event.open_balance != 0.0) {
+            if (event.has_open_balance) {
                 return convert_money(
                     event.open_balance,
                     event.currency,

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -60,6 +60,8 @@ namespace optionx::storage {
             const auto ordered_records = make_ordered_records(records);
             std::vector<Event> events;
             events.reserve(records.size() * 2);
+            std::vector<BalanceSnapshotEvent> balance_events;
+            balance_events.reserve(records.size());
 
             for (const auto* rec_ptr : ordered_records) {
                 const auto& rec = *rec_ptr;
@@ -83,16 +85,13 @@ namespace optionx::storage {
                     }
                 }
 
-                // 4. Currency conversion (for monetary stats)
-                double amount = rec.amount;
-                double profit = rec.profit;
-                if (config.convert) {
-                    amount = config.convert(amount, rec.currency);
-                    profit = config.convert(profit, rec.currency);
-                }
-
-                // 5. Monetary aggregations (same selected result-state population)
+                // 4. Monetary aggregations (same selected result-state population)
                 if (include_selected && optionx::is_result_state(rec.trade_state)) {
+                    const auto curve_ts = rec.close_date > 0 ? rec.close_date : rec.open_date;
+                    const auto amount_ts = rec.open_date > 0 ? rec.open_date : curve_ts;
+                    const double amount = convert_money(rec.amount, rec.currency, amount_ts, config);
+                    const double profit = convert_money(rec.profit, rec.currency, curve_ts, config);
+
                     ++volume_trade_count;
                     stats.total_volume += amount;
                     stats.total_profit += profit;
@@ -104,10 +103,23 @@ namespace optionx::storage {
 
                     // Realized-profit curves are built after aggregation by
                     // timestamp, so same-moment closes do not invent an order.
-                    const auto curve_ts = rec.close_date > 0 ? rec.close_date : rec.open_date;
-
                     if (curve_ts > 0) {
                         realized_profit_by_ts[curve_ts] += profit;
+                        const double close_balance = close_balance_snapshot(rec);
+                        if (close_balance != 0.0) {
+                            balance_events.push_back({
+                                curve_ts,
+                                rec.open_date > 0 ? rec.open_date : curve_ts,
+                                AccountKey{
+                                    rec.platform_type,
+                                    rec.account_type,
+                                    rec.account_id,
+                                    rec.currency},
+                                rec.currency,
+                                rec.open_balance,
+                                close_balance,
+                                rec.profit});
+                        }
 
                         // Daily / hourly profit buckets
                         const auto day_utc =
@@ -264,37 +276,12 @@ namespace optionx::storage {
                     stats.total_profit / static_cast<double>(volume_trade_count);
             }
 
-            // Realized synthetic equity/profit curves.
-            double running_balance = config.start_balance;
-            double peak_balance = config.start_balance;
-            double cumulative_profit = 0.0;
-            for (const auto& kv : realized_profit_by_ts) {
-                const auto ts = kv.first;
-                const auto delta = kv.second;
-                running_balance += delta;
-                cumulative_profit += delta;
-                peak_balance = std::max(peak_balance, running_balance);
-
-                stats.equity_curve.x_time.push_back(ts);
-                stats.equity_curve.y_value.push_back(running_balance);
-                stats.profit_curve.x_time.push_back(ts);
-                stats.profit_curve.y_value.push_back(cumulative_profit);
-                if (config.start_balance > 0.0) {
-                    stats.profit_percent_curve.x_time.push_back(ts);
-                    stats.profit_percent_curve.y_value.push_back(
-                        (cumulative_profit / config.start_balance) * 100.0);
-                }
-
-                const auto dd = peak_balance - running_balance;
-                if (dd > stats.max_absolute_drawdown) {
-                    stats.max_absolute_drawdown = dd;
-                    stats.max_drawdown_date = ts;
-                }
-                if (peak_balance > 0.0) {
-                    stats.max_relative_drawdown = std::max(
-                        stats.max_relative_drawdown,
-                        dd / peak_balance);
-                }
+            if (config.equity_mode == optionx::TradeStatsEquityMode::RECORD_BALANCE) {
+                build_record_balance_curves(stats, config, balance_events);
+            } else if (config.equity_mode == optionx::TradeStatsEquityMode::PORTFOLIO_BALANCE) {
+                build_portfolio_balance_curves(stats, config, balance_events);
+            } else {
+                build_synthetic_curves(stats, config, realized_profit_by_ts);
             }
 
             // Fill chart data
@@ -345,11 +332,223 @@ namespace optionx::storage {
         }
 
     private:
+        struct AccountKey {
+            optionx::PlatformType platform_type = optionx::PlatformType::UNKNOWN;
+            optionx::AccountType account_type = optionx::AccountType::UNKNOWN;
+            std::int64_t account_id = 0;
+            optionx::CurrencyType currency = optionx::CurrencyType::UNKNOWN;
+
+            bool operator<(const AccountKey& other) const noexcept {
+                if (platform_type != other.platform_type) return platform_type < other.platform_type;
+                if (account_type != other.account_type) return account_type < other.account_type;
+                if (account_id != other.account_id) return account_id < other.account_id;
+                return currency < other.currency;
+            }
+        };
+
+        struct BalanceSnapshotEvent {
+            std::int64_t ts = 0;
+            std::int64_t open_ts = 0;
+            AccountKey account;
+            optionx::CurrencyType currency = optionx::CurrencyType::UNKNOWN;
+            double open_balance = 0.0;
+            double close_balance = 0.0;
+            double profit = 0.0;
+        };
+
         static std::int64_t stats_order_timestamp(
                 const optionx::TradeRecord& rec) noexcept {
             if (rec.close_date > 0) return rec.close_date;
             if (rec.open_date > 0) return rec.open_date;
             return optionx::select_timestamp_ms(rec, optionx::TradeRecordTimeField::AUTO);
+        }
+
+        static double close_balance_snapshot(
+                const optionx::TradeRecord& rec) noexcept {
+            return rec.close_balance != 0.0 ? rec.close_balance : rec.balance;
+        }
+
+        static double convert_money(
+                double value,
+                optionx::CurrencyType from,
+                std::int64_t timestamp_ms,
+                const optionx::TradeStatsConfig& config) {
+            const auto to = config.currency_matrix.base_currency;
+            if (config.convert_currency) {
+                return config.convert_currency(value, from, to, timestamp_ms);
+            }
+            if (to != optionx::CurrencyType::UNKNOWN) {
+                return config.currency_matrix.convert_to_base(value, from);
+            }
+            if (config.convert) {
+                return config.convert(value, from);
+            }
+            return value;
+        }
+
+        static double initial_balance_for_event(
+                const BalanceSnapshotEvent& event,
+                const optionx::TradeStatsConfig& config) {
+            if (event.open_balance != 0.0) {
+                return convert_money(
+                    event.open_balance,
+                    event.currency,
+                    event.open_ts > 0 ? event.open_ts : event.ts,
+                    config);
+            }
+
+            const double close_balance = convert_money(
+                event.close_balance,
+                event.currency,
+                event.ts,
+                config);
+            const double profit = convert_money(
+                event.profit,
+                event.currency,
+                event.ts,
+                config);
+            return close_balance - profit;
+        }
+
+        static void append_equity_sample(
+                optionx::TradeStats& stats,
+                std::int64_t ts,
+                double equity,
+                double baseline) {
+            stats.equity_curve.x_time.push_back(ts);
+            stats.equity_curve.y_value.push_back(equity);
+            stats.profit_curve.x_time.push_back(ts);
+            stats.profit_curve.y_value.push_back(equity - baseline);
+            if (baseline > 0.0) {
+                stats.profit_percent_curve.x_time.push_back(ts);
+                stats.profit_percent_curve.y_value.push_back(
+                    ((equity - baseline) / baseline) * 100.0);
+            }
+        }
+
+        static void update_equity_drawdown(
+                optionx::TradeStats& stats,
+                std::int64_t ts,
+                double equity,
+                double& peak) {
+            peak = std::max(peak, equity);
+            const auto dd = peak - equity;
+            if (dd > stats.max_absolute_drawdown) {
+                stats.max_absolute_drawdown = dd;
+                stats.max_drawdown_date = ts;
+            }
+            if (peak > 0.0) {
+                stats.max_relative_drawdown = std::max(
+                    stats.max_relative_drawdown,
+                    dd / peak);
+            }
+        }
+
+        static void build_synthetic_curves(
+                optionx::TradeStats& stats,
+                const optionx::TradeStatsConfig& config,
+                const std::map<std::int64_t, double>& realized_profit_by_ts) {
+            double equity = config.start_balance;
+            double peak = config.start_balance;
+            for (const auto& kv : realized_profit_by_ts) {
+                const auto ts = kv.first;
+                equity += kv.second;
+                append_equity_sample(stats, ts, equity, config.start_balance);
+                update_equity_drawdown(stats, ts, equity, peak);
+            }
+        }
+
+        static void build_record_balance_curves(
+                optionx::TradeStats& stats,
+                const optionx::TradeStatsConfig& config,
+                std::vector<BalanceSnapshotEvent> events) {
+            if (events.empty()) return;
+
+            std::stable_sort(
+                events.begin(),
+                events.end(),
+                [](const BalanceSnapshotEvent& lhs, const BalanceSnapshotEvent& rhs) {
+                    if (lhs.ts != rhs.ts) return lhs.ts < rhs.ts;
+                    return lhs.account < rhs.account;
+                });
+
+            bool has_baseline = false;
+            double baseline = 0.0;
+            double peak = 0.0;
+
+            for (std::size_t i = 0; i < events.size();) {
+                const auto ts = events[i].ts;
+                double equity = 0.0;
+                do {
+                    const auto& event = events[i];
+                    if (!has_baseline) {
+                        baseline = initial_balance_for_event(event, config);
+                        peak = baseline;
+                        has_baseline = true;
+                    }
+                    equity = convert_money(
+                        event.close_balance,
+                        event.currency,
+                        event.ts,
+                        config);
+                    ++i;
+                } while (i < events.size() && events[i].ts == ts);
+
+                append_equity_sample(stats, ts, equity, baseline);
+                update_equity_drawdown(stats, ts, equity, peak);
+            }
+        }
+
+        static void build_portfolio_balance_curves(
+                optionx::TradeStats& stats,
+                const optionx::TradeStatsConfig& config,
+                std::vector<BalanceSnapshotEvent> events) {
+            if (events.empty()) return;
+
+            std::stable_sort(
+                events.begin(),
+                events.end(),
+                [](const BalanceSnapshotEvent& lhs, const BalanceSnapshotEvent& rhs) {
+                    if (lhs.ts != rhs.ts) return lhs.ts < rhs.ts;
+                    return lhs.account < rhs.account;
+                });
+
+            std::map<AccountKey, double> account_balances;
+            double baseline = 0.0;
+            double equity = 0.0;
+            double peak = 0.0;
+            bool has_sample = false;
+
+            for (std::size_t i = 0; i < events.size();) {
+                const auto ts = events[i].ts;
+                do {
+                    const auto& event = events[i];
+                    const double close_balance = convert_money(
+                        event.close_balance,
+                        event.currency,
+                        event.ts,
+                        config);
+
+                    auto account_it = account_balances.find(event.account);
+                    if (account_it == account_balances.end()) {
+                        const double initial_balance = initial_balance_for_event(event, config);
+                        baseline += initial_balance;
+                        equity += initial_balance;
+                        account_it = account_balances.emplace(event.account, initial_balance).first;
+                        if (!has_sample) {
+                            peak = baseline;
+                            has_sample = true;
+                        }
+                    }
+
+                    equity += close_balance - account_it->second;
+                    account_it->second = close_balance;
+                    ++i;
+                } while (i < events.size() && events[i].ts == ts);
+
+                append_equity_sample(stats, ts, equity, baseline);
+                update_equity_drawdown(stats, ts, equity, peak);
+            }
         }
 
         static std::vector<const optionx::TradeRecord*> make_ordered_records(

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <vector>
 
 #include <time_shield.hpp>
 
@@ -57,25 +58,22 @@ namespace optionx::storage {
                     return ts > other.ts; // min-heap for std::priority_queue
                 }
             };
+
+            const auto ordered_records = make_ordered_records(records, config);
             std::vector<Event> events;
             events.reserve(records.size() * 2);
 
-            for (const auto& rec : records) {
+            for (const auto* rec_ptr : ordered_records) {
+                const auto& rec = *rec_ptr;
+
                 // 1. Filter predicate (applies to both outcome and monetary)
                 if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) {
                     continue;
                 }
 
-                // 2. Determine if this record contributes to OUTCOME statistics
-                bool include_outcome = true;
-                if (config.selection == optionx::TradeStatsSelection::FIRST_MM_STEP && rec.mm_step != 0) {
-                    include_outcome = false;
-                }
-                if (config.selection == optionx::TradeStatsSelection::LAST_IN_GROUP) {
-                    if (!rec.last_in_group()) {
-                        include_outcome = false;
-                    }
-                }
+                // 2. Determine if this record contributes to selected statistics.
+                const bool include_selected = include_by_selection(rec, config);
+                bool include_outcome = include_selected;
 
                 // 3. Error / terminal inclusion for outcome stats
                 if (include_outcome) {
@@ -95,8 +93,8 @@ namespace optionx::storage {
                     profit = config.convert(profit, rec.currency);
                 }
 
-                // 5. Monetary aggregations (all result-state trades always contribute)
-                if (optionx::is_result_state(rec.trade_state)) {
+                // 5. Monetary aggregations (same selected result-state population)
+                if (include_selected && optionx::is_result_state(rec.trade_state)) {
                     ++volume_trade_count;
                     stats.total_volume += amount;
                     stats.total_profit += profit;
@@ -244,7 +242,7 @@ namespace optionx::storage {
             stats.series.current_is_win = current_is_win;
 
             // Recount series properly for averages
-            recount_series(records, config, stats.series);
+            recount_series(ordered_records, config, stats.series);
 
             // Finalize winrate stats
             stats.total.calc();
@@ -275,14 +273,11 @@ namespace optionx::storage {
             if (volume_trade_count > 0) {
                 stats.average_amount = stats.total_volume / static_cast<double>(volume_trade_count);
             }
-            if (stats.total.trades > 0) {
-                stats.average_profit_per_trade = stats.total_profit / static_cast<double>(stats.total.trades);
-            }
-
-            const auto result_count = stats.total.wins + stats.total.losses +
-                                      stats.total.standoffs + stats.total.refunds;
-            if (result_count > 0) {
-                stats.average_profit = stats.total_profit / static_cast<double>(result_count);
+            if (volume_trade_count > 0) {
+                stats.average_profit_per_trade =
+                    stats.total_profit / static_cast<double>(volume_trade_count);
+                stats.average_profit =
+                    stats.total_profit / static_cast<double>(volume_trade_count);
             }
 
             // Fill chart data
@@ -333,20 +328,58 @@ namespace optionx::storage {
         }
 
     private:
+        static std::int64_t stats_order_timestamp(
+                const optionx::TradeRecord& rec) noexcept {
+            if (rec.close_date > 0) return rec.close_date;
+            if (rec.open_date > 0) return rec.open_date;
+            return optionx::select_timestamp_ms(rec, optionx::TradeRecordTimeField::AUTO);
+        }
+
+        static std::vector<const optionx::TradeRecord*> make_ordered_records(
+                const std::vector<optionx::TradeRecord>& records,
+                const optionx::TradeStatsConfig& config) {
+            std::vector<const optionx::TradeRecord*> ordered;
+            ordered.reserve(records.size());
+            for (const auto& record : records) {
+                ordered.push_back(&record);
+            }
+
+            if (config.input_order == optionx::TradeStatsInputOrder::PLACE_DATE_ASC) {
+                return ordered;
+            }
+
+            std::stable_sort(
+                ordered.begin(),
+                ordered.end(),
+                [](const optionx::TradeRecord* lhs, const optionx::TradeRecord* rhs) {
+                    const auto lhs_ts = stats_order_timestamp(*lhs);
+                    const auto rhs_ts = stats_order_timestamp(*rhs);
+                    if (lhs_ts != rhs_ts) return lhs_ts < rhs_ts;
+                    if (lhs->trade_id != rhs->trade_id) return lhs->trade_id < rhs->trade_id;
+                    return lhs->request_unique_id < rhs->request_unique_id;
+                });
+            return ordered;
+        }
+
+        static bool include_by_selection(
+                const optionx::TradeRecord& rec,
+                const optionx::TradeStatsConfig& config) noexcept {
+            if (config.selection == optionx::TradeStatsSelection::FIRST_MM_STEP && rec.mm_step != 0) {
+                return false;
+            }
+            if (config.selection == optionx::TradeStatsSelection::LAST_IN_GROUP) {
+                return rec.last_in_group();
+            }
+            return true;
+        }
+
         static bool include_outcome(
                 const optionx::TradeRecord& rec,
                 const optionx::TradeStatsConfig& config) noexcept {
             if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) {
                 return false;
             }
-            if (config.selection == optionx::TradeStatsSelection::FIRST_MM_STEP && rec.mm_step != 0) {
-                return false;
-            }
-            if (config.selection == optionx::TradeStatsSelection::LAST_IN_GROUP) {
-                if (!rec.last_in_group()) {
-                    return false;
-                }
-            }
+            if (!include_by_selection(rec, config)) return false;
             if (!config.include_errors && optionx::is_error_trade_state(rec.trade_state)) {
                 return false;
             }
@@ -357,7 +390,7 @@ namespace optionx::storage {
         }
 
         static void recount_series(
-                const std::vector<optionx::TradeRecord>& records,
+                const std::vector<const optionx::TradeRecord*>& records,
                 const optionx::TradeStatsConfig& config,
                 optionx::TradeSeriesStats& series) {
             std::uint64_t cur_win = 0, cur_loss = 0;
@@ -365,7 +398,8 @@ namespace optionx::storage {
             std::uint64_t count_w = 0, count_l = 0;
             std::uint64_t total_w_len = 0, total_l_len = 0;
 
-            for (const auto& rec : records) {
+            for (const auto* rec_ptr : records) {
+                const auto& rec = *rec_ptr;
                 if (!include_outcome(rec, config)) continue;
                 if (!optionx::is_terminal_trade_state(rec.trade_state)) continue;
 

--- a/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
+++ b/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
@@ -726,7 +726,7 @@ void print_trade_record_line(
         << " close_price=" << std::setprecision(12) << record.close_price
         << " profit=" << std::setprecision(12) << record.profit
         << " payout=" << std::setprecision(12) << record.payout
-        << " balance=" << std::setprecision(12) << record.balance
+        << " close_balance=" << std::setprecision(12) << record.close_balance
         << " open_date=" << record.open_date
         << " close_date=" << record.close_date
         << " comment=" << record.comment

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -409,6 +409,22 @@ namespace optionx::modules {
         std::vector<std::string> reasons;
     };
 
+    class TradeRequestCapture : public utils::EventMediator {
+    public:
+        explicit TradeRequestCapture(utils::EventBus& bus)
+            : utils::EventMediator(bus) {
+            subscribe<events::TradeRequestEvent>();
+        }
+
+        void on_event(const utils::Event* const event) override {
+            if (auto request_event = dynamic_cast<const events::TradeRequestEvent*>(event)) {
+                results.push_back(request_event->result);
+            }
+        }
+
+        std::vector<std::shared_ptr<TradeResult>> results;
+    };
+
     /// \brief Outputs the details of a TradeRequest.
     /// \param request The TradeRequest instance to output.
     void print_trade_request(const TradeRequest& request) {
@@ -576,6 +592,62 @@ TEST_F(TradeManagerTestFixture, OrderIntervalDelaysQueuedTrades) {
     std::this_thread::sleep_for(std::chrono::milliseconds(120));
     EXPECT_TRUE(wait_for_open_trades_count(trade_manager, bus, capture, 2, 1000));
 
+    trade_manager.shutdown();
+}
+
+TEST_F(TradeManagerTestFixture, OpenBalanceUsesTrustedIdleBalanceDuringTradeStorm) {
+    utils::EventBus bus;
+    auto account_info = std::make_shared<AccountInfoData>();
+    account_info->user_id = 12345;
+    account_info->balance = 1000.0;
+    account_info->currency = CurrencyType::USD;
+    account_info->account_type = AccountType::DEMO;
+    account_info->connect = true;
+    account_info->order_interval_ms = 0;
+
+    TradeManagerTest trade_manager(bus, account_info);
+    OpenTradesCapture open_trades_capture(bus, account_info);
+    TradeRequestCapture request_capture(bus);
+
+    ASSERT_TRUE(trade_manager.place_trade(make_valid_sprint_trade_request()));
+    trade_manager.process();
+    bus.process();
+
+    ASSERT_EQ(request_capture.results.size(), 1u);
+    ASSERT_TRUE(request_capture.results[0]->has_balance());
+    ASSERT_TRUE(request_capture.results[0]->has_open_balance());
+    EXPECT_DOUBLE_EQ(request_capture.results[0]->balance, 1000.0);
+    EXPECT_DOUBLE_EQ(request_capture.results[0]->open_balance, 1000.0);
+
+    account_info->balance = 900.0;
+    ASSERT_TRUE(trade_manager.place_trade(make_valid_sprint_trade_request()));
+    trade_manager.process();
+    bus.process();
+
+    ASSERT_EQ(request_capture.results.size(), 2u);
+    ASSERT_TRUE(request_capture.results[1]->has_balance());
+    ASSERT_TRUE(request_capture.results[1]->has_open_balance());
+    EXPECT_DOUBLE_EQ(request_capture.results[1]->balance, 900.0);
+    EXPECT_DOUBLE_EQ(request_capture.results[1]->open_balance, 1000.0);
+
+    request_capture.results[0]->profit = 8.0;
+    request_capture.results[0]->trade_state = TradeState::WIN;
+    request_capture.results[0]->live_state = TradeState::WIN;
+    trade_manager.process();
+    bus.process();
+
+    account_info->balance = 800.0;
+    ASSERT_TRUE(trade_manager.place_trade(make_valid_sprint_trade_request()));
+    trade_manager.process();
+    bus.process();
+
+    ASSERT_EQ(request_capture.results.size(), 3u);
+    ASSERT_TRUE(request_capture.results[2]->has_balance());
+    ASSERT_TRUE(request_capture.results[2]->has_open_balance());
+    EXPECT_DOUBLE_EQ(request_capture.results[2]->balance, 800.0);
+    EXPECT_DOUBLE_EQ(request_capture.results[2]->open_balance, 1008.0);
+
+    EXPECT_EQ(open_trades_capture.last_count(), 2);
     trade_manager.shutdown();
 }
 

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -60,8 +60,8 @@ TradeRecord make_record(
     record.min_payout = 0.75;
     record.payout = 0.82;
     record.profit = 12.3;
-    record.open_balance = 1000.0;
-    record.close_balance = 1012.3;
+    record.set_open_balance(1000.0);
+    record.set_close_balance(1012.3);
     record.trade_state = optionx::TradeState::IN_PROGRESS;
     record.live_state = optionx::TradeState::IN_PROGRESS;
     record.open_price = 1.12345;

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -60,7 +60,8 @@ TradeRecord make_record(
     record.min_payout = 0.75;
     record.payout = 0.82;
     record.profit = 12.3;
-    record.balance = 1012.3;
+    record.open_balance = 1000.0;
+    record.close_balance = 1012.3;
     record.trade_state = optionx::TradeState::IN_PROGRESS;
     record.live_state = optionx::TradeState::IN_PROGRESS;
     record.open_price = 1.12345;

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -67,6 +67,8 @@ TradeRecord make_win_record(
     record.payout = 0.82;
     record.profit = profit;
     record.balance = 1000.0 + profit;
+    record.open_balance = 1000.0;
+    record.close_balance = record.balance;
     record.trade_state = state;
     record.open_price = 1.12345;
     record.close_price = 1.12400;
@@ -568,6 +570,73 @@ TEST(TradeStatsCalculatorTest, RealizedCurveFallsBackToOpenDateWhenCloseDateMiss
     EXPECT_EQ(stats.equity_curve.x_time[1], records[1].close_date);
     EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 108.0);
     EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 115.0);
+}
+
+TEST(TradeStatsCalculatorTest, RecordBalanceModeUsesSnapshotsWithoutStartBalance) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, -5.0, "EURUSD", optionx::TradeState::LOSS));
+    records.back().open_balance = 1000.0;
+    records.back().close_balance = 995.0;
+    records.back().balance = 995.0;
+    records.push_back(make_win_record(2, 2000, 10.0, 15.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().open_balance = 995.0;
+    records.back().close_balance = 1010.0;
+    records.back().balance = 1010.0;
+
+    optionx::TradeStatsConfig cfg;
+    cfg.equity_mode = optionx::TradeStatsEquityMode::RECORD_BALANCE;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 995.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 1010.0);
+    ASSERT_EQ(stats.profit_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[0], -5.0);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[1], 10.0);
+    ASSERT_EQ(stats.profit_percent_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[0], -0.5);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[1], 1.0);
+    EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown, 5.0);
+}
+
+TEST(TradeStatsCalculatorTest, PortfolioBalanceModeCombinesAccountsInBaseCurrency) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(2, 2000, 1000.0, -900.0, "EURUSD", optionx::TradeState::LOSS));
+    records.back().account_id = 2;
+    records.back().currency = optionx::CurrencyType::RUB;
+    records.back().open_balance = 90000.0;
+    records.back().close_balance = 89100.0;
+    records.back().balance = 89100.0;
+
+    records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().account_id = 1;
+    records.back().currency = optionx::CurrencyType::USD;
+    records.back().open_balance = 1000.0;
+    records.back().close_balance = 1010.0;
+    records.back().balance = 1010.0;
+
+    optionx::TradeStatsConfig cfg;
+    cfg.equity_mode = optionx::TradeStatsEquityMode::PORTFOLIO_BALANCE;
+    cfg.currency_matrix.base_currency = optionx::CurrencyType::USD;
+    cfg.currency_matrix.set_rate(optionx::CurrencyType::RUB, optionx::CurrencyType::USD, 0.01);
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.x_time.size(), 2u);
+    EXPECT_EQ(stats.equity_curve.x_time[0], records[1].close_date);
+    EXPECT_EQ(stats.equity_curve.x_time[1], records[0].close_date);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 1010.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 1901.0);
+
+    ASSERT_EQ(stats.profit_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[0], 10.0);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[1], 1.0);
+    ASSERT_EQ(stats.profit_percent_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[1], (1.0 / 1900.0) * 100.0);
+    EXPECT_DOUBLE_EQ(stats.total_profit, 1.0);
 }
 
 TEST(TradeStatsCalculatorTest, SelectionAppliesToMonetaryStats) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -524,6 +524,26 @@ TEST(TradeStatsCalculatorTest, SameCloseDateAggregatesRealizedProfitBeforeDrawdo
     EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown, 0.0);
 }
 
+TEST(TradeStatsCalculatorTest, SweepLineAggregatesSameTimestampEventsBeforeDrawdown) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 100.0, 10.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().open_date = 5000;
+    records.back().close_date = 5000;
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 1000.0;
+    cfg.balance_mode = optionx::TradeStatsBalanceMode::SWEEP_LINE;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.free_funds_curve.x_time.size(), 1u);
+    EXPECT_EQ(stats.free_funds_curve.x_time[0], 5000);
+    EXPECT_DOUBLE_EQ(stats.free_funds_curve.y_value[0], 1010.0);
+    EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown_free, 0.0);
+    EXPECT_DOUBLE_EQ(stats.max_relative_drawdown_free, 0.0);
+}
+
 TEST(TradeStatsCalculatorTest, ProfitPercentCurveUsesStartBalance) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -453,6 +453,55 @@ TEST(TradeStatsCalculatorTest, DrawdownAndEquityCurve) {
     EXPECT_NEAR(stats.max_relative_drawdown, 20.0 / 108.2, 0.001);
 }
 
+TEST(TradeStatsCalculatorTest, AsIsInputSortsRealizedCurvesAndSeries) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(3, 3000, 10.0, -10.0, "EURUSD", optionx::TradeState::LOSS));
+    records.push_back(make_win_record(1, 1000, 10.0, 8.0, "EURUSD", optionx::TradeState::WIN));
+    records.push_back(make_win_record(2, 2000, 10.0, 7.0, "EURUSD", optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 100.0;
+    cfg.include_non_terminal = false;
+    cfg.input_order = optionx::TradeStatsInputOrder::AS_IS;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.x_time.size(), 3u);
+    EXPECT_EQ(stats.equity_curve.x_time[0], records[1].close_date);
+    EXPECT_EQ(stats.equity_curve.x_time[1], records[2].close_date);
+    EXPECT_EQ(stats.equity_curve.x_time[2], records[0].close_date);
+
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 108.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 115.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[2], 105.0);
+
+    EXPECT_EQ(stats.series.max_win_series, 2u);
+    EXPECT_EQ(stats.series.current_series, 1u);
+    EXPECT_FALSE(stats.series.current_is_win);
+}
+
+TEST(TradeStatsCalculatorTest, SelectionAppliesToMonetaryStats) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, 8.0, "EURUSD", optionx::TradeState::WIN));
+    records.push_back(make_win_record(2, 2000, 100.0, 80.0, "EURUSD", optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.selection = optionx::TradeStatsSelection::FIRST_MM_STEP;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    EXPECT_EQ(stats.total.trades, 1u);
+    EXPECT_EQ(stats.total.wins, 1u);
+    EXPECT_DOUBLE_EQ(stats.total_volume, 10.0);
+    EXPECT_DOUBLE_EQ(stats.total_profit, 8.0);
+    EXPECT_DOUBLE_EQ(stats.average_amount, 10.0);
+    EXPECT_DOUBLE_EQ(stats.average_profit, 8.0);
+    EXPECT_DOUBLE_EQ(stats.average_profit_per_trade, 8.0);
+    EXPECT_EQ(stats.by_mm_step.count(0), 1u);
+    EXPECT_EQ(stats.by_mm_step.count(1), 0u);
+}
+
 TEST(TradeMetaStatsCalculatorTest, CollectsUniqueSymbols) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, 8.2, "EURUSD", optionx::TradeState::WIN));

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -480,6 +480,96 @@ TEST(TradeStatsCalculatorTest, AsIsInputSortsRealizedCurvesAndSeries) {
     EXPECT_FALSE(stats.series.current_is_win);
 }
 
+TEST(TradeStatsCalculatorTest, PlaceDateAscStillUsesResultTimeForRealizedCurve) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, -100.0, "EURUSD", optionx::TradeState::LOSS));
+    records.back().close_date = 5000;
+    records.push_back(make_win_record(2, 2000, 10.0, 50.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().close_date = 3000;
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 100.0;
+    cfg.include_non_terminal = false;
+    cfg.input_order = optionx::TradeStatsInputOrder::PLACE_DATE_ASC;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.x_time.size(), 2u);
+    EXPECT_EQ(stats.equity_curve.x_time[0], records[1].close_date);
+    EXPECT_EQ(stats.equity_curve.x_time[1], records[0].close_date);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 150.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 50.0);
+    EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown, 100.0);
+}
+
+TEST(TradeStatsCalculatorTest, SameCloseDateAggregatesRealizedProfitBeforeDrawdown) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, -100.0, "EURUSD", optionx::TradeState::LOSS));
+    records.push_back(make_win_record(2, 2000, 10.0, 100.0, "EURUSD", optionx::TradeState::WIN));
+    records[0].close_date = 5000;
+    records[1].close_date = 5000;
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 1000.0;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.x_time.size(), 1u);
+    EXPECT_EQ(stats.equity_curve.x_time[0], 5000);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 1000.0);
+    ASSERT_EQ(stats.profit_curve.y_value.size(), 1u);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[0], 0.0);
+    EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown, 0.0);
+}
+
+TEST(TradeStatsCalculatorTest, ProfitPercentCurveUsesStartBalance) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
+    records.push_back(make_win_record(2, 2000, 10.0, -5.0, "EURUSD", optionx::TradeState::LOSS));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 100.0;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.profit_percent_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[0], 10.0);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[1], 5.0);
+}
+
+TEST(TradeStatsCalculatorTest, ProfitPercentCurveEmptyWithoutStartBalance) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 0.0;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+
+    EXPECT_TRUE(stats_ptr->profit_percent_curve.y_value.empty());
+}
+
+TEST(TradeStatsCalculatorTest, RealizedCurveFallsBackToOpenDateWhenCloseDateMissing) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 10.0, 8.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().close_date = 0;
+    records.push_back(make_win_record(2, 2000, 10.0, 7.0, "EURUSD", optionx::TradeState::WIN));
+
+    optionx::TradeStatsConfig cfg;
+    cfg.start_balance = 100.0;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.x_time.size(), 2u);
+    EXPECT_EQ(stats.equity_curve.x_time[0], records[0].open_date);
+    EXPECT_EQ(stats.equity_curve.x_time[1], records[1].close_date);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 108.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 115.0);
+}
+
 TEST(TradeStatsCalculatorTest, SelectionAppliesToMonetaryStats) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, 8.0, "EURUSD", optionx::TradeState::WIN));

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -66,8 +66,8 @@ TradeRecord make_win_record(
     record.amount = amount;
     record.payout = 0.82;
     record.profit = profit;
-    record.open_balance = 1000.0;
-    record.close_balance = 1000.0 + profit;
+    record.set_open_balance(1000.0);
+    record.set_close_balance(1000.0 + profit);
     record.trade_state = state;
     record.open_price = 1.12345;
     record.close_price = 1.12400;
@@ -574,11 +574,11 @@ TEST(TradeStatsCalculatorTest, RealizedCurveFallsBackToOpenDateWhenCloseDateMiss
 TEST(TradeStatsCalculatorTest, RecordBalanceModeUsesSnapshotsWithoutStartBalance) {
     std::vector<TradeRecord> records;
     records.push_back(make_win_record(1, 1000, 10.0, -5.0, "EURUSD", optionx::TradeState::LOSS));
-    records.back().open_balance = 1000.0;
-    records.back().close_balance = 995.0;
+    records.back().set_open_balance(1000.0);
+    records.back().set_close_balance(995.0);
     records.push_back(make_win_record(2, 2000, 10.0, 15.0, "EURUSD", optionx::TradeState::WIN));
-    records.back().open_balance = 995.0;
-    records.back().close_balance = 1010.0;
+    records.back().set_open_balance(995.0);
+    records.back().set_close_balance(1010.0);
 
     optionx::TradeStatsConfig cfg;
     cfg.equity_mode = optionx::TradeStatsEquityMode::RECORD_BALANCE;
@@ -603,14 +603,14 @@ TEST(TradeStatsCalculatorTest, PortfolioBalanceModeCombinesAccountsInBaseCurrenc
     records.push_back(make_win_record(2, 2000, 1000.0, -900.0, "EURUSD", optionx::TradeState::LOSS));
     records.back().account_id = 2;
     records.back().currency = optionx::CurrencyType::RUB;
-    records.back().open_balance = 90000.0;
-    records.back().close_balance = 89100.0;
+    records.back().set_open_balance(90000.0);
+    records.back().set_close_balance(89100.0);
 
     records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
     records.back().account_id = 1;
     records.back().currency = optionx::CurrencyType::USD;
-    records.back().open_balance = 1000.0;
-    records.back().close_balance = 1010.0;
+    records.back().set_open_balance(1000.0);
+    records.back().set_close_balance(1010.0);
 
     optionx::TradeStatsConfig cfg;
     cfg.equity_mode = optionx::TradeStatsEquityMode::PORTFOLIO_BALANCE;
@@ -632,6 +632,54 @@ TEST(TradeStatsCalculatorTest, PortfolioBalanceModeCombinesAccountsInBaseCurrenc
     ASSERT_EQ(stats.profit_percent_curve.y_value.size(), 2u);
     EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[1], (1.0 / 1900.0) * 100.0);
     EXPECT_DOUBLE_EQ(stats.total_profit, 1.0);
+}
+
+TEST(TradeStatsCalculatorTest, RecordBalanceModePreservesZeroCloseBalanceSnapshot) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 100.0, -100.0, "EURUSD", optionx::TradeState::LOSS));
+    records.back().set_open_balance(100.0);
+    records.back().set_close_balance(0.0);
+
+    optionx::TradeStatsConfig cfg;
+    cfg.equity_mode = optionx::TradeStatsEquityMode::RECORD_BALANCE;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.y_value.size(), 1u);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 0.0);
+    ASSERT_EQ(stats.profit_curve.y_value.size(), 1u);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[0], -100.0);
+    ASSERT_EQ(stats.profit_percent_curve.y_value.size(), 1u);
+    EXPECT_DOUBLE_EQ(stats.profit_percent_curve.y_value[0], -100.0);
+    EXPECT_DOUBLE_EQ(stats.max_absolute_drawdown, 100.0);
+    EXPECT_DOUBLE_EQ(stats.max_relative_drawdown, 1.0);
+}
+
+TEST(TradeStatsCalculatorTest, PortfolioBalanceModePreservesZeroAccountSnapshot) {
+    std::vector<TradeRecord> records;
+    records.push_back(make_win_record(1, 1000, 100.0, -100.0, "EURUSD", optionx::TradeState::LOSS));
+    records.back().account_id = 1;
+    records.back().set_open_balance(100.0);
+    records.back().set_close_balance(0.0);
+
+    records.push_back(make_win_record(2, 2000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
+    records.back().account_id = 2;
+    records.back().set_open_balance(1000.0);
+    records.back().set_close_balance(1010.0);
+
+    optionx::TradeStatsConfig cfg;
+    cfg.equity_mode = optionx::TradeStatsEquityMode::PORTFOLIO_BALANCE;
+    cfg.include_non_terminal = false;
+    auto stats_ptr = TradeStatsCalculator::calc(records, cfg);
+    auto& stats = *stats_ptr;
+
+    ASSERT_EQ(stats.equity_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[0], 0.0);
+    EXPECT_DOUBLE_EQ(stats.equity_curve.y_value[1], 1010.0);
+    ASSERT_EQ(stats.profit_curve.y_value.size(), 2u);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[0], -100.0);
+    EXPECT_DOUBLE_EQ(stats.profit_curve.y_value[1], -90.0);
 }
 
 TEST(TradeStatsCalculatorTest, SelectionAppliesToMonetaryStats) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -66,9 +66,8 @@ TradeRecord make_win_record(
     record.amount = amount;
     record.payout = 0.82;
     record.profit = profit;
-    record.balance = 1000.0 + profit;
     record.open_balance = 1000.0;
-    record.close_balance = record.balance;
+    record.close_balance = 1000.0 + profit;
     record.trade_state = state;
     record.open_price = 1.12345;
     record.close_price = 1.12400;
@@ -577,11 +576,9 @@ TEST(TradeStatsCalculatorTest, RecordBalanceModeUsesSnapshotsWithoutStartBalance
     records.push_back(make_win_record(1, 1000, 10.0, -5.0, "EURUSD", optionx::TradeState::LOSS));
     records.back().open_balance = 1000.0;
     records.back().close_balance = 995.0;
-    records.back().balance = 995.0;
     records.push_back(make_win_record(2, 2000, 10.0, 15.0, "EURUSD", optionx::TradeState::WIN));
     records.back().open_balance = 995.0;
     records.back().close_balance = 1010.0;
-    records.back().balance = 1010.0;
 
     optionx::TradeStatsConfig cfg;
     cfg.equity_mode = optionx::TradeStatsEquityMode::RECORD_BALANCE;
@@ -608,14 +605,12 @@ TEST(TradeStatsCalculatorTest, PortfolioBalanceModeCombinesAccountsInBaseCurrenc
     records.back().currency = optionx::CurrencyType::RUB;
     records.back().open_balance = 90000.0;
     records.back().close_balance = 89100.0;
-    records.back().balance = 89100.0;
 
     records.push_back(make_win_record(1, 1000, 10.0, 10.0, "EURUSD", optionx::TradeState::WIN));
     records.back().account_id = 1;
     records.back().currency = optionx::CurrencyType::USD;
     records.back().open_balance = 1000.0;
     records.back().close_balance = 1010.0;
-    records.back().balance = 1010.0;
 
     optionx::TradeStatsConfig cfg;
     cfg.equity_mode = optionx::TradeStatsEquityMode::PORTFOLIO_BALANCE;

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -84,6 +84,8 @@ optionx::TradeResult make_result() {
     result.payout = 0.82;
     result.profit = 12.71;
     result.balance = 1012.71;
+    result.open_balance = 997.21;
+    result.close_balance = 1012.71;
     result.open_price = 1.12345;
     result.close_price = 1.12400;
     result.delay = 30;
@@ -161,6 +163,9 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.request_unique_hash, "request-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
+    EXPECT_DOUBLE_EQ(record.balance, 1012.71);
+    EXPECT_DOUBLE_EQ(record.open_balance, 997.21);
+    EXPECT_DOUBLE_EQ(record.close_balance, 1012.71);
     EXPECT_EQ(record.close_date, 1712345700000);
     EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
     EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
@@ -189,6 +194,19 @@ TEST(TradeRecordFactoryTest, PreservesRequestContextWhenResultIsPartial) {
     EXPECT_EQ(record.close_date, 1712345700000);
     EXPECT_EQ(record.error_code, optionx::TradeErrorCode::PARSING_ERROR);
     EXPECT_EQ(record.error_desc, "partial broker response");
+}
+
+TEST(TradeRecordFactoryTest, TreatsLegacyResultBalanceAsCloseBalance) {
+    auto result = make_result();
+    result.open_balance = 0.0;
+    result.close_balance = 0.0;
+    result.balance = 1007.5;
+
+    const auto record = optionx::TradeRecord::from_trade(make_request(), result);
+
+    EXPECT_DOUBLE_EQ(record.balance, 1007.5);
+    EXPECT_DOUBLE_EQ(record.open_balance, 0.0);
+    EXPECT_DOUBLE_EQ(record.close_balance, 1007.5);
 }
 
 TEST(TradeRecordFactoryTest, UsesCloseDateForPlannedAndKnownCloseTime) {

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -119,7 +119,7 @@ optionx::TradeRecord make_record() {
 
 } // namespace
 
-TEST(TradeRecordSerializationTest, RoundTripsBinaryV2) {
+TEST(TradeRecordSerializationTest, RoundTripsBinaryV3) {
     const auto record = make_record();
     const auto bytes = record.to_bytes();
     const auto restored = optionx::TradeRecord::from_bytes(bytes.data(), bytes.size());
@@ -163,7 +163,6 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.request_unique_hash, "request-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
-    EXPECT_DOUBLE_EQ(record.balance, 1012.71);
     EXPECT_DOUBLE_EQ(record.open_balance, 997.21);
     EXPECT_DOUBLE_EQ(record.close_balance, 1012.71);
     EXPECT_EQ(record.close_date, 1712345700000);
@@ -204,9 +203,20 @@ TEST(TradeRecordFactoryTest, TreatsLegacyResultBalanceAsCloseBalance) {
 
     const auto record = optionx::TradeRecord::from_trade(make_request(), result);
 
-    EXPECT_DOUBLE_EQ(record.balance, 1007.5);
     EXPECT_DOUBLE_EQ(record.open_balance, 0.0);
     EXPECT_DOUBLE_EQ(record.close_balance, 1007.5);
+}
+
+TEST(TradeRecordFactoryTest, EstimatesCloseBalanceFromOpenBalanceAndProfit) {
+    optionx::TradeResult result;
+    result.open_balance = 1000.0;
+    result.profit = -15.5;
+    result.trade_state = optionx::TradeState::LOSS;
+
+    const auto record = optionx::TradeRecord::from_trade(make_request(), result);
+
+    EXPECT_DOUBLE_EQ(record.open_balance, 1000.0);
+    EXPECT_DOUBLE_EQ(record.close_balance, 984.5);
 }
 
 TEST(TradeRecordFactoryTest, UsesCloseDateForPlannedAndKnownCloseTime) {

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -83,9 +83,9 @@ optionx::TradeResult make_result() {
     result.amount = 15.5;
     result.payout = 0.82;
     result.profit = 12.71;
-    result.balance = 1012.71;
-    result.open_balance = 997.21;
-    result.close_balance = 1012.71;
+    result.set_balance(1012.71);
+    result.set_open_balance(997.21);
+    result.set_close_balance(1012.71);
     result.open_price = 1.12345;
     result.close_price = 1.12400;
     result.delay = 30;
@@ -163,6 +163,8 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.request_unique_hash, "request-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
+    EXPECT_TRUE(record.has_open_balance());
+    EXPECT_TRUE(record.has_close_balance());
     EXPECT_DOUBLE_EQ(record.open_balance, 997.21);
     EXPECT_DOUBLE_EQ(record.close_balance, 1012.71);
     EXPECT_EQ(record.close_date, 1712345700000);
@@ -195,28 +197,54 @@ TEST(TradeRecordFactoryTest, PreservesRequestContextWhenResultIsPartial) {
     EXPECT_EQ(record.error_desc, "partial broker response");
 }
 
-TEST(TradeRecordFactoryTest, TreatsLegacyResultBalanceAsCloseBalance) {
+TEST(TradeRecordFactoryTest, DoesNotTreatLatestBalanceAsCloseBalance) {
     auto result = make_result();
+    result.balance_flags = 0;
     result.open_balance = 0.0;
     result.close_balance = 0.0;
-    result.balance = 1007.5;
+    result.set_balance(1007.5);
 
     const auto record = optionx::TradeRecord::from_trade(make_request(), result);
 
+    EXPECT_FALSE(record.has_open_balance());
+    EXPECT_FALSE(record.has_close_balance());
     EXPECT_DOUBLE_EQ(record.open_balance, 0.0);
-    EXPECT_DOUBLE_EQ(record.close_balance, 1007.5);
+    EXPECT_DOUBLE_EQ(record.close_balance, 0.0);
 }
 
 TEST(TradeRecordFactoryTest, EstimatesCloseBalanceFromOpenBalanceAndProfit) {
     optionx::TradeResult result;
-    result.open_balance = 1000.0;
+    result.set_open_balance(1000.0);
     result.profit = -15.5;
     result.trade_state = optionx::TradeState::LOSS;
 
     const auto record = optionx::TradeRecord::from_trade(make_request(), result);
 
+    EXPECT_TRUE(record.has_open_balance());
+    EXPECT_TRUE(record.has_close_balance());
     EXPECT_DOUBLE_EQ(record.open_balance, 1000.0);
     EXPECT_DOUBLE_EQ(record.close_balance, 984.5);
+}
+
+TEST(TradeRecordFactoryTest, PreservesExplicitZeroCloseBalance) {
+    optionx::TradeResult result;
+    result.set_open_balance(100.0);
+    result.set_close_balance(0.0);
+    result.profit = -100.0;
+    result.trade_state = optionx::TradeState::LOSS;
+
+    const auto record = optionx::TradeRecord::from_trade(make_request(), result);
+
+    EXPECT_TRUE(record.has_open_balance());
+    EXPECT_TRUE(record.has_close_balance());
+    EXPECT_DOUBLE_EQ(record.open_balance, 100.0);
+    EXPECT_DOUBLE_EQ(record.close_balance, 0.0);
+
+    const auto bytes = record.to_bytes();
+    const auto restored = optionx::TradeRecord::from_bytes(bytes.data(), bytes.size());
+    EXPECT_TRUE(restored.has_open_balance());
+    EXPECT_TRUE(restored.has_close_balance());
+    EXPECT_DOUBLE_EQ(restored.close_balance, 0.0);
 }
 
 TEST(TradeRecordFactoryTest, UsesCloseDateForPlannedAndKnownCloseTime) {


### PR DESCRIPTION
## What Changed

- Build realized synthetic equity/profit curves from PnL grouped by result timestamp, so same-moment closes do not create artificial drawdown.
- Aggregate sweep-line free-funds events by timestamp before drawdown calculation, so simultaneous open/close cash events do not create artificial intramoment drawdown.
- Keep realized stats ordered by result time even for the legacy `PLACE_DATE_ASC` hint.
- Apply `TradeStatsSelection` to monetary result statistics as well as outcome counts, so `FIRST_MM_STEP` / `LAST_IN_GROUP` no longer mix selected winrate counts with all-trade profit totals.
- Add `profit_percent_curve` for synthetic and balance-snapshot equity curves.
- Keep latest/current `balance` on `TradeResult`, and add explicit presence flags for `balance`, `open_balance`, and `close_balance`.
- Store explicit `open_balance` / `close_balance` snapshots on `TradeRecord` with presence flags, so a real `0.0` balance is distinguishable from ?not available?.
- Stop treating late broker balance snapshots as a per-trade close balance; final/live close-equivalent balance is derived as `open_balance + profit` when a monetary result is known.
- Preserve a trusted idle balance baseline across local trade bursts, so delayed broker balance polling after one or more opens does not overwrite the pre-storm open balance for subsequent trades.
- Add `TradeStatsEquityMode`:
  - `SYNTHETIC_PROFIT`: `start_balance + cumulative realized PnL`.
  - `RECORD_BALANCE`: single-account equity from record balance snapshots.
  - `PORTFOLIO_BALANCE`: multi-account equity from per-account snapshots.
- Add `TradeCurrencyConversionMatrix` and `convert_currency` hook for multi-currency portfolio stats.
- Added regression tests for shuffled input ordering, same timestamp realized/free-funds aggregation, selected monetary totals, snapshot equity mode, portfolio conversion, explicit zero balance snapshots, storage roundtrip, and trusted trade-storm balances.

## Why

F-039/F-040: trade statistics could produce different realized curves/series depending on input order, and selected outcome modes could divide all-trade monetary totals by selected-trade counts. That made averages and curves misleading for callers passing DB/history records in non-chronological order or using money-management selection modes.

The follow-up also makes the equity source explicit. Synthetic stats still work for imported histories without balance snapshots, while account/portfolio modes can use `TradeRecord` balance snapshots when they are available. `TradeResult::balance` remains a latest account snapshot, while `open_balance` and `close_balance` are explicit per-trade balance fields.

## Validation

- `cmake --build build-codex --target trade_record_stats_test -- -j1`
- `./build-codex/trade_record_stats_test.exe --gtest_brief=1` (32/32 passed)
- `cmake --build build-codex --target trade_record_storage_test -- -j1`
- `./build-codex/trade_record_storage_test.exe --gtest_brief=1` (11/11 passed)
- `cmake --build build-codex --target trade_record_db_test -- -j1`
- `./build-codex/trade_record_db_test.exe --gtest_brief=1` (21/21 passed)
- `cmake --build build-codex --target trade_manager_test -- -j1`
- `./build-codex/trade_manager_test.exe --gtest_brief=1` (20/20 passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (4/4 passed)
- `git diff --check`
