### PR TITLE
[codex] Guard Windows CMake link libraries

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -1,0 +1,31 @@
+name: Ubuntu Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  trade-record-db:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+
+      - name: Configure
+        run: cmake -S . -B build-linux -DBUILD_DEPS=ON -DBUILD_TESTS=ON
+
+      - name: Build trade_record_db_test
+        run: cmake --build build-linux --target trade_record_db_test -j
+
+      - name: Run trade_record_db_test
+        run: ./build-linux/trade_record_db_test --gtest_brief=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,27 @@ set(DEPS_BUILD_DIR "" CACHE PATH "Path to directory where dependencies were buil
 set(LOGIT_BASE_PATH "${CMAKE_SOURCE_DIR}" CACHE PATH "Base path for LOGIT logs")
 file(TO_CMAKE_PATH "${LOGIT_BASE_PATH}" LOGIT_BASE_PATH_FWD)
 
+function(optionx_get_network_link_libraries out_var)
+    if(WIN32)
+        set(network_libs
+            ssl
+            crypto
+            curl
+        )
+    else()
+        find_package(OpenSSL REQUIRED)
+        find_package(CURL REQUIRED)
+
+        set(network_libs
+            OpenSSL::SSL
+            OpenSSL::Crypto
+            CURL::libcurl
+        )
+    endif()
+
+    set(${out_var} ${network_libs} PARENT_SCOPE)
+endfunction()
+
 if(BUILD_DEPS)
     add_subdirectory(external)
 endif()
@@ -52,10 +73,10 @@ if(BUILD_EXAMPLES)
         KURLYK_OAUTH_SUPPORT=0
     )
 
+    optionx_get_network_link_libraries(EXAMPLE_NETWORK_LIBS)
+
     set(EXAMPLE_LIBS
-        ssl
-        crypto
-        curl
+        ${EXAMPLE_NETWORK_LIBS}
         mdbx
         AES
     )
@@ -129,10 +150,10 @@ if(BUILD_TESTS)
         KURLYK_OAUTH_SUPPORT=0
     )
 
+    optionx_get_network_link_libraries(PROJECT_NETWORK_LIBS)
+
     set(PROJECT_LIBS
-        ssl
-        crypto
-        curl
+        ${PROJECT_NETWORK_LIBS}
         mdbx
         AES
         gtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,17 +53,22 @@ if(BUILD_EXAMPLES)
     )
 
     set(EXAMPLE_LIBS
-        ws2_32
-        wsock32
-        crypt32
         ssl
         crypto
         curl
         mdbx
-        ntdll
-        bcrypt
         AES
     )
+
+    if(WIN32)
+        list(APPEND EXAMPLE_LIBS
+            ws2_32
+            wsock32
+            crypt32
+            ntdll
+            bcrypt
+        )
+    endif()
 
     add_executable(trade_record_db_example examples/trade_record_db_example.cpp)
 
@@ -125,18 +130,23 @@ if(BUILD_TESTS)
     )
 
     set(PROJECT_LIBS
-        ws2_32
-        wsock32
-        crypt32
         ssl
         crypto
         curl
         mdbx
-        ntdll
-        bcrypt
         AES
         gtest
     )
+
+    if(WIN32)
+        list(APPEND PROJECT_LIBS
+            ws2_32
+            wsock32
+            crypt32
+            ntdll
+            bcrypt
+        )
+    endif()
 
     file(GLOB_RECURSE PROJECT_HEADERS
         RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -11,8 +11,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_link_options(
         -static-libgcc
         -static-libstdc++
-        -static-libwinpthread
     )
+
+    if(MINGW)
+        add_link_options(
+            -static-libwinpthread
+        )
+    endif()
 
 elseif (MSVC)
     add_compile_options(
@@ -32,6 +37,7 @@ include(${EXTERNAL_CMAKE_DIR}/install-runtime-dlls.cmake)
 # mdbx
 include(${EXTERNAL_CMAKE_DIR}/libmdbx-wrapper.cmake)
 
+if(WIN32)
 # openssl
 install_headers_to_include(openssl ${CMAKE_CURRENT_LIST_DIR}/openssl-win64-v3.4.0/include/openssl)
 install_static_libs_to_lib(${CMAKE_CURRENT_LIST_DIR}/openssl-win64-v3.4.0/lib/VC/x64/MT)
@@ -51,6 +57,10 @@ file(COPY
     ${CMAKE_CURRENT_LIST_DIR}/curl-8.11.0_1-win64-mingw/bin/curl-ca-bundle.crt
     DESTINATION ${CMAKE_BINARY_DIR}/bin
 )
+else()
+    find_package(OpenSSL REQUIRED)
+    find_package(CURL REQUIRED)
+endif()
 
 # AES
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/AES)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -58,8 +58,8 @@ file(COPY
     DESTINATION ${CMAKE_BINARY_DIR}/bin
 )
 else()
-    find_package(OpenSSL REQUIRED)
-    find_package(CURL REQUIRED)
+    # Non-Windows builds use system OpenSSL/CURL targets from the root
+    # tests/examples link configuration.
 endif()
 
 # AES


### PR DESCRIPTION
## What Changed

- Split common test/example link libraries from Windows-only system libraries.
- Append `ws2_32`, `wsock32`, `crypt32`, `ntdll`, and `bcrypt` only under `WIN32`.
- Keep existing Windows builds using the same libraries while avoiding non-Windows configure/link failures from WinAPI names.
- Add a minimal Ubuntu GitHub Actions smoke workflow that configures dependencies, builds `trade_record_db_test`, and runs it.

## Why

F-029: tests/examples CMake linked Windows system libraries unconditionally, which makes the build path Windows-biased even though the library itself is header-only and the dependency layout is otherwise cross-platform friendly.

The workflow gives this portability fix a real non-Windows validation path instead of relying only on a Windows local build.

## Validation

Local Windows:

- `cmake --build build-codex --target trade_record_db_test -- -j1`
- `./build-codex/trade_record_db_test.exe --gtest_brief=1` (21/21 passed)
- `git diff --check`

GitHub Actions:

- `Ubuntu Smoke / trade-record-db` passed on `ubuntu-latest` (run `28407803320`): configured with `BUILD_DEPS=ON`, built `trade_record_db_test`, and ran it.


