### PR TITLE
[codex] Preserve UTF-8 filesystem paths

### DIFF
--- a/include/optionx_cpp/utils/path_utils.hpp
+++ b/include/optionx_cpp/utils/path_utils.hpp
@@ -94,7 +94,9 @@ namespace optionx::utils {
     /// \return Absolute path constructed as: exec_dir/relative_path
     /// \see get_exec_dir()
     inline std::string resolve_exec_path(const std::string& relative_path) {
-        return std::filesystem::absolute(get_exec_dir() + "/" + relative_path).string();
+        const auto exec_path = std::filesystem::u8path(get_exec_dir());
+        const auto relative = std::filesystem::u8path(relative_path);
+        return std::filesystem::absolute(exec_path / relative).u8string();
     }
 
     /// \brief Creates directory structure recursively.
@@ -102,7 +104,7 @@ namespace optionx::utils {
     /// \throw std::runtime_error If directory creation fails
     /// \note No-op if directory already exists
     inline void create_directories(const std::string& path) {
-        std::filesystem::path dir(path);
+        std::filesystem::path dir = std::filesystem::u8path(path);
         if (!std::filesystem::exists(dir)) {
             std::error_code ec;
             if (!std::filesystem::create_directories(dir, ec)) {

--- a/tests/utils_core_test.cpp
+++ b/tests/utils_core_test.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <optionx_cpp/utils.hpp>
@@ -19,6 +20,18 @@ std::string unique_path_component(const std::string& prefix) {
     return prefix + "_" + std::to_string(stamp) + "_" +
            std::to_string(counter.fetch_add(1));
 }
+
+struct ScopedPathCleanup {
+    explicit ScopedPathCleanup(std::filesystem::path cleanup_path)
+        : path(std::move(cleanup_path)) {}
+
+    ~ScopedPathCleanup() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+
+    std::filesystem::path path;
+};
 
 } // namespace
 
@@ -61,10 +74,10 @@ TEST(PathUtilsTest, CreatesUtf8DirectoriesFromUtf8Strings) {
         "\xD1\x82\xD0\xB5\xD1\x81\xD1\x82_\xE8\xB7\xAF\xE5\xBE\x84";
     const auto root = std::filesystem::temp_directory_path() /
         unique_path_component("optionx_path_utils");
-    const auto target = root / unicode_name / "nested";
+    const ScopedPathCleanup root_cleanup(root);
+    const auto target = root / std::filesystem::u8path(unicode_name) / "nested";
     const auto target_utf8 = target.u8string();
 
-    std::filesystem::remove_all(root);
     ASSERT_NO_THROW(optionx::utils::create_directories(target_utf8));
     EXPECT_TRUE(std::filesystem::is_directory(target));
 
@@ -75,11 +88,16 @@ TEST(PathUtilsTest, CreatesUtf8DirectoriesFromUtf8Strings) {
         std::filesystem::u8path(relative).filename().u8string(),
         "nested");
 
-    const auto resolved = optionx::utils::resolve_exec_path(unicode_name);
-    EXPECT_TRUE(std::filesystem::u8path(resolved).is_absolute());
-    EXPECT_EQ(optionx::utils::get_file_name(resolved), unicode_name);
+    const auto exec_relative_root = unique_path_component("optionx_exec_path");
+    const auto exec_relative_path = exec_relative_root + "/" + unicode_name + "/nested";
+    const auto resolved = optionx::utils::resolve_exec_path(exec_relative_path);
+    const auto resolved_path = std::filesystem::u8path(resolved);
+    const ScopedPathCleanup exec_cleanup(resolved_path.parent_path().parent_path());
 
-    std::filesystem::remove_all(root);
+    EXPECT_TRUE(resolved_path.is_absolute());
+    EXPECT_EQ(resolved_path.parent_path().filename().u8string(), unicode_name);
+    ASSERT_NO_THROW(optionx::utils::create_directories(resolved));
+    EXPECT_TRUE(std::filesystem::is_directory(resolved_path));
 }
 
 TEST(FixedPointUtilsTest, PrecisionToleranceUsesHalfDecimalStep) {

--- a/tests/utils_core_test.cpp
+++ b/tests/utils_core_test.cpp
@@ -1,10 +1,26 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <optionx_cpp/utils.hpp>
+
+namespace {
+
+std::string unique_path_component(const std::string& prefix) {
+    static std::atomic<std::uint64_t> counter{0};
+    const auto stamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    return prefix + "_" + std::to_string(stamp) + "_" +
+           std::to_string(counter.fetch_add(1));
+}
+
+} // namespace
 
 TEST(StringUtilsTest, ParseListIgnoresEmptyInput) {
     std::vector<std::string> items{"existing"};
@@ -38,6 +54,32 @@ TEST(HttpUtilsTest, RemoveHttpPrefixOnlyRemovesLeadingScheme) {
     EXPECT_EQ(
         optionx::utils::remove_http_prefix("prefixhttps://intrade.bar"),
         "prefixhttps://intrade.bar");
+}
+
+TEST(PathUtilsTest, CreatesUtf8DirectoriesFromUtf8Strings) {
+    const std::string unicode_name =
+        "\xD1\x82\xD0\xB5\xD1\x81\xD1\x82_\xE8\xB7\xAF\xE5\xBE\x84";
+    const auto root = std::filesystem::temp_directory_path() /
+        unique_path_component("optionx_path_utils");
+    const auto target = root / unicode_name / "nested";
+    const auto target_utf8 = target.u8string();
+
+    std::filesystem::remove_all(root);
+    ASSERT_NO_THROW(optionx::utils::create_directories(target_utf8));
+    EXPECT_TRUE(std::filesystem::is_directory(target));
+
+    const auto relative = optionx::utils::make_relative(
+        target_utf8,
+        root.u8string());
+    EXPECT_EQ(
+        std::filesystem::u8path(relative).filename().u8string(),
+        "nested");
+
+    const auto resolved = optionx::utils::resolve_exec_path(unicode_name);
+    EXPECT_TRUE(std::filesystem::u8path(resolved).is_absolute());
+    EXPECT_EQ(optionx::utils::get_file_name(resolved), unicode_name);
+
+    std::filesystem::remove_all(root);
 }
 
 TEST(FixedPointUtilsTest, PrecisionToleranceUsesHalfDecimalStep) {


### PR DESCRIPTION
## What Changed

- Updated `resolve_exec_path()` to compose paths through `std::filesystem::u8path()` and return UTF-8 via `u8string()`.
- Updated `create_directories()` to treat incoming `std::string` paths as UTF-8 instead of the platform narrow codepage.
- Added a Unicode path regression test covering directory creation, relative path handling, and executable-relative path resolution.
- Strengthened the test so expected paths are also constructed through `u8path()`, avoiding the same narrow-string conversion the implementation fixes.

## Why

Covers F-022. The project API documents these helpers as UTF-8 string based, but Windows narrow `std::filesystem::path(path)` construction can interpret non-ASCII bytes through the active codepage. That makes Unicode paths fragile for users and tests.

## Validation

- `cmake --build build-codex --target utils_core_test -- -j1`
- `./build-codex/utils_core_test.exe --gtest_brief=1` (5/5 passed)
- `git diff --check`

Note: the build still prints existing external dependency warnings from `external/libmdbx` and `external/AES`; no new project warning was introduced by this PR.