### PR TITLE
[codex] Document open trades sync smoke

### DIFF
--- a/tests/intrade_bar_api/README.md
+++ b/tests/intrade_bar_api/README.md
@@ -25,6 +25,7 @@ $env:OPTIONX_INTRADE_BAR_CONFIG_FILE="tests\intrade_bar_api\intrade_bar_api.loca
 .\build-codex\intrade_bar_smoke_cli.exe history --source=HTML_CSV --all --account-type=DEMO --comment=account-history-export
 .\build-codex\intrade_bar_smoke_cli.exe switch-check --confirm --account-type=DEMO --currency=USD
 .\build-codex\intrade_bar_smoke_cli.exe open-trade --confirm --symbol=EURUSD --amount=1 --duration=60 --buy
+.\build-codex\intrade_bar_smoke_cli.exe open-trades-sync-check --confirm --symbol=BTCUSDT --amount=1 --duration=300 --count=1
 .\build-codex\intrade_bar_smoke_cli.exe open-check-result --confirm --symbol=BTCUSDT --amount=1 --duration=300 --buy
 ```
 
@@ -32,8 +33,8 @@ For RF/CIS domain blocking checks, keep `OPTIONX_INTRADE_BAR_AUTO_FIND_DOMAIN=1`
 and use a negative `OPTIONX_INTRADE_BAR_DOMAIN_MIN` to skip the primary
 `https://intrade.bar` host.
 
-`open-trade` and `open-check-result` require `--confirm` or
-`OPTIONX_INTRADE_BAR_ALLOW_TRADE=1`.
+`open-trade`, `open-trades-sync-check`, and `open-check-result` require
+`--confirm` or `OPTIONX_INTRADE_BAR_ALLOW_TRADE=1`.
 Real-account trades are refused unless both `--allow-real` and
 `OPTIONX_INTRADE_BAR_ALLOW_REAL_TRADE=1` are set.
 Set `OPTIONX_INTRADE_BAR_CLI_CONSOLE_LOG=1` when you want internal workflow

--- a/tests/intrade_bar_api/WORKFLOWS.md
+++ b/tests/intrade_bar_api/WORKFLOWS.md
@@ -202,4 +202,6 @@ shape without changing Intrade Bar parser literals.
 `auth-cache`, `show-account`, `quotes`, `history`, guarded `open-trade`,
 `open-trades-sync-check`, and `open-check-result` commands. Use
 `open-trades-sync-check` when validating broker active-trade snapshots,
-reconnect counter synchronization, and staggered close-time countdown behavior.
+reconnect counter synchronization, and close-time countdown behavior. Use
+`--count=2` or more with `--interval-ms=...` when validating staggered
+close-time countdowns.

--- a/tests/intrade_bar_api/WORKFLOWS.md
+++ b/tests/intrade_bar_api/WORKFLOWS.md
@@ -199,5 +199,7 @@ shape without changing Intrade Bar parser literals.
 4. Account type, currency, balance, and one live quote snapshot after auth.
 
 `intrade_bar_smoke_cli` exposes the same pieces manually through `auth`,
-`auth-cache`, `show-account`, `quotes`, `history`, guarded `open-trade`, and
-`open-check-result` commands.
+`auth-cache`, `show-account`, `quotes`, `history`, guarded `open-trade`,
+`open-trades-sync-check`, and `open-check-result` commands. Use
+`open-trades-sync-check` when validating broker active-trade snapshots,
+reconnect counter synchronization, and staggered close-time countdown behavior.


### PR DESCRIPTION
## What Changed

- Added `open-trades-sync-check` to the Intrade smoke README quick command list.
- Updated the guarded trade safety note to include `open-trades-sync-check`.
- Added the command to `WORKFLOWS.md` live smoke coverage and described what it validates.
- Clarified that staggered close-time countdown validation requires `--count=2` or more with `--interval-ms=...`; the quick example remains a safer one-trade smoke.

## Why

Covers F-026. The full command reference already documented `open-trades-sync-check`, but the quick smoke helper and workflow coverage map still omitted it, making the active-trades synchronization smoke path easy to miss.

## Validation

- `git diff --check`

Docs-only change; no build was required.