### PR TITLE
[codex] Document trade queue loop ownership

### DIFF
--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -203,8 +203,9 @@ facade lifecycle или остаться probe/internal component.
 - Trade result callbacks вызываются через queue/result flow.
 - Persistent trade storage uses TradeRequest::trade_id, not unique_id.
 - `TradeQueueManager::add_trade()` is the only queue entry point intended for
-  external callers. It locks pending queue intake, but the rest of the queue
-  state is owned by the platform event loop.
+  external callers. It synchronizes only final insertion into the pending
+  queue; the caller must ensure the trade ID provider, account info access, and
+  preprocess callback are safe from that calling thread.
 
 Инварианты:
 
@@ -214,9 +215,9 @@ facade lifecycle или остаться probe/internal component.
 - Не строй primary ID сделки из даты или timestamp bucket.
 - Сохраняй propagation TradeRequest::trade_id -> TradeResult::trade_id.
 - Не меняй active/pending trades напрямую из platform manager.
-- Do not call `TradeQueueManager::process()` or event handlers concurrently
-  with the platform loop. Local open-trade counters, broker snapshot counters,
-  and active transaction lists are single-loop state.
+- Do not call `TradeQueueManager::process()`, `finalize_all_trades()`, or event
+  handlers concurrently with the platform loop. Local open-trade counters,
+  broker snapshot counters, and active transaction lists are single-loop state.
 - Preprocess hook должен вернуть `false` и заполнить result error, если request
   невалиден.
 - On shutdown все pending/active trades должны финализироваться.

--- a/guides/implementation-notes.md
+++ b/guides/implementation-notes.md
@@ -202,6 +202,9 @@ facade lifecycle или остаться probe/internal component.
 - State manager отвечает за допустимые переходы и проверки.
 - Trade result callbacks вызываются через queue/result flow.
 - Persistent trade storage uses TradeRequest::trade_id, not unique_id.
+- `TradeQueueManager::add_trade()` is the only queue entry point intended for
+  external callers. It locks pending queue intake, but the rest of the queue
+  state is owned by the platform event loop.
 
 Инварианты:
 
@@ -211,6 +214,9 @@ facade lifecycle или остаться probe/internal component.
 - Не строй primary ID сделки из даты или timestamp bucket.
 - Сохраняй propagation TradeRequest::trade_id -> TradeResult::trade_id.
 - Не меняй active/pending trades напрямую из platform manager.
+- Do not call `TradeQueueManager::process()` or event handlers concurrently
+  with the platform loop. Local open-trade counters, broker snapshot counters,
+  and active transaction lists are single-loop state.
 - Preprocess hook должен вернуть `false` и заполнить result error, если request
   невалиден.
 - On shutdown все pending/active trades должны финализироваться.

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
@@ -21,11 +21,14 @@ namespace optionx::modules {
     /// - `OpenTradesEvent`: Notifies about open trade count updates.
     ///
     /// ### Threading contract:
-    /// - `add_trade()` may be called from outside the platform event loop; it
-    ///   locks only pending queue intake.
-    /// - `process()` and event handlers are platform event-loop owned. Local
-    ///   open-trade counters, broker snapshot counters, and active transaction
-    ///   lists must not be driven concurrently from another thread.
+    /// - `add_trade()` is the only supported external enqueue entry point, but
+    ///   it synchronizes only final insertion into the pending queue. The caller
+    ///   must ensure the trade ID provider, account info access, and preprocess
+    ///   callback are safe from the calling thread.
+    /// - `process()`, `finalize_all_trades()`, and event handlers are platform
+    ///   event-loop owned. Local open-trade counters, broker snapshot counters,
+    ///   and active transaction lists must not be driven concurrently from
+    ///   another thread.
     class TradeQueueManager : public utils::EventMediator {
     public:
         using transaction_t = std::shared_ptr<events::TradeTransactionEvent>;

--- a/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
+++ b/include/optionx_cpp/modules/BaseTradeExecutionModule/TradeQueueManager.hpp
@@ -19,6 +19,13 @@ namespace optionx::modules {
     /// - `TradeRequestEvent`: Notifies when a trade request is sent.
     /// - `TradeStatusEvent`: Reports trade state changes.
     /// - `OpenTradesEvent`: Notifies about open trade count updates.
+    ///
+    /// ### Threading contract:
+    /// - `add_trade()` may be called from outside the platform event loop; it
+    ///   locks only pending queue intake.
+    /// - `process()` and event handlers are platform event-loop owned. Local
+    ///   open-trade counters, broker snapshot counters, and active transaction
+    ///   lists must not be driven concurrently from another thread.
     class TradeQueueManager : public utils::EventMediator {
     public:
         using transaction_t = std::shared_ptr<events::TradeTransactionEvent>;


### PR DESCRIPTION
## What Changed

- Documented the `TradeQueueManager` threading contract in its public Doxygen block.
- Updated implementation notes to state that only pending queue insertion is synchronized internally.
- Clarified that callers must ensure trade ID provider, account info access, and preprocess callback are safe from the calling thread.
- Marked `process()`, `finalize_all_trades()`, and event handlers as platform event-loop-owned operations.

## Why

Covers F-050 as a contract/documentation fix. The queue has a mutex for final pending-list insertion, but that mutex does not make the full `add_trade()` path or the active/snapshot state cross-thread safe. The intended model is external enqueueing through the facade and single platform event-loop ownership after intake.

## Validation

- `git diff --check`

Docs/comment-only change; no build was required.