### PR TITLE
[codex] Make trade record range filters explicit

### DIFF
--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "enums.hpp"
@@ -90,19 +91,19 @@ namespace optionx {
         std::int64_t stop_second_of_day = 0;    ///< Range end in seconds from midnight (0..86399).
         bool use_second_of_day = false;         ///< Enable time-of-day filtering.
 
-        double min_amount = 0.0;
-        double max_amount = 0.0;
-        double min_payout = 0.0;
-        double max_payout = 0.0;
-        double min_profit = 0.0;
-        double max_profit = 0.0;
-        double min_balance = 0.0; ///< Minimum close-equivalent balance.
-        double max_balance = 0.0; ///< Maximum close-equivalent balance.
+        std::optional<double> min_amount;  ///< Minimum trade amount, if set.
+        std::optional<double> max_amount;  ///< Maximum trade amount, if set.
+        std::optional<double> min_payout;  ///< Minimum payout ratio, if set.
+        std::optional<double> max_payout;  ///< Maximum payout ratio, if set.
+        std::optional<double> min_profit;  ///< Minimum trade profit, if set.
+        std::optional<double> max_profit;  ///< Maximum trade profit, if set.
+        std::optional<double> min_balance; ///< Minimum close-equivalent balance, if set.
+        std::optional<double> max_balance; ///< Maximum close-equivalent balance, if set.
 
-        std::int64_t min_ping = 0;
-        std::int64_t max_ping = 0;
-        std::int64_t min_delay = 0;
-        std::int64_t max_delay = 0;
+        std::optional<std::int64_t> min_ping;  ///< Minimum request ping in milliseconds, if set.
+        std::optional<std::int64_t> max_ping;  ///< Maximum request ping in milliseconds, if set.
+        std::optional<std::int64_t> min_delay; ///< Minimum request delay in milliseconds, if set.
+        std::optional<std::int64_t> max_delay; ///< Maximum request delay in milliseconds, if set.
 
         bool only_terminal = false;      ///< Match only terminal trade states.
         bool only_non_terminal = false;  ///< Match only non-terminal trade states.

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -81,19 +81,19 @@ namespace optionx::storage {
             if (filter.only_first_mm_step && record.mm_step != 0) return false;
 
             // Scalar range checks
-            if (filter.min_amount > 0.0 && record.amount < filter.min_amount) return false;
-            if (filter.max_amount > 0.0 && record.amount > filter.max_amount) return false;
-            if (filter.min_payout > 0.0 && record.payout < filter.min_payout) return false;
-            if (filter.max_payout > 0.0 && record.payout > filter.max_payout) return false;
-            if (filter.min_profit > 0.0 && record.profit < filter.min_profit) return false;
-            if (filter.max_profit > 0.0 && record.profit > filter.max_profit) return false;
-            if (filter.min_balance > 0.0 && record.close_balance < filter.min_balance) return false;
-            if (filter.max_balance > 0.0 && record.close_balance > filter.max_balance) return false;
+            if (filter.min_amount && record.amount < *filter.min_amount) return false;
+            if (filter.max_amount && record.amount > *filter.max_amount) return false;
+            if (filter.min_payout && record.payout < *filter.min_payout) return false;
+            if (filter.max_payout && record.payout > *filter.max_payout) return false;
+            if (filter.min_profit && record.profit < *filter.min_profit) return false;
+            if (filter.max_profit && record.profit > *filter.max_profit) return false;
+            if (filter.min_balance && record.close_balance < *filter.min_balance) return false;
+            if (filter.max_balance && record.close_balance > *filter.max_balance) return false;
 
-            if (filter.min_ping > 0 && record.ping < filter.min_ping) return false;
-            if (filter.max_ping > 0 && record.ping > filter.max_ping) return false;
-            if (filter.min_delay > 0 && record.delay < filter.min_delay) return false;
-            if (filter.max_delay > 0 && record.delay > filter.max_delay) return false;
+            if (filter.min_ping && record.ping < *filter.min_ping) return false;
+            if (filter.max_ping && record.ping > *filter.max_ping) return false;
+            if (filter.min_delay && record.delay < *filter.min_delay) return false;
+            if (filter.max_delay && record.delay > *filter.max_delay) return false;
 
             // Local-time component filters
             if (selected_ms == 0) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -123,6 +123,18 @@ TEST(TradeRecordFilterMatcherTest, MatchesByAmountRange) {
     EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
 }
 
+TEST(TradeRecordFilterMatcherTest, OptionalRangeBoundsDistinguishUnsetFromZero) {
+    TradeRecordFilter filter;
+    EXPECT_FALSE(filter.max_profit.has_value());
+
+    filter.max_profit = 0.0;
+    ASSERT_TRUE(filter.max_profit.has_value());
+    EXPECT_DOUBLE_EQ(*filter.max_profit, 0.0);
+
+    filter.max_profit.reset();
+    EXPECT_FALSE(filter.max_profit.has_value());
+}
+
 TEST(TradeRecordFilterMatcherTest, MatchesZeroAndNegativeProfitRange) {
     TradeRecord loss = make_win_record(1, 100000, 10.0, -5.0);
     TradeRecord standoff = make_win_record(2, 100000, 10.0, 0.0);

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -123,6 +123,41 @@ TEST(TradeRecordFilterMatcherTest, MatchesByAmountRange) {
     EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
 }
 
+TEST(TradeRecordFilterMatcherTest, MatchesZeroAndNegativeProfitRange) {
+    TradeRecord loss = make_win_record(1, 100000, 10.0, -5.0);
+    TradeRecord standoff = make_win_record(2, 100000, 10.0, 0.0);
+    TradeRecord win = make_win_record(3, 100000, 10.0, 2.0);
+
+    TradeRecordQuery query;
+    query.filter.max_profit = 0.0;
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(loss, query));
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(standoff, query));
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(win, query));
+
+    query.filter.min_profit = -10.0;
+    query.filter.max_profit = -1.0;
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(loss, query));
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(standoff, query));
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(win, query));
+}
+
+TEST(TradeRecordFilterMatcherTest, MatchesZeroLatencyRange) {
+    TradeRecord immediate = make_win_record(1, 100000);
+    immediate.ping = 0;
+    immediate.delay = 0;
+
+    TradeRecord delayed = make_win_record(2, 100000);
+    delayed.ping = 1;
+    delayed.delay = 1;
+
+    TradeRecordQuery query;
+    query.filter.max_ping = 0;
+    query.filter.max_delay = 0;
+
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(immediate, query));
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(delayed, query));
+}
+
 TEST(TradeRecordFilterMatcherTest, OnlyTerminalFilter) {
     TradeRecord rec = make_win_record(1, 100000, 10.0, 8.2, "EURUSD", optionx::TradeState::IN_PROGRESS);
 


### PR DESCRIPTION
## What Changed

- Changed `TradeRecordFilter` scalar ranges from sentinel `0` values to `std::optional` bounds.
- Updated `TradeRecordFilterMatcher` to treat a range as active only when the optional bound is set.
- Added regression coverage for `max_profit = 0`, negative profit ranges, zero ping/delay bounds, and the unset-vs-zero optional contract.

## Why

F-038: the old `> 0` checks made valid range predicates impossible to express. Examples: `max_profit = 0` was treated as disabled, negative profit ranges could not be represented, and `max_ping = 0` / `max_delay = 0` could not filter exact zero-latency records.

## API Compatibility

This is an intentional source/ABI breaking change while the library is still in active development. `TradeRecordFilter` range fields changed from scalar values to `std::optional`; consumers that read, compare, increment, or bind these fields directly must be updated. Simple assignment such as `filter.min_amount = 10.0` still works, but clearing a bound is now explicit via `reset()` / `std::nullopt`.

## Validation

- `cmake --build build-codex --target trade_record_stats_test -- -j1`
- `./build-codex/trade_record_stats_test.exe --gtest_brief=1` (`35/35` passed)
- `cmake --build build-codex --target trade_record_db_test -- -j1`
- `./build-codex/trade_record_db_test.exe --gtest_brief=1` (`21/21` passed)
- `git diff --check`