### PR TITLE
[codex] Decouple TradeStats DTO from utils

### DIFF
--- a/include/optionx_cpp/data/trading.hpp
+++ b/include/optionx_cpp/data/trading.hpp
@@ -46,6 +46,7 @@
 #include "trading/TradeRecordFilter.hpp"
 #include "trading/TradeRecordQuery.hpp"
 #include "trading/TradeHistoryResult.hpp"
+#include "trading/trade_state_traits.hpp"
 #include "trading/TradeStats.hpp"
 
 #endif // _OPTIONX_TRADING_HPP_INCLUDED

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -17,7 +17,7 @@
 #include "TradeRecord.hpp"
 #include "TradeRecordFilter.hpp"
 #include "TradeTimeZone.hpp"
-#include "utils/trade_state_utils.hpp"
+#include "trade_state_traits.hpp"
 
 namespace optionx {
 

--- a/include/optionx_cpp/data/trading/trade_state_traits.hpp
+++ b/include/optionx_cpp/data/trading/trade_state_traits.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#ifndef _OPTIONX_TRADE_STATE_TRAITS_HPP_INCLUDED
+#define _OPTIONX_TRADE_STATE_TRAITS_HPP_INCLUDED
+
+/// \file trade_state_traits.hpp
+/// \brief Domain predicates for TradeState values.
+
+#include "enums.hpp"
+
+namespace optionx {
+
+    /// \brief Returns true if the state represents a winning trade.
+    inline bool is_win(TradeState state) noexcept {
+        return state == TradeState::WIN;
+    }
+
+    /// \brief Returns true if the state represents a losing trade.
+    inline bool is_loss(TradeState state) noexcept {
+        return state == TradeState::LOSS;
+    }
+
+    /// \brief Returns true if the state represents a standoff (no outcome).
+    inline bool is_standoff(TradeState state) noexcept {
+        return state == TradeState::STANDOFF;
+    }
+
+    /// \brief Returns true if the state represents a refunded trade.
+    inline bool is_refund(TradeState state) noexcept {
+        return state == TradeState::REFUND;
+    }
+
+    /// \brief Returns true if the state is terminal (no further lifecycle changes expected).
+    inline bool is_terminal_trade_state(TradeState state) noexcept {
+        return state == TradeState::WIN ||
+               state == TradeState::LOSS ||
+               state == TradeState::STANDOFF ||
+               state == TradeState::REFUND ||
+               state == TradeState::OPEN_ERROR ||
+               state == TradeState::CHECK_ERROR ||
+               state == TradeState::CANCELED_TRADE;
+    }
+
+    /// \brief Returns true if the state represents an error outcome.
+    inline bool is_error_trade_state(TradeState state) noexcept {
+        return state == TradeState::OPEN_ERROR ||
+               state == TradeState::CHECK_ERROR ||
+               state == TradeState::CANCELED_TRADE;
+    }
+
+    /// \brief Returns true if the state carries a monetary result (win/loss/standoff/refund).
+    inline bool is_result_state(TradeState state) noexcept {
+        return state == TradeState::WIN ||
+               state == TradeState::LOSS ||
+               state == TradeState::STANDOFF ||
+               state == TradeState::REFUND;
+    }
+
+} // namespace optionx
+
+#endif // _OPTIONX_TRADE_STATE_TRAITS_HPP_INCLUDED

--- a/include/optionx_cpp/utils/trade_state_utils.hpp
+++ b/include/optionx_cpp/utils/trade_state_utils.hpp
@@ -5,56 +5,6 @@
 /// \file trade_state_utils.hpp
 /// \brief Terminal-state and outcome predicates for TradeState.
 
-#include "data/trading/enums.hpp"
-
-namespace optionx {
-
-    /// \brief Returns true if the state represents a winning trade.
-    inline bool is_win(TradeState state) noexcept {
-        return state == TradeState::WIN;
-    }
-
-    /// \brief Returns true if the state represents a losing trade.
-    inline bool is_loss(TradeState state) noexcept {
-        return state == TradeState::LOSS;
-    }
-
-    /// \brief Returns true if the state represents a standoff (no outcome).
-    inline bool is_standoff(TradeState state) noexcept {
-        return state == TradeState::STANDOFF;
-    }
-
-    /// \brief Returns true if the state represents a refunded trade.
-    inline bool is_refund(TradeState state) noexcept {
-        return state == TradeState::REFUND;
-    }
-
-    /// \brief Returns true if the state is terminal (no further lifecycle changes expected).
-    inline bool is_terminal_trade_state(TradeState state) noexcept {
-        return state == TradeState::WIN ||
-               state == TradeState::LOSS ||
-               state == TradeState::STANDOFF ||
-               state == TradeState::REFUND ||
-               state == TradeState::OPEN_ERROR ||
-               state == TradeState::CHECK_ERROR ||
-               state == TradeState::CANCELED_TRADE;
-    }
-
-    /// \brief Returns true if the state represents an error outcome.
-    inline bool is_error_trade_state(TradeState state) noexcept {
-        return state == TradeState::OPEN_ERROR ||
-               state == TradeState::CHECK_ERROR ||
-               state == TradeState::CANCELED_TRADE;
-    }
-
-    /// \brief Returns true if the state carries a monetary result (win/loss/standoff/refund).
-    inline bool is_result_state(TradeState state) noexcept {
-        return state == TradeState::WIN ||
-               state == TradeState::LOSS ||
-               state == TradeState::STANDOFF ||
-               state == TradeState::REFUND;
-    }
-
-} // namespace optionx
+#include "data/trading/trade_state_traits.hpp"
 
 #endif // _OPTIONX_TRADE_STATE_UTILS_HPP_INCLUDED


### PR DESCRIPTION
## What Changed

- Added `data/trading/trade_state_traits.hpp` as the trading-domain home for `TradeState` predicates.
- Removed the `utils/trade_state_utils.hpp` implementation from the utils layer; it now forwards to the trading-domain header for compatibility.
- Updated `TradeStats.hpp` to depend on trading-domain traits instead of the utils layer.

## Why

F-030/F-054: `TradeStats.hpp` is a trading DTO header and should not pull in the utils layer for `TradeState` predicates. Moving the predicates into the trading domain keeps the DTO include model clean without duplicating error-state logic.

The new file uses snake_case because it is a helper header, matching the project naming rule: PascalCase for class headers, snake_case for helpers.

## Validation

- `cmake --build build-codex --target trade_record_stats_test -- -j1`
- `./build-codex/trade_record_stats_test.exe --gtest_brief=1` (`35/35` passed)
- `cmake --build build-codex --target header_only_odr_test -- -j1`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` (`4/4` passed)
- `git diff --check`