### PR TITLE
[codex] Share storage operation result DTOs

### DIFF
--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -195,6 +195,22 @@ Trade ID and result merge contract:
   values. `TradeResult` still does not provide presence flags for every scalar,
   so patch semantics must stay conservative near valid zero values.
 
+## Storage Result Contract
+
+Storage services share common operation result DTOs:
+
+- `StorageStatus` - success/failure code for storage operations.
+- `StorageWriteResult<Record>` - write/upsert result with the written or
+  attempted record.
+- `StorageReadResult<Record>` - single-record lookup result with `found`.
+- `StorageListResult<Record>` - multi-record query result.
+
+Domain storage APIs keep readable aliases, for example
+`TradeRecordDBStatus`, `TradeRecordDBWriteResult`,
+`TradeRecordDBReadResult` and `TradeRecordDBListResult`. New storage services
+should reuse the common result templates and expose domain-specific aliases
+rather than duplicating equivalent result structs.
+
 ## Intrade Bar History Sources
 
 Source выбирается через `platforms::intrade_bar::TradeHistorySource` в

--- a/include/optionx_cpp/storages.hpp
+++ b/include/optionx_cpp/storages.hpp
@@ -4,6 +4,7 @@
 
 #include "crypto.hpp"
 #include "utils.hpp"
+#include "storages/common.hpp"
 #include "storages/ServiceSessionDB.hpp"
 #include "storages/TradeRecordDB.hpp"
 

--- a/include/optionx_cpp/storages/TradeRecordDB.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB.hpp
@@ -19,6 +19,7 @@
 #include <mdbx_containers/ValueTable.hpp>
 
 #include "data/trading.hpp"
+#include "common.hpp"
 #include "TradeRecordDB/enums.hpp"
 #include "TradeRecordDB/data.hpp"
 #include "TradeRecordDB/detail.hpp"

--- a/include/optionx_cpp/storages/TradeRecordDB/data.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/data.hpp
@@ -9,7 +9,6 @@
 
 #include "data/trading.hpp"
 #include "enums.hpp"
-#include "storages/common/StorageResult.hpp"
 
 namespace optionx::storage {
 

--- a/include/optionx_cpp/storages/TradeRecordDB/data.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/data.hpp
@@ -5,11 +5,11 @@
 /// \file data.hpp
 /// \brief Defines TradeRecordDB operation result DTOs.
 
-#include <string>
-#include <vector>
+#include <type_traits>
 
 #include "data/trading.hpp"
 #include "enums.hpp"
+#include "storages/common/StorageResult.hpp"
 
 namespace optionx::storage {
 
@@ -23,45 +23,14 @@ namespace optionx::storage {
     static_assert(std::is_trivially_copyable_v<TradeRecordDBMeta>,
                   "TradeRecordDBMeta must be trivially copyable for ValueTable storage");
 
-    /// \struct TradeRecordDBWriteResult
     /// \brief Result of a TradeRecord write operation.
-    struct TradeRecordDBWriteResult {
-        TradeRecordDBStatus status = TradeRecordDBStatus::NOT_OPEN; ///< Operation status.
-        TradeRecord record;                                         ///< Written or attempted record.
-        std::string message;                                        ///< Diagnostic message.
+    using TradeRecordDBWriteResult = StorageWriteResult<TradeRecord>;
 
-        /// \brief Returns true if operation completed successfully.
-        bool ok() const noexcept {
-            return status == TradeRecordDBStatus::SUCCESS;
-        }
-    };
-
-    /// \struct TradeRecordDBReadResult
     /// \brief Result of a single-record TradeRecord read operation.
-    struct TradeRecordDBReadResult {
-        TradeRecordDBStatus status = TradeRecordDBStatus::NOT_OPEN; ///< Operation status.
-        TradeRecord record;                                         ///< Found record, when available.
-        bool found = false;                                         ///< True when record was found.
-        std::string message;                                        ///< Diagnostic message.
+    using TradeRecordDBReadResult = StorageReadResult<TradeRecord>;
 
-        /// \brief Returns true if the read operation succeeded and found a record.
-        bool ok() const noexcept {
-            return status == TradeRecordDBStatus::SUCCESS && found;
-        }
-    };
-
-    /// \struct TradeRecordDBListResult
     /// \brief Result of a multi-record TradeRecord read operation.
-    struct TradeRecordDBListResult {
-        TradeRecordDBStatus status = TradeRecordDBStatus::NOT_OPEN; ///< Operation status.
-        std::vector<TradeRecord> records;                           ///< Found records.
-        std::string message;                                        ///< Diagnostic message.
-
-        /// \brief Returns true if the list operation completed successfully.
-        bool ok() const noexcept {
-            return status == TradeRecordDBStatus::SUCCESS;
-        }
-    };
+    using TradeRecordDBListResult = StorageListResult<TradeRecord>;
 
 } // namespace optionx::storage
 

--- a/include/optionx_cpp/storages/TradeRecordDB/enums.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/enums.hpp
@@ -5,8 +5,6 @@
 /// \file enums.hpp
 /// \brief Defines TradeRecordDB status codes.
 
-#include "storages/common/StorageStatus.hpp"
-
 namespace optionx::storage {
 
     /// \brief Status codes returned by TradeRecordDB operations.

--- a/include/optionx_cpp/storages/TradeRecordDB/enums.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/enums.hpp
@@ -5,20 +5,12 @@
 /// \file enums.hpp
 /// \brief Defines TradeRecordDB status codes.
 
+#include "storages/common/StorageStatus.hpp"
+
 namespace optionx::storage {
 
-    /// \enum TradeRecordDBStatus
     /// \brief Status codes returned by TradeRecordDB operations.
-    enum class TradeRecordDBStatus {
-        SUCCESS,
-        NOT_FOUND,
-        INVALID_ARGUMENT,
-        NOT_OPEN,
-        READ_ONLY,
-        QUEUE_CLOSED,
-        DB_ERROR,
-        SEQUENCE_EXHAUSTED ///< Legacy timestamp-bucket status; linear TradeRecordDB does not return it.
-    };
+    using TradeRecordDBStatus = StorageStatus;
 
 } // namespace optionx::storage
 

--- a/include/optionx_cpp/storages/common.hpp
+++ b/include/optionx_cpp/storages/common.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef _OPTIONX_STORAGES_COMMON_HPP_INCLUDED
+#define _OPTIONX_STORAGES_COMMON_HPP_INCLUDED
+
+/// \file common.hpp
+/// \brief Aggregate header for common storage DTOs.
+
+#include "common/StorageStatus.hpp"
+#include "common/StorageResult.hpp"
+
+#endif // _OPTIONX_STORAGES_COMMON_HPP_INCLUDED

--- a/include/optionx_cpp/storages/common/StorageResult.hpp
+++ b/include/optionx_cpp/storages/common/StorageResult.hpp
@@ -1,0 +1,75 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_COMMON_STORAGE_RESULT_HPP_INCLUDED
+#define _OPTIONX_STORAGE_COMMON_STORAGE_RESULT_HPP_INCLUDED
+
+/// \file StorageResult.hpp
+/// \brief Defines common storage operation result DTO templates.
+
+#include <string>
+#include <vector>
+
+#include "StorageStatus.hpp"
+
+namespace optionx::storage {
+
+    /// \struct StorageWriteResult
+    /// \brief Result of a single-record storage write operation.
+    template<class Record>
+    struct StorageWriteResult {
+        StorageStatus status = StorageStatus::NOT_OPEN; ///< Operation status.
+        Record record;                                  ///< Written or attempted record.
+        std::string message;                            ///< Diagnostic message.
+
+        /// \brief Returns true if operation completed successfully.
+        bool ok() const noexcept {
+            return status == StorageStatus::SUCCESS;
+        }
+
+        /// \brief Returns true if operation completed successfully.
+        explicit operator bool() const noexcept {
+            return ok();
+        }
+    };
+
+    /// \struct StorageReadResult
+    /// \brief Result of a single-record storage read operation.
+    template<class Record>
+    struct StorageReadResult {
+        StorageStatus status = StorageStatus::NOT_OPEN; ///< Operation status.
+        Record record;                                  ///< Found record, when available.
+        bool found = false;                             ///< True when record was found.
+        std::string message;                            ///< Diagnostic message.
+
+        /// \brief Returns true if the read operation succeeded and found a record.
+        bool ok() const noexcept {
+            return status == StorageStatus::SUCCESS && found;
+        }
+
+        /// \brief Returns true if the read operation succeeded and found a record.
+        explicit operator bool() const noexcept {
+            return ok();
+        }
+    };
+
+    /// \struct StorageListResult
+    /// \brief Result of a multi-record storage read operation.
+    template<class Record>
+    struct StorageListResult {
+        StorageStatus status = StorageStatus::NOT_OPEN; ///< Operation status.
+        std::vector<Record> records;                    ///< Found records.
+        std::string message;                            ///< Diagnostic message.
+
+        /// \brief Returns true if the list operation completed successfully.
+        bool ok() const noexcept {
+            return status == StorageStatus::SUCCESS;
+        }
+
+        /// \brief Returns true if the list operation completed successfully.
+        explicit operator bool() const noexcept {
+            return ok();
+        }
+    };
+
+} // namespace optionx::storage
+
+#endif // _OPTIONX_STORAGE_COMMON_STORAGE_RESULT_HPP_INCLUDED

--- a/include/optionx_cpp/storages/common/StorageStatus.hpp
+++ b/include/optionx_cpp/storages/common/StorageStatus.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_COMMON_STORAGE_STATUS_HPP_INCLUDED
+#define _OPTIONX_STORAGE_COMMON_STORAGE_STATUS_HPP_INCLUDED
+
+/// \file StorageStatus.hpp
+/// \brief Defines common storage operation status codes.
+
+namespace optionx::storage {
+
+    /// \enum StorageStatus
+    /// \brief Status codes returned by storage services.
+    enum class StorageStatus {
+        SUCCESS,
+        NOT_FOUND,
+        INVALID_ARGUMENT,
+        NOT_OPEN,
+        READ_ONLY,
+        QUEUE_CLOSED,
+        DB_ERROR,
+        STORAGE_ERROR = DB_ERROR,
+        SEQUENCE_EXHAUSTED
+    };
+
+} // namespace optionx::storage
+
+#endif // _OPTIONX_STORAGE_COMMON_STORAGE_STATUS_HPP_INCLUDED

--- a/tests/storage_result_test.cpp
+++ b/tests/storage_result_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/storages.hpp>
+
+namespace {
+
+struct DummyRecord {
+    int value = 0;
+};
+
+} // namespace
+
+TEST(StorageResultTest, WriteResultOkFollowsSuccessStatus) {
+    optionx::storage::StorageWriteResult<DummyRecord> result;
+    EXPECT_FALSE(result.ok());
+    EXPECT_FALSE(static_cast<bool>(result));
+
+    result.status = optionx::storage::StorageStatus::SUCCESS;
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(static_cast<bool>(result));
+}
+
+TEST(StorageResultTest, ReadResultRequiresSuccessAndFound) {
+    optionx::storage::StorageReadResult<DummyRecord> result;
+    result.status = optionx::storage::StorageStatus::SUCCESS;
+
+    EXPECT_FALSE(result.ok());
+    EXPECT_FALSE(static_cast<bool>(result));
+
+    result.found = true;
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(static_cast<bool>(result));
+}
+
+TEST(StorageResultTest, TradeRecordDbResultAliasesUseCommonStorageStatus) {
+    optionx::storage::TradeRecordDBWriteResult result;
+    result.status = optionx::storage::TradeRecordDBStatus::SUCCESS;
+
+    EXPECT_TRUE(result.ok());
+    EXPECT_TRUE(static_cast<bool>(result));
+    EXPECT_EQ(result.status, optionx::storage::StorageStatus::SUCCESS);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What Changed

- Added common storage result contracts:
  - `StorageStatus`
  - `StorageWriteResult<Record>`
  - `StorageReadResult<Record>`
  - `StorageListResult<Record>`
- Exposed them through `storages/common.hpp` and the public `storages.hpp` aggregate.
- Converted `TradeRecordDBStatus` and `TradeRecordDB*Result` to domain aliases over the common storage result types while preserving existing names and `.ok()` behavior.
- Documented the storage result contract for future `SignalRecordDB` work.
- Added focused tests for the generic result DTOs and the `TradeRecordDB` aliases.

## Why

Signal storage will need the same write/read/list result shape as trade storage. Sharing the DTO templates avoids copying the same result structs into every storage service while keeping readable domain-specific API aliases.

## Validation

- `cmake --build build-codex --target storage_result_test trade_record_db_test --parallel`
- `./build-codex/storage_result_test.exe` (3/3 passed)
- `./build-codex/trade_record_db_test.exe` (21/21 passed)
- `git diff --check`