### PR TITLE
[codex] Add signal record contracts

### DIFF
--- a/include/optionx_cpp/data/account/AccountInfoRequest.hpp
+++ b/include/optionx_cpp/data/account/AccountInfoRequest.hpp
@@ -21,7 +21,7 @@ namespace optionx {
         CurrencyType    currency    = CurrencyType::UNKNOWN;    ///< Account currency, if supported.
         OptionType      option_type = OptionType::UNKNOWN;      ///< Option type.
         OrderType       order_type  = OrderType::UNKNOWN;       ///< Order type.
-        int64_t         duration    = 0;                        ///< Option duration in seconds.
+        std::uint32_t   duration    = 0;                        ///< Option duration in seconds; 0 means not specified.
         int64_t         expiry_time = 0;                        ///< Expiration timestamp (Unix, sec).
         int64_t         timestamp   = 0;                        ///< General timestamp (Unix, sec).
 

--- a/include/optionx_cpp/data/account/enums.hpp
+++ b/include/optionx_cpp/data/account/enums.hpp
@@ -36,8 +36,8 @@ namespace optionx {
         MIN_AMOUNT,               ///< Minimum allowed trade amount (double)
         MAX_AMOUNT,               ///< Maximum allowed trade amount (double)
         MAX_REFUND,               ///< Maximum refund percentage (0.0-1.0)
-        MIN_DURATION,             ///< Shortest allowed option duration in seconds (uint64)
-        MAX_DURATION,             ///< Longest allowed option duration in seconds (uint64)
+        MIN_DURATION,             ///< Shortest allowed option duration in seconds
+        MAX_DURATION,             ///< Longest allowed option duration in seconds
 
         // Session parameters
         START_TIME,               ///< Trading session start (seconds since midnight UTC)

--- a/include/optionx_cpp/data/trading.hpp
+++ b/include/optionx_cpp/data/trading.hpp
@@ -11,6 +11,7 @@
 /// \note Headers from the trading/ directory are internal components and are
 /// intended to be included through this umbrella header.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -42,6 +43,7 @@
 #include "trading/IMoneyManagementParams.hpp"
 #include "trading/ITradeDecisionParams.hpp"
 #include "trading/TradeSignal.hpp"
+#include "trading/SignalRecord.hpp"
 #include "trading/TradeRecord.hpp"
 #include "trading/TradeRecordFilter.hpp"
 #include "trading/TradeRecordQuery.hpp"

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -12,7 +12,7 @@ namespace optionx {
     class SignalRecord {
     public:
         // Storage identity
-        std::uint64_t signal_id = 0;          ///< Persistent signal ID; 0 means "not assigned".
+        std::uint32_t signal_id = 0;          ///< Persistent signal ID; 0 means "not assigned".
         std::int64_t request_unique_id = 0;   ///< Unique ID from the root TradeRequest.
         std::string request_unique_hash;      ///< Unique hash from the root TradeRequest.
         std::int64_t account_id = 0;          ///< Target account ID, if known.

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -1,0 +1,174 @@
+#pragma once
+#ifndef _OPTIONX_SIGNAL_RECORD_HPP_INCLUDED
+#define _OPTIONX_SIGNAL_RECORD_HPP_INCLUDED
+
+/// \file SignalRecord.hpp
+/// \brief Defines the persistent DTO used to store trading signals.
+
+namespace optionx {
+
+    /// \class SignalRecord
+    /// \brief Flat persistent representation of a signal and the trades it produced.
+    class SignalRecord {
+    public:
+        // Storage identity
+        std::uint64_t signal_id = 0;          ///< Persistent signal ID; 0 means "not assigned".
+        std::int64_t request_unique_id = 0;   ///< Unique ID from the root TradeRequest.
+        std::string request_unique_hash;      ///< Unique hash from the root TradeRequest.
+        std::int64_t account_id = 0;          ///< Target account ID, if known.
+
+        // Context copied from TradeRequest
+        PlatformType platform_type = PlatformType::UNKNOWN; ///< Trading platform.
+        AccountType account_type = AccountType::UNKNOWN;    ///< Account type.
+        CurrencyType currency = CurrencyType::UNKNOWN;      ///< Account currency.
+        std::string symbol;                                 ///< Trading symbol.
+        std::string signal_name;                            ///< Signal or strategy name.
+        std::string user_data;                              ///< User-defined request data.
+        std::string comment;                                ///< Signal comment.
+
+        // Requested trade parameters
+        OptionType option_type = OptionType::UNKNOWN;       ///< Requested option type.
+        OrderType order_type = OrderType::UNKNOWN;          ///< Requested direction.
+        double amount = 0.0;                                ///< Initial requested amount.
+        double refund = 0.0;                                ///< Requested refund ratio.
+        double min_payout = 0.0;                            ///< Minimum acceptable payout.
+        std::int64_t duration = 0;                          ///< Requested duration in seconds.
+        std::int64_t expiry_time = 0;                       ///< Requested classic expiry time in seconds.
+
+        // Signal lifecycle and outcome
+        SignalStatus status = SignalStatus::UNKNOWN;        ///< Signal processing status.
+        SignalRejectCode reject_code = SignalRejectCode::NONE; ///< Rejection reason, if rejected.
+        std::string reject_desc;                            ///< Human-readable rejection details.
+        SignalOutcome outcome = SignalOutcome::UNKNOWN;     ///< Aggregated signal outcome.
+        TradeState trade_state = TradeState::UNKNOWN;       ///< Trade-like terminal state for summary use.
+        double total_amount = 0.0;                          ///< Sum of generated trade amounts.
+        double total_profit = 0.0;                          ///< Aggregated realized/current profit.
+
+        // Timestamps are milliseconds.
+        std::int64_t create_date = 0;                       ///< Signal creation timestamp.
+        std::int64_t accept_date = 0;                       ///< Accepted timestamp.
+        std::int64_t reject_date = 0;                       ///< Rejected timestamp.
+        std::int64_t complete_date = 0;                     ///< Completed timestamp.
+
+        // Money management and extensibility
+        MmSystemType mm_type = MmSystemType::NONE;          ///< Money management strategy.
+        std::int32_t mm_step = 0;                           ///< Generic money management step.
+        std::int64_t mm_group_id = 0;                       ///< Numeric money management group.
+        std::string mm_group_hash;                          ///< Hash of the money management group.
+        std::string mm_group_name;                          ///< Human-readable group name.
+        std::string mm_params_json;                         ///< Serialized money management params.
+        std::string decision_params_json;                   ///< Serialized decision params.
+        std::string metadata_json;                          ///< Future extension data.
+
+        // Produced trades
+        std::vector<std::uint32_t> trade_ids;               ///< Persistent TradeRecord IDs produced by this signal.
+
+        /// \brief Returns true when signal_id contains a persistent identity.
+        bool has_signal_id() const noexcept {
+            return signal_id != 0;
+        }
+
+        /// \brief Returns true when this signal already references the trade ID.
+        bool has_trade_id(std::uint32_t trade_id) const {
+            return std::find(trade_ids.begin(), trade_ids.end(), trade_id) != trade_ids.end();
+        }
+
+        /// \brief Adds a produced trade ID, ignoring zero and duplicates.
+        void add_trade_id(std::uint32_t trade_id) {
+            if (trade_id == 0 || has_trade_id(trade_id)) return;
+            trade_ids.push_back(trade_id);
+        }
+
+        /// \brief Copies request-side fields into this signal record.
+        void assign_request(const TradeRequest& request) {
+            signal_id = request.signal_id;
+            request_unique_id = request.unique_id;
+            request_unique_hash = request.unique_hash;
+            account_id = request.account_id;
+            account_type = request.account_type;
+            currency = request.currency;
+            symbol = request.symbol;
+            signal_name = request.signal_name;
+            user_data = request.user_data;
+            comment = request.comment;
+            option_type = request.option_type;
+            order_type = request.order_type;
+            amount = request.amount;
+            refund = request.refund;
+            min_payout = request.min_payout;
+            duration = request.duration;
+            expiry_time = request.expiry_time;
+        }
+
+        /// \brief Copies request and money-management fields from a signal.
+        void assign_signal(const TradeSignal& signal) {
+            assign_request(signal.request);
+            const auto effective_signal_id = signal.resolved_signal_id();
+            if (effective_signal_id != 0) {
+                signal_id = effective_signal_id;
+            }
+            mm_type = signal.mm_type;
+            mm_params_json = signal.mm_params ? signal.mm_params->to_json().dump() : std::string();
+            decision_params_json = signal.decision_params ? signal.decision_params->to_json().dump() : std::string();
+        }
+
+        /// \brief Builds a record from a trade request.
+        static SignalRecord from_signal(const TradeRequest& request) {
+            SignalRecord record;
+            record.assign_request(request);
+            return record;
+        }
+
+        /// \brief Builds a record from a trade signal.
+        static SignalRecord from_signal(const TradeSignal& signal) {
+            SignalRecord record;
+            record.assign_signal(signal);
+            return record;
+        }
+
+        NLOHMANN_DEFINE_TYPE_INTRUSIVE(
+            SignalRecord,
+            signal_id,
+            request_unique_id,
+            request_unique_hash,
+            account_id,
+            platform_type,
+            account_type,
+            currency,
+            symbol,
+            signal_name,
+            user_data,
+            comment,
+            option_type,
+            order_type,
+            amount,
+            refund,
+            min_payout,
+            duration,
+            expiry_time,
+            status,
+            reject_code,
+            reject_desc,
+            outcome,
+            trade_state,
+            total_amount,
+            total_profit,
+            create_date,
+            accept_date,
+            reject_date,
+            complete_date,
+            mm_type,
+            mm_step,
+            mm_group_id,
+            mm_group_hash,
+            mm_group_name,
+            mm_params_json,
+            decision_params_json,
+            metadata_json,
+            trade_ids
+        )
+    };
+
+} // namespace optionx
+
+#endif // _OPTIONX_SIGNAL_RECORD_HPP_INCLUDED

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -32,7 +32,7 @@ namespace optionx {
         double amount = 0.0;                                ///< Initial requested amount.
         double refund = 0.0;                                ///< Requested refund ratio.
         double min_payout = 0.0;                            ///< Minimum acceptable payout.
-        std::int64_t duration = 0;                          ///< Requested duration in seconds.
+        std::uint32_t duration = 0;                         ///< Requested duration in seconds; 0 means not specified.
         std::int64_t expiry_time = 0;                       ///< Requested classic expiry time in seconds.
 
         // Signal lifecycle and outcome

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -13,11 +13,11 @@ namespace optionx {
     public:
         // Storage identity
         std::uint32_t signal_id = 0;          ///< Persistent signal ID; 0 means "not assigned".
-        std::int64_t request_unique_id = 0;   ///< Unique ID from the root TradeRequest.
-        std::string request_unique_hash;      ///< Unique hash from the root TradeRequest.
+        std::int64_t unique_id = 0;           ///< External/runtime signal identifier.
+        std::string unique_hash;              ///< External/runtime signal hash.
         std::int64_t account_id = 0;          ///< Target account ID, if known.
 
-        // Context copied from TradeRequest
+        // Signal context
         PlatformType platform_type = PlatformType::UNKNOWN; ///< Trading platform.
         AccountType account_type = AccountType::UNKNOWN;    ///< Account type.
         CurrencyType currency = CurrencyType::UNKNOWN;      ///< Account currency.
@@ -82,8 +82,8 @@ namespace optionx {
         /// \brief Copies request-side fields into this signal record.
         void assign_request(const TradeRequest& request) {
             signal_id = request.signal_id;
-            request_unique_id = request.unique_id;
-            request_unique_hash = request.unique_hash;
+            unique_id = request.unique_id;
+            unique_hash = request.unique_hash;
             account_id = request.account_id;
             account_type = request.account_type;
             currency = request.currency;
@@ -102,12 +102,29 @@ namespace optionx {
 
         /// \brief Copies request and money-management fields from a signal.
         void assign_signal(const TradeSignal& signal) {
-            assign_request(signal.request);
-            const auto effective_signal_id = signal.resolved_signal_id();
-            if (effective_signal_id != 0) {
-                signal_id = effective_signal_id;
-            }
+            signal_id = signal.signal_id;
+            unique_id = signal.unique_id;
+            unique_hash = signal.unique_hash;
+            account_id = signal.account_id;
+            platform_type = signal.platform_type;
+            account_type = signal.account_type;
+            currency = signal.currency;
+            symbol = signal.symbol;
+            signal_name = signal.signal_name;
+            user_data = signal.user_data;
+            comment = signal.comment;
+            option_type = signal.option_type;
+            order_type = signal.order_type;
+            amount = signal.amount;
+            refund = signal.refund;
+            min_payout = signal.min_payout;
+            duration = signal.duration;
+            expiry_time = signal.expiry_time;
             mm_type = signal.mm_type;
+            mm_step = signal.mm_step;
+            mm_group_id = signal.mm_group_id;
+            mm_group_hash = signal.mm_group_hash;
+            mm_group_name = signal.mm_group_name;
             mm_params_json = signal.mm_params ? signal.mm_params->to_json().dump() : std::string();
             decision_params_json = signal.decision_params ? signal.decision_params->to_json().dump() : std::string();
         }
@@ -129,8 +146,8 @@ namespace optionx {
         NLOHMANN_DEFINE_TYPE_INTRUSIVE(
             SignalRecord,
             signal_id,
-            request_unique_id,
-            request_unique_hash,
+            unique_id,
+            unique_hash,
             account_id,
             platform_type,
             account_type,

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -440,15 +440,13 @@ namespace optionx {
             }
 
             const auto version = reader.read<std::uint16_t>();
-            if (version < 1 || version > kBinaryVersion) {
+            if (version != kBinaryVersion) {
                 throw std::runtime_error("TradeRecord::from_bytes: unsupported version");
             }
 
             TradeRecord record;
             record.trade_id = reader.read<std::uint32_t>();
-            if (version >= 3) {
-                record.signal_id = reader.read<std::uint32_t>();
-            }
+            record.signal_id = reader.read<std::uint32_t>();
             record.request_unique_id = reader.read<std::int64_t>();
             record.request_unique_hash = reader.read_string();
             record.account_id = reader.read<std::int64_t>();
@@ -470,17 +468,8 @@ namespace optionx {
             record.min_payout = reader.read<double>();
             record.payout = reader.read<double>();
             record.profit = reader.read<double>();
-            double legacy_balance = 0.0;
-            if (version == 1 || version == 2) {
-                legacy_balance = reader.read<double>();
-                if (version == 1) {
-                    record.set_close_balance(legacy_balance);
-                }
-            }
-            if (version >= 2) {
-                record.open_balance = reader.read<double>();
-                record.close_balance = reader.read<double>();
-            }
+            record.open_balance = reader.read<double>();
+            record.close_balance = reader.read<double>();
 
             record.trade_state = reader.read_enum8<TradeState>();
             record.live_state = reader.read_enum8<TradeState>();
@@ -507,17 +496,6 @@ namespace optionx {
             record.metadata_json = reader.read_string();
 
             record.flags = reader.read<std::uint8_t>();
-            if (version < 3) {
-                if (record.open_balance != 0.0) {
-                    record.flags |= FLAG_HAS_OPEN_BALANCE;
-                }
-                if (version == 1 || record.close_balance != 0.0 || legacy_balance != 0.0) {
-                    record.flags |= FLAG_HAS_CLOSE_BALANCE;
-                    if (version == 2 && record.close_balance == 0.0) {
-                        record.close_balance = legacy_balance;
-                    }
-                }
-            }
 
             record.spread.raw = reader.read<std::uint64_t>();
             record.spread.digits = reader.read<std::uint8_t>();
@@ -582,7 +560,7 @@ namespace optionx {
 
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
-        static constexpr std::uint16_t kBinaryVersion = 3;
+        static constexpr std::uint16_t kBinaryVersion = 1;
 
         template<typename T>
         static bool same_known(T lhs, T rhs, T unknown) noexcept {

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -57,7 +57,7 @@ namespace optionx {
         std::int64_t send_date = 0;                         ///< Broker send timestamp.
         std::int64_t open_date = 0;                         ///< Trade open timestamp.
         std::int64_t close_date = 0;                        ///< Planned or known close timestamp (classic expiry, sprint open + duration).
-        std::int64_t duration = 0;                          ///< Requested duration in seconds.
+        std::uint32_t duration = 0;                         ///< Requested duration in seconds; 0 means not specified.
 
         // Money management and extensibility
         MmSystemType mm_type = MmSystemType::NONE;          ///< Money management strategy.
@@ -484,7 +484,7 @@ namespace optionx {
             record.send_date = reader.read<std::int64_t>();
             record.open_date = reader.read<std::int64_t>();
             record.close_date = reader.read<std::int64_t>();
-            record.duration = reader.read<std::int64_t>();
+            record.duration = reader.read<std::uint32_t>();
 
             record.mm_type = reader.read_enum8<MmSystemType>();
             record.mm_step = reader.read<std::int32_t>();

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -15,6 +15,7 @@ namespace optionx {
     public:
         // Storage identity
         std::uint32_t trade_id = 0;           ///< Linear persistent trade ID; 0 means "not assigned".
+        std::uint64_t signal_id = 0;          ///< Persistent signal ID; 0 means "not attached to a signal".
         std::int64_t request_unique_id = 0;   ///< Unique ID from TradeRequest.
         std::string request_unique_hash;      ///< Unique hash from TradeRequest.
         std::int64_t account_id = 0;          ///< Trading account ID.
@@ -106,6 +107,7 @@ namespace optionx {
         /// \brief Copies request-side fields into this record.
         void assign_request(const TradeRequest& request) {
             trade_id = request.trade_id;
+            signal_id = request.signal_id;
             request_unique_id = request.unique_id;
             request_unique_hash = request.unique_hash;
             account_id = request.account_id;
@@ -296,6 +298,10 @@ namespace optionx {
         /// \brief Copies request and money-management fields from a signal.
         void assign_signal(const TradeSignal& signal) {
             assign_request(signal.request);
+            const auto effective_signal_id = signal.resolved_signal_id();
+            if (effective_signal_id != 0) {
+                signal_id = effective_signal_id;
+            }
             mm_type = signal.mm_type;
             mm_params_json = signal.mm_params ? signal.mm_params->to_json().dump() : std::string();
             decision_params_json = signal.decision_params ? signal.decision_params->to_json().dump() : std::string();
@@ -368,6 +374,7 @@ namespace optionx {
             append_value(bytes, kBinaryVersion);
 
             append_value(bytes, trade_id);
+            append_value(bytes, signal_id);
             append_value(bytes, request_unique_id);
             append_string(bytes, request_unique_hash);
             append_value(bytes, account_id);
@@ -439,6 +446,9 @@ namespace optionx {
 
             TradeRecord record;
             record.trade_id = reader.read<std::uint32_t>();
+            if (version >= 3) {
+                record.signal_id = reader.read<std::uint64_t>();
+            }
             record.request_unique_id = reader.read<std::int64_t>();
             record.request_unique_hash = reader.read_string();
             record.account_id = reader.read<std::int64_t>();
@@ -518,6 +528,7 @@ namespace optionx {
 
         bool operator==(const TradeRecord& other) const {
             return trade_id == other.trade_id &&
+                   signal_id == other.signal_id &&
                    request_unique_id == other.request_unique_id &&
                    request_unique_hash == other.request_unique_hash &&
                    account_id == other.account_id &&

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -15,7 +15,7 @@ namespace optionx {
     public:
         // Storage identity
         std::uint32_t trade_id = 0;           ///< Linear persistent trade ID; 0 means "not assigned".
-        std::uint64_t signal_id = 0;          ///< Persistent signal ID; 0 means "not attached to a signal".
+        std::uint32_t signal_id = 0;          ///< Persistent signal ID; 0 means "not attached to a signal".
         std::int64_t request_unique_id = 0;   ///< Unique ID from TradeRequest.
         std::string request_unique_hash;      ///< Unique hash from TradeRequest.
         std::int64_t account_id = 0;          ///< Trading account ID.
@@ -447,7 +447,7 @@ namespace optionx {
             TradeRecord record;
             record.trade_id = reader.read<std::uint32_t>();
             if (version >= 3) {
-                record.signal_id = reader.read<std::uint64_t>();
+                record.signal_id = reader.read<std::uint32_t>();
             }
             record.request_unique_id = reader.read<std::int64_t>();
             record.request_unique_hash = reader.read_string();

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -297,12 +297,12 @@ namespace optionx {
 
         /// \brief Copies request and money-management fields from a signal.
         void assign_signal(const TradeSignal& signal) {
-            assign_request(signal.request);
-            const auto effective_signal_id = signal.resolved_signal_id();
-            if (effective_signal_id != 0) {
-                signal_id = effective_signal_id;
-            }
+            assign_request(signal.to_trade_request());
             mm_type = signal.mm_type;
+            mm_step = signal.mm_step;
+            mm_group_id = signal.mm_group_id;
+            mm_group_hash = signal.mm_group_hash;
+            mm_group_name = signal.mm_group_name;
             mm_params_json = signal.mm_params ? signal.mm_params->to_json().dump() : std::string();
             decision_params_json = signal.decision_params ? signal.decision_params->to_json().dump() : std::string();
         }

--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -80,7 +80,7 @@ namespace optionx {
         IncludeExcludeFilter<std::uint32_t> signal_ids;
         IncludeExcludeFilter<std::int64_t> request_unique_ids;
 
-        IncludeExcludeFilter<std::int64_t> durations;
+        IncludeExcludeFilter<std::uint32_t> durations;
         IncludeExcludeFilter<std::int32_t> mm_steps;
 
         IncludeExcludeFilter<std::uint32_t> hours;

--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -77,7 +77,7 @@ namespace optionx {
         IncludeExcludeFilter<std::int64_t> account_ids;
         IncludeExcludeFilter<std::int64_t> option_ids;
         IncludeExcludeFilter<std::uint32_t> trade_ids;
-        IncludeExcludeFilter<std::uint64_t> signal_ids;
+        IncludeExcludeFilter<std::uint32_t> signal_ids;
         IncludeExcludeFilter<std::int64_t> request_unique_ids;
 
         IncludeExcludeFilter<std::int64_t> durations;

--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -77,6 +77,7 @@ namespace optionx {
         IncludeExcludeFilter<std::int64_t> account_ids;
         IncludeExcludeFilter<std::int64_t> option_ids;
         IncludeExcludeFilter<std::uint32_t> trade_ids;
+        IncludeExcludeFilter<std::uint64_t> signal_ids;
         IncludeExcludeFilter<std::int64_t> request_unique_ids;
 
         IncludeExcludeFilter<std::int64_t> durations;

--- a/include/optionx_cpp/data/trading/TradeRequest.hpp
+++ b/include/optionx_cpp/data/trading/TradeRequest.hpp
@@ -20,7 +20,7 @@ namespace optionx {
 
         // Identifiers
         std::uint32_t trade_id = 0; ///< Persistent trade record ID propagated into TradeResult::trade_id.
-        std::uint64_t signal_id = 0; ///< Persistent signal ID; 0 means the request is not attached to a signal.
+        std::uint32_t signal_id = 0; ///< Persistent signal ID; 0 means the request is not attached to a signal.
         int64_t unique_id   = 0;    ///< Unique identifier of the trade request.
         int64_t account_id  = 0;    ///< Identifier of the associated trading account.
 

--- a/include/optionx_cpp/data/trading/TradeRequest.hpp
+++ b/include/optionx_cpp/data/trading/TradeRequest.hpp
@@ -20,6 +20,7 @@ namespace optionx {
 
         // Identifiers
         std::uint32_t trade_id = 0; ///< Persistent trade record ID propagated into TradeResult::trade_id.
+        std::uint64_t signal_id = 0; ///< Persistent signal ID; 0 means the request is not attached to a signal.
         int64_t unique_id   = 0;    ///< Unique identifier of the trade request.
         int64_t account_id  = 0;    ///< Identifier of the associated trading account.
 
@@ -129,6 +130,7 @@ namespace optionx {
             comment,
             unique_hash,
             trade_id,
+            signal_id,
             unique_id,
             account_id,
             option_type,
@@ -152,6 +154,7 @@ namespace optionx {
             comment = other.comment;
             unique_hash = other.unique_hash;
             trade_id = other.trade_id;
+            signal_id = other.signal_id;
             unique_id = other.unique_id;
             account_id = other.account_id;
             option_type = other.option_type;

--- a/include/optionx_cpp/data/trading/TradeRequest.hpp
+++ b/include/optionx_cpp/data/trading/TradeRequest.hpp
@@ -36,7 +36,7 @@ namespace optionx {
         double min_payout = 0.0; ///< Minimum acceptable payout percentage.
 
         // Timing parameters
-        int64_t duration = 0;        ///< Trade duration in seconds.
+        std::uint32_t duration = 0;  ///< Trade duration in seconds; 0 means not specified.
         int64_t expiry_time = 0;     ///< Expiration time as a Unix timestamp.
 
         TradeRequest() = default;

--- a/include/optionx_cpp/data/trading/TradeSignal.hpp
+++ b/include/optionx_cpp/data/trading/TradeSignal.hpp
@@ -32,7 +32,7 @@ namespace optionx {
         double amount = 0.0;                                ///< Suggested initial trade amount.
         double refund = 0.0;                                ///< Suggested refund ratio.
         double min_payout = 0.0;                            ///< Minimum acceptable payout.
-        std::int64_t duration = 0;                          ///< Suggested duration in seconds.
+        std::uint32_t duration = 0;                         ///< Suggested duration in seconds; 0 means not specified.
         std::int64_t expiry_time = 0;                       ///< Suggested classic expiry timestamp in seconds.
 
         // Money-management context
@@ -190,7 +190,7 @@ namespace nlohmann {
             signal.amount = j.value("amount", 0.0);
             signal.refund = j.value("refund", 0.0);
             signal.min_payout = j.value("min_payout", 0.0);
-            signal.duration = j.value("duration", std::int64_t{0});
+            signal.duration = j.value("duration", std::uint32_t{0});
             signal.expiry_time = j.value("expiry_time", std::int64_t{0});
             signal.mm_type = j.value("mm_type", optionx::MmSystemType::NONE);
             signal.mm_step = j.value("mm_step", std::int32_t{0});

--- a/include/optionx_cpp/data/trading/TradeSignal.hpp
+++ b/include/optionx_cpp/data/trading/TradeSignal.hpp
@@ -3,25 +3,36 @@
 #define _OPTIONX_TRADE_SIGNAL_HPP_INCLUDED
 
 /// \file TradeSignal.hpp
-/// \brief Defines the TradeSignal class, which represents a trade signal with execution and money management parameters.
+/// \brief Defines the TradeSignal class with execution and money-management data.
 
 namespace optionx {
 
     /// \class TradeSignal
-    /// \brief Represents a trade signal with execution and money management parameters.
-	/// \brief Represents a trade signal containing trade execution parameters and decision-making settings.
+    /// \brief Represents a trade signal with execution, decision, and money-management parameters.
     class TradeSignal {
     public:
-        TradeRequest request;  								///< Trade request parameters.
-        MmSystemType mm_type = MmSystemType::NONE;  		///< Money management system type.
-        std::unique_ptr<IMoneyManagementParams> mm_params;  ///< Money management parameters.
-		std::unique_ptr<ITradeDecisionParams> decision_params;  ///< Decision-making parameters.
+        std::uint64_t signal_id = 0;                         ///< Persistent signal ID; 0 means "not assigned".
+        TradeRequest request;                                ///< Trade request parameters.
+        MmSystemType mm_type = MmSystemType::NONE;           ///< Money management system type.
+        std::unique_ptr<IMoneyManagementParams> mm_params;   ///< Money management parameters.
+        std::unique_ptr<ITradeDecisionParams> decision_params; ///< Decision-making parameters.
+
+        /// \brief Returns the effective signal ID shared with generated requests.
+        std::uint64_t resolved_signal_id() const noexcept {
+            return signal_id != 0 ? signal_id : request.signal_id;
+        }
+
+        /// \brief Assigns the signal ID to both the signal and its root request.
+        void set_signal_id(std::uint64_t value) noexcept {
+            signal_id = value;
+            request.signal_id = value;
+        }
 
         /// \brief Sets the money management parameters for the trade signal.
-        /// 
-        /// If `params` is valid, it is stored and the `mm_type` is updated accordingly. 
+        ///
+        /// If `params` is valid, it is stored and the `mm_type` is updated accordingly.
         /// If `params` is null, the money management type is reset to NONE.
-        /// 
+        ///
         /// \param params A unique pointer to money management parameters.
         void set_money_management(std::unique_ptr<IMoneyManagementParams> params) {
             if (params) {
@@ -34,17 +45,25 @@ namespace optionx {
         }
 
         /// \brief Creates a deep copy of the trade signal.
-        /// 
-        /// This method clones the `TradeSignal`, including a copy of `TradeRequest` 
-        /// and a new instance of `mm_params` if it exists.
-        /// 
+        ///
+        /// This method clones the `TradeSignal`, including a copy of `TradeRequest`
+        /// and cloned parameter objects when they exist.
+        ///
         /// \return A unique pointer to the cloned `TradeSignal`.
         std::unique_ptr<TradeSignal> clone() const {
             auto cloned = std::make_unique<TradeSignal>();
+            const auto effective_signal_id = resolved_signal_id();
+            cloned->signal_id = effective_signal_id;
             cloned->request = request;
+            if (cloned->request.signal_id == 0) {
+                cloned->request.signal_id = effective_signal_id;
+            }
             cloned->mm_type = mm_type;
             if (mm_params) {
                 cloned->mm_params = mm_params->clone();
+            }
+            if (decision_params) {
+                cloned->decision_params = decision_params->clone();
             }
             return cloned;
         }
@@ -62,9 +81,11 @@ namespace nlohmann {
         /// \param signal The TradeSignal object to convert.
         static void to_json(json& j, const optionx::TradeSignal& signal) {
             j = json{
+                {"signal_id", signal.resolved_signal_id()},
                 {"request", signal.request},
-                {"mm_type", signal.mm_type},  // Теперь сериализуется через adl_serializer
-                {"mm_params", signal.mm_params ? signal.mm_params->to_json() : nullptr}
+                {"mm_type", signal.mm_type},
+                {"mm_params", signal.mm_params ? signal.mm_params->to_json() : nullptr},
+                {"decision_params", signal.decision_params ? signal.decision_params->to_json() : nullptr}
             };
         }
 
@@ -72,13 +93,20 @@ namespace nlohmann {
         /// \param j The JSON object to read.
         /// \param signal The TradeSignal object to populate.
         static void from_json(const json& j, optionx::TradeSignal& signal) {
+            signal.signal_id = j.value("signal_id", std::uint64_t{0});
             signal.request = j.at("request").get<optionx::TradeRequest>();
-            signal.mm_type = j.at("mm_type").get<optionx::MmSystemType>(); // Используем adl_serializer
+            if (signal.signal_id == 0) {
+                signal.signal_id = signal.request.signal_id;
+            } else if (signal.request.signal_id == 0) {
+                signal.request.signal_id = signal.signal_id;
+            }
+            signal.mm_type = j.at("mm_type").get<optionx::MmSystemType>();
 
             if (!j["mm_params"].is_null()) {
-                //auto mm = std::make_unique<optionx::MoneyManagementParams>();
-                //*mm = j.at("mm_params").get<optionx::MoneyManagementParams>();
-                //signal.mm_params = std::move(mm);
+                // Typed money-management params are restored by higher-level strategy code.
+            }
+            if (j.contains("decision_params") && !j["decision_params"].is_null()) {
+                // Typed decision params are restored by higher-level strategy code.
             }
         }
     };

--- a/include/optionx_cpp/data/trading/TradeSignal.hpp
+++ b/include/optionx_cpp/data/trading/TradeSignal.hpp
@@ -3,29 +3,75 @@
 #define _OPTIONX_TRADE_SIGNAL_HPP_INCLUDED
 
 /// \file TradeSignal.hpp
-/// \brief Defines the TradeSignal class with execution and money-management data.
+/// \brief Defines the TradeSignal class with signal intent and money-management data.
 
 namespace optionx {
 
     /// \class TradeSignal
-    /// \brief Represents a trade signal with execution, decision, and money-management parameters.
+    /// \brief Represents a strategy signal that may later produce one or more trade requests.
     class TradeSignal {
     public:
-        std::uint32_t signal_id = 0;                         ///< Persistent signal ID; 0 means "not assigned".
-        TradeRequest request;                                ///< Trade request parameters.
-        MmSystemType mm_type = MmSystemType::NONE;           ///< Money management system type.
-        std::unique_ptr<IMoneyManagementParams> mm_params;   ///< Money management parameters.
+        // Signal identity
+        std::uint32_t signal_id = 0;          ///< Persistent signal ID; 0 means "not assigned".
+        std::int64_t unique_id = 0;           ///< External/runtime signal identifier.
+        std::string unique_hash;              ///< External/runtime signal hash.
+
+        // Context
+        PlatformType platform_type = PlatformType::UNKNOWN; ///< Target platform, if known.
+        AccountType account_type = AccountType::UNKNOWN;    ///< Target account type, if known.
+        CurrencyType currency = CurrencyType::UNKNOWN;      ///< Target account currency, if known.
+        std::int64_t account_id = 0;                        ///< Target account ID, if known.
+        std::string symbol;                                 ///< Trading symbol.
+        std::string signal_name;                            ///< Signal or strategy name.
+        std::string user_data;                              ///< User-defined signal data.
+        std::string comment;                                ///< Optional signal comment.
+
+        // Suggested trade parameters
+        OptionType option_type = OptionType::UNKNOWN;       ///< Suggested option type.
+        OrderType order_type = OrderType::UNKNOWN;          ///< Suggested direction.
+        double amount = 0.0;                                ///< Suggested initial trade amount.
+        double refund = 0.0;                                ///< Suggested refund ratio.
+        double min_payout = 0.0;                            ///< Minimum acceptable payout.
+        std::int64_t duration = 0;                          ///< Suggested duration in seconds.
+        std::int64_t expiry_time = 0;                       ///< Suggested classic expiry timestamp in seconds.
+
+        // Money-management context
+        MmSystemType mm_type = MmSystemType::NONE;          ///< Money management system type.
+        std::int32_t mm_step = 0;                           ///< Generic money management step.
+        std::int64_t mm_group_id = 0;                       ///< Numeric money management group.
+        std::string mm_group_hash;                          ///< Hash of the money management group.
+        std::string mm_group_name;                          ///< Human-readable group name.
+        std::unique_ptr<IMoneyManagementParams> mm_params;  ///< Money management parameters.
         std::unique_ptr<ITradeDecisionParams> decision_params; ///< Decision-making parameters.
 
-        /// \brief Returns the effective signal ID shared with generated requests.
-        std::uint32_t resolved_signal_id() const noexcept {
-            return signal_id != 0 ? signal_id : request.signal_id;
+        /// \brief Assigns signal fields to an executable trade request.
+        /// \details The request gets signal identity and the suggested trade
+        /// parameters, but runtime fields such as callbacks are untouched.
+        void assign_to_request(TradeRequest& request) const {
+            request.signal_id = signal_id;
+            request.unique_id = unique_id;
+            request.unique_hash = unique_hash;
+            request.account_id = account_id;
+            request.account_type = account_type;
+            request.currency = currency;
+            request.symbol = symbol;
+            request.signal_name = signal_name;
+            request.user_data = user_data;
+            request.comment = comment;
+            request.option_type = option_type;
+            request.order_type = order_type;
+            request.amount = amount;
+            request.refund = refund;
+            request.min_payout = min_payout;
+            request.duration = duration;
+            request.expiry_time = expiry_time;
         }
 
-        /// \brief Assigns the signal ID to both the signal and its root request.
-        void set_signal_id(std::uint32_t value) noexcept {
-            signal_id = value;
-            request.signal_id = value;
+        /// \brief Builds an executable trade request from this signal.
+        TradeRequest to_trade_request() const {
+            TradeRequest request;
+            assign_to_request(request);
+            return request;
         }
 
         /// \brief Sets the money management parameters for the trade signal.
@@ -46,19 +92,34 @@ namespace optionx {
 
         /// \brief Creates a deep copy of the trade signal.
         ///
-        /// This method clones the `TradeSignal`, including a copy of `TradeRequest`
-        /// and cloned parameter objects when they exist.
+        /// This method clones parameter objects when they exist.
         ///
         /// \return A unique pointer to the cloned `TradeSignal`.
         std::unique_ptr<TradeSignal> clone() const {
             auto cloned = std::make_unique<TradeSignal>();
-            const auto effective_signal_id = resolved_signal_id();
-            cloned->signal_id = effective_signal_id;
-            cloned->request = request;
-            if (cloned->request.signal_id == 0) {
-                cloned->request.signal_id = effective_signal_id;
-            }
+            cloned->signal_id = signal_id;
+            cloned->unique_id = unique_id;
+            cloned->unique_hash = unique_hash;
+            cloned->platform_type = platform_type;
+            cloned->account_type = account_type;
+            cloned->currency = currency;
+            cloned->account_id = account_id;
+            cloned->symbol = symbol;
+            cloned->signal_name = signal_name;
+            cloned->user_data = user_data;
+            cloned->comment = comment;
+            cloned->option_type = option_type;
+            cloned->order_type = order_type;
+            cloned->amount = amount;
+            cloned->refund = refund;
+            cloned->min_payout = min_payout;
+            cloned->duration = duration;
+            cloned->expiry_time = expiry_time;
             cloned->mm_type = mm_type;
+            cloned->mm_step = mm_step;
+            cloned->mm_group_id = mm_group_id;
+            cloned->mm_group_hash = mm_group_hash;
+            cloned->mm_group_name = mm_group_name;
             if (mm_params) {
                 cloned->mm_params = mm_params->clone();
             }
@@ -81,9 +142,29 @@ namespace nlohmann {
         /// \param signal The TradeSignal object to convert.
         static void to_json(json& j, const optionx::TradeSignal& signal) {
             j = json{
-                {"signal_id", signal.resolved_signal_id()},
-                {"request", signal.request},
+                {"signal_id", signal.signal_id},
+                {"unique_id", signal.unique_id},
+                {"unique_hash", signal.unique_hash},
+                {"platform_type", signal.platform_type},
+                {"account_type", signal.account_type},
+                {"currency", signal.currency},
+                {"account_id", signal.account_id},
+                {"symbol", signal.symbol},
+                {"signal_name", signal.signal_name},
+                {"user_data", signal.user_data},
+                {"comment", signal.comment},
+                {"option_type", signal.option_type},
+                {"order_type", signal.order_type},
+                {"amount", signal.amount},
+                {"refund", signal.refund},
+                {"min_payout", signal.min_payout},
+                {"duration", signal.duration},
+                {"expiry_time", signal.expiry_time},
                 {"mm_type", signal.mm_type},
+                {"mm_step", signal.mm_step},
+                {"mm_group_id", signal.mm_group_id},
+                {"mm_group_hash", signal.mm_group_hash},
+                {"mm_group_name", signal.mm_group_name},
                 {"mm_params", signal.mm_params ? signal.mm_params->to_json() : nullptr},
                 {"decision_params", signal.decision_params ? signal.decision_params->to_json() : nullptr}
             };
@@ -94,15 +175,30 @@ namespace nlohmann {
         /// \param signal The TradeSignal object to populate.
         static void from_json(const json& j, optionx::TradeSignal& signal) {
             signal.signal_id = j.value("signal_id", std::uint32_t{0});
-            signal.request = j.at("request").get<optionx::TradeRequest>();
-            if (signal.signal_id == 0) {
-                signal.signal_id = signal.request.signal_id;
-            } else if (signal.request.signal_id == 0) {
-                signal.request.signal_id = signal.signal_id;
-            }
-            signal.mm_type = j.at("mm_type").get<optionx::MmSystemType>();
+            signal.unique_id = j.value("unique_id", std::int64_t{0});
+            signal.unique_hash = j.value("unique_hash", std::string());
+            signal.platform_type = j.value("platform_type", optionx::PlatformType::UNKNOWN);
+            signal.account_type = j.value("account_type", optionx::AccountType::UNKNOWN);
+            signal.currency = j.value("currency", optionx::CurrencyType::UNKNOWN);
+            signal.account_id = j.value("account_id", std::int64_t{0});
+            signal.symbol = j.value("symbol", std::string());
+            signal.signal_name = j.value("signal_name", std::string());
+            signal.user_data = j.value("user_data", std::string());
+            signal.comment = j.value("comment", std::string());
+            signal.option_type = j.value("option_type", optionx::OptionType::UNKNOWN);
+            signal.order_type = j.value("order_type", optionx::OrderType::UNKNOWN);
+            signal.amount = j.value("amount", 0.0);
+            signal.refund = j.value("refund", 0.0);
+            signal.min_payout = j.value("min_payout", 0.0);
+            signal.duration = j.value("duration", std::int64_t{0});
+            signal.expiry_time = j.value("expiry_time", std::int64_t{0});
+            signal.mm_type = j.value("mm_type", optionx::MmSystemType::NONE);
+            signal.mm_step = j.value("mm_step", std::int32_t{0});
+            signal.mm_group_id = j.value("mm_group_id", std::int64_t{0});
+            signal.mm_group_hash = j.value("mm_group_hash", std::string());
+            signal.mm_group_name = j.value("mm_group_name", std::string());
 
-            if (!j["mm_params"].is_null()) {
+            if (j.contains("mm_params") && !j["mm_params"].is_null()) {
                 // Typed money-management params are restored by higher-level strategy code.
             }
             if (j.contains("decision_params") && !j["decision_params"].is_null()) {

--- a/include/optionx_cpp/data/trading/TradeSignal.hpp
+++ b/include/optionx_cpp/data/trading/TradeSignal.hpp
@@ -11,19 +11,19 @@ namespace optionx {
     /// \brief Represents a trade signal with execution, decision, and money-management parameters.
     class TradeSignal {
     public:
-        std::uint64_t signal_id = 0;                         ///< Persistent signal ID; 0 means "not assigned".
+        std::uint32_t signal_id = 0;                         ///< Persistent signal ID; 0 means "not assigned".
         TradeRequest request;                                ///< Trade request parameters.
         MmSystemType mm_type = MmSystemType::NONE;           ///< Money management system type.
         std::unique_ptr<IMoneyManagementParams> mm_params;   ///< Money management parameters.
         std::unique_ptr<ITradeDecisionParams> decision_params; ///< Decision-making parameters.
 
         /// \brief Returns the effective signal ID shared with generated requests.
-        std::uint64_t resolved_signal_id() const noexcept {
+        std::uint32_t resolved_signal_id() const noexcept {
             return signal_id != 0 ? signal_id : request.signal_id;
         }
 
         /// \brief Assigns the signal ID to both the signal and its root request.
-        void set_signal_id(std::uint64_t value) noexcept {
+        void set_signal_id(std::uint32_t value) noexcept {
             signal_id = value;
             request.signal_id = value;
         }
@@ -93,7 +93,7 @@ namespace nlohmann {
         /// \param j The JSON object to read.
         /// \param signal The TradeSignal object to populate.
         static void from_json(const json& j, optionx::TradeSignal& signal) {
-            signal.signal_id = j.value("signal_id", std::uint64_t{0});
+            signal.signal_id = j.value("signal_id", std::uint32_t{0});
             signal.request = j.at("request").get<optionx::TradeRequest>();
             if (signal.signal_id == 0) {
                 signal.signal_id = signal.request.signal_id;

--- a/include/optionx_cpp/data/trading/TradeStats.hpp
+++ b/include/optionx_cpp/data/trading/TradeStats.hpp
@@ -108,7 +108,7 @@ namespace optionx {
         std::map<std::string, TradeWinrateStats>  by_signal;
         std::map<PlatformType, TradeWinrateStats> by_platform;
         std::map<CurrencyType, TradeWinrateStats> by_currency;
-        std::map<std::int64_t, TradeWinrateStats> by_duration;
+        std::map<std::uint32_t, TradeWinrateStats> by_duration;
         std::map<std::int32_t, TradeWinrateStats> by_mm_step;
 
         std::array<TradeWinrateStats, 86400> by_sec;       ///< Index = second of day (0..86399).
@@ -242,7 +242,7 @@ namespace optionx {
         std::vector<CurrencyType> currencies;
         std::vector<std::string> symbols;
         std::vector<std::string> signals;
-        std::vector<std::int64_t> durations;
+        std::vector<std::uint32_t> durations;
         bool has_demo = false;
         bool has_real = false;
 

--- a/include/optionx_cpp/data/trading/enums.hpp
+++ b/include/optionx_cpp/data/trading/enums.hpp
@@ -534,6 +534,234 @@ namespace optionx {
 
 //------------------------------------------------------------------------------
 
+    /// \enum SignalStatus
+    /// \brief Represents lifecycle states of a stored trading signal.
+    enum class SignalStatus {
+        UNKNOWN,     ///< Unknown signal state.
+        RECEIVED,    ///< Signal was received but not accepted yet.
+        ACCEPTED,    ///< Signal passed validation and may produce trades.
+        REJECTED,    ///< Signal was rejected before producing trades.
+        IN_PROGRESS, ///< Signal is producing or waiting for trades.
+        COMPLETED,   ///< Signal processing is complete.
+        CANCELED,    ///< Signal was canceled.
+        FAILED       ///< Signal processing ended with an error.
+    };
+
+    /// \brief Converts SignalStatus to its string representation.
+    inline const std::string& to_str(SignalStatus value) noexcept {
+        static const std::vector<std::string> str_data = {
+            "UNKNOWN",
+            "RECEIVED",
+            "ACCEPTED",
+            "REJECTED",
+            "IN_PROGRESS",
+            "COMPLETED",
+            "CANCELED",
+            "ERROR"
+        };
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
+    }
+
+    /// \brief Converts a string to SignalStatus.
+    inline bool to_enum(const std::string& str, SignalStatus& value) noexcept {
+        static const std::unordered_map<std::string, SignalStatus> str_data = {
+            {"UNKNOWN",     SignalStatus::UNKNOWN},
+            {"RECEIVED",    SignalStatus::RECEIVED},
+            {"ACCEPTED",    SignalStatus::ACCEPTED},
+            {"REJECTED",    SignalStatus::REJECTED},
+            {"IN_PROGRESS", SignalStatus::IN_PROGRESS},
+            {"COMPLETED",   SignalStatus::COMPLETED},
+            {"CANCELED",    SignalStatus::CANCELED},
+            {"ERROR",       SignalStatus::FAILED},
+            {"FAILED",      SignalStatus::FAILED}
+        };
+        auto it = str_data.find(utils::to_upper_case(str));
+        if (it != str_data.end()) {
+            value = it->second;
+            return true;
+        }
+        return false;
+    }
+
+    /// \brief Template specialization to convert a string to SignalStatus.
+    template <>
+    inline SignalStatus to_enum<SignalStatus>(const std::string& str) {
+        SignalStatus value;
+        if (!to_enum(str, value)) {
+            throw std::invalid_argument("Invalid SignalStatus string: " + str);
+        }
+        return value;
+    }
+
+    /// \brief Converts SignalStatus to JSON.
+    inline void to_json(nlohmann::json& j, const SignalStatus& status) {
+        j = optionx::to_str(status);
+    }
+
+    /// \brief Converts JSON to SignalStatus.
+    inline void from_json(const nlohmann::json& j, SignalStatus& status) {
+        status = optionx::to_enum<SignalStatus>(j.get<std::string>());
+    }
+
+    /// \brief Stream output operator for SignalStatus.
+    inline std::ostream& operator<<(std::ostream& os, SignalStatus value) {
+        os << optionx::to_str(value);
+        return os;
+    }
+
+//------------------------------------------------------------------------------
+
+    /// \enum SignalRejectCode
+    /// \brief Represents signal-level rejection reasons.
+    enum class SignalRejectCode {
+        NONE,            ///< Signal was not rejected.
+        INVALID_SIGNAL,  ///< Signal payload is invalid.
+        INVALID_REQUEST, ///< Embedded trade request is invalid.
+        FILTERED,        ///< Signal was filtered by strategy/risk rules.
+        RISK_LIMIT,      ///< Risk or money-management limit rejected it.
+        DUPLICATE_SIGNAL, ///< Duplicate signal was detected.
+        NO_CONNECTION,   ///< Required broker/platform connection was unavailable.
+        INTERNAL_ERROR   ///< Internal processing error.
+    };
+
+    /// \brief Converts SignalRejectCode to its string representation.
+    inline const std::string& to_str(SignalRejectCode value) noexcept {
+        static const std::vector<std::string> str_data = {
+            "NONE",
+            "INVALID_SIGNAL",
+            "INVALID_REQUEST",
+            "FILTERED",
+            "RISK_LIMIT",
+            "DUPLICATE",
+            "NO_CONNECTION",
+            "INTERNAL_ERROR"
+        };
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
+    }
+
+    /// \brief Converts a string to SignalRejectCode.
+    inline bool to_enum(const std::string& str, SignalRejectCode& value) noexcept {
+        static const std::unordered_map<std::string, SignalRejectCode> str_data = {
+            {"NONE",            SignalRejectCode::NONE},
+            {"INVALID_SIGNAL",  SignalRejectCode::INVALID_SIGNAL},
+            {"INVALID_REQUEST", SignalRejectCode::INVALID_REQUEST},
+            {"FILTERED",        SignalRejectCode::FILTERED},
+            {"RISK_LIMIT",      SignalRejectCode::RISK_LIMIT},
+            {"DUPLICATE",       SignalRejectCode::DUPLICATE_SIGNAL},
+            {"DUPLICATE_SIGNAL", SignalRejectCode::DUPLICATE_SIGNAL},
+            {"NO_CONNECTION",   SignalRejectCode::NO_CONNECTION},
+            {"INTERNAL_ERROR",  SignalRejectCode::INTERNAL_ERROR}
+        };
+        auto it = str_data.find(utils::to_upper_case(str));
+        if (it != str_data.end()) {
+            value = it->second;
+            return true;
+        }
+        return false;
+    }
+
+    /// \brief Template specialization to convert a string to SignalRejectCode.
+    template <>
+    inline SignalRejectCode to_enum<SignalRejectCode>(const std::string& str) {
+        SignalRejectCode value;
+        if (!to_enum(str, value)) {
+            throw std::invalid_argument("Invalid SignalRejectCode string: " + str);
+        }
+        return value;
+    }
+
+    /// \brief Converts SignalRejectCode to JSON.
+    inline void to_json(nlohmann::json& j, const SignalRejectCode& code) {
+        j = optionx::to_str(code);
+    }
+
+    /// \brief Converts JSON to SignalRejectCode.
+    inline void from_json(const nlohmann::json& j, SignalRejectCode& code) {
+        code = optionx::to_enum<SignalRejectCode>(j.get<std::string>());
+    }
+
+    /// \brief Stream output operator for SignalRejectCode.
+    inline std::ostream& operator<<(std::ostream& os, SignalRejectCode value) {
+        os << optionx::to_str(value);
+        return os;
+    }
+
+//------------------------------------------------------------------------------
+
+    /// \enum SignalOutcome
+    /// \brief Represents aggregated outcome of a signal and its produced trades.
+    enum class SignalOutcome {
+        UNKNOWN,  ///< Outcome has not been calculated.
+        WIN,      ///< Signal ended with positive profit.
+        LOSS,     ///< Signal ended with negative profit.
+        STANDOFF, ///< Signal ended flat.
+        REFUND,   ///< Signal was refunded.
+        MIXED,    ///< Produced trades have mixed terminal states.
+        FAILED    ///< Signal ended with an error state.
+    };
+
+    /// \brief Converts SignalOutcome to its string representation.
+    inline const std::string& to_str(SignalOutcome value) noexcept {
+        static const std::vector<std::string> str_data = {
+            "UNKNOWN",
+            "WIN",
+            "LOSS",
+            "STANDOFF",
+            "REFUND",
+            "MIXED",
+            "ERROR"
+        };
+        return utils::enum_string_or_unknown(str_data, static_cast<size_t>(value));
+    }
+
+    /// \brief Converts a string to SignalOutcome.
+    inline bool to_enum(const std::string& str, SignalOutcome& value) noexcept {
+        static const std::unordered_map<std::string, SignalOutcome> str_data = {
+            {"UNKNOWN",  SignalOutcome::UNKNOWN},
+            {"WIN",      SignalOutcome::WIN},
+            {"LOSS",     SignalOutcome::LOSS},
+            {"STANDOFF", SignalOutcome::STANDOFF},
+            {"REFUND",   SignalOutcome::REFUND},
+            {"MIXED",    SignalOutcome::MIXED},
+            {"ERROR",    SignalOutcome::FAILED},
+            {"FAILED",   SignalOutcome::FAILED}
+        };
+        auto it = str_data.find(utils::to_upper_case(str));
+        if (it != str_data.end()) {
+            value = it->second;
+            return true;
+        }
+        return false;
+    }
+
+    /// \brief Template specialization to convert a string to SignalOutcome.
+    template <>
+    inline SignalOutcome to_enum<SignalOutcome>(const std::string& str) {
+        SignalOutcome value;
+        if (!to_enum(str, value)) {
+            throw std::invalid_argument("Invalid SignalOutcome string: " + str);
+        }
+        return value;
+    }
+
+    /// \brief Converts SignalOutcome to JSON.
+    inline void to_json(nlohmann::json& j, const SignalOutcome& outcome) {
+        j = optionx::to_str(outcome);
+    }
+
+    /// \brief Converts JSON to SignalOutcome.
+    inline void from_json(const nlohmann::json& j, SignalOutcome& outcome) {
+        outcome = optionx::to_enum<SignalOutcome>(j.get<std::string>());
+    }
+
+    /// \brief Stream output operator for SignalOutcome.
+    inline std::ostream& operator<<(std::ostream& os, SignalOutcome value) {
+        os << optionx::to_str(value);
+        return os;
+    }
+
+//------------------------------------------------------------------------------
+
     /// \enum TradeErrorCode
     /// \brief Represents error codes for order validation and processing.
     enum class TradeErrorCode {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/AccountInfoData.hpp
@@ -114,10 +114,11 @@ namespace optionx::platforms::intrade_bar {
                 if (request.option_type == OptionType::CLASSIC) return true;
                 const int64_t req_min_duration = get_min_duration(request);
                 const int64_t req_max_duration = get_max_duration_sec(request);
-                return (request.duration >= req_min_duration &&
-                        request.duration <= req_max_duration &&
-                        (request.duration % time_shield::SEC_PER_MIN) == 0 &&
-                        request.duration != (2 * time_shield::SEC_PER_MIN));
+                const int64_t req_duration = request.duration;
+                return (req_duration >= req_min_duration &&
+                        req_duration <= req_max_duration &&
+                        (req_duration % time_shield::SEC_PER_MIN) == 0 &&
+                        req_duration != (2 * time_shield::SEC_PER_MIN));
             }
             case AccountInfoType::EXPIRATION_DATE_AVAILABLE: {
                 if (request.option_type == OptionType::SPRINT) return true;
@@ -317,6 +318,7 @@ namespace optionx::platforms::intrade_bar {
         /// \param request The account information request.
         /// \return The payout percentage (as a decimal value).
         double get_payout(const AccountInfoRequest& request) const {
+            const int64_t duration = request.duration;
 
             if ((request.currency == CurrencyType::USD && request.amount < min_usd_amount) ||
                 (request.currency == CurrencyType::RUB && request.amount < min_rub_amount)) {
@@ -330,8 +332,8 @@ namespace optionx::platforms::intrade_bar {
             const int64_t sec_of_day = time_shield::sec_of_day(request.timestamp);
             if (is_btc_symbol(request.symbol)) {
                 if (request.option_type == OptionType::CLASSIC ||
-                    request.duration < min_btc_duration ||
-                    request.duration > max_duration) {
+                    duration < min_btc_duration ||
+                    duration > max_duration) {
                     return 0.0;
                 }
                 // В выходные дни выплаты по сделкам с BTC будут снижены до 60%.
@@ -361,10 +363,10 @@ namespace optionx::platforms::intrade_bar {
             }
 
             if (request.option_type == OptionType::SPRINT) {
-                if (request.duration < time_shield::SEC_PER_MIN ||
-                    request.duration == (2 * time_shield::SEC_PER_MIN) ||
-                    (request.duration % time_shield::SEC_PER_MIN) != 0 ||
-                    request.duration > std::min(time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)), max_duration)) {
+                if (duration < time_shield::SEC_PER_MIN ||
+                    duration == (2 * time_shield::SEC_PER_MIN) ||
+                    (duration % time_shield::SEC_PER_MIN) != 0 ||
+                    duration > std::min(time_shield::start_of_min(end_time - time_shield::sec_of_day(request.timestamp)), max_duration)) {
                     return 0.0;
                 }
                 if (!check_payout_limits(sec_of_day)) {
@@ -376,19 +378,19 @@ namespace optionx::platforms::intrade_bar {
                         (currency == CurrencyType::RUB && request.amount >= high_payout_rub_amount)) {
                         return 0.85;
                     }
-                    if (request.duration == 180) return 0.82;
-                    if (request.duration == 60) return 0.82;
+                    if (duration == 180) return 0.82;
+                    if (duration == 60) return 0.82;
                     return 0.82;
                 }
                 return 0.6;
             } else
             if (request.option_type == OptionType::CLASSIC) {
-                if (request.duration > time_shield::SEC_PER_YEAR) {
-                    const int64_t expiration = calc_expiration(request.timestamp, request.duration);
+                if (duration > time_shield::SEC_PER_YEAR) {
+                    const int64_t expiration = calc_expiration(request.timestamp, duration);
                     if (expiration == 0) return 0.0;
                 } else {
-                    if ((request.duration % (5 * time_shield::SEC_PER_MIN)) != 0) return 0.0;
-                    const int64_t timestamp = calc_expiry_time(request.timestamp, request.duration / time_shield::SEC_PER_MIN);
+                    if ((duration % (5 * time_shield::SEC_PER_MIN)) != 0) return 0.0;
+                    const int64_t timestamp = calc_expiry_time(request.timestamp, duration / time_shield::SEC_PER_MIN);
                     if (timestamp == 0) return 0.0;
                     if (timestamp > (time_shield::start_of_day(timestamp) + end_time)) return 0.0;
                 }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/TradeExecutionComponent.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/TradeExecutionComponent.hpp
@@ -5,6 +5,8 @@
 /// \file TradeExecutionComponent.hpp
 /// \brief Implements trade execution functionality for the Intrade Bar platform.
 
+#include <limits>
+
 #include "SymbolUtils.hpp"
 
 namespace optionx::platforms::intrade_bar {
@@ -53,9 +55,14 @@ namespace optionx::platforms::intrade_bar {
             if (trade_request &&
                 trade_request->option_type == OptionType::CLASSIC) {
                 if (trade_request->expiry_time > 0) {
-                    trade_request->duration = calc_expiration(
+                    const auto duration = calc_expiration(
                         time_shield::ms_to_sec(trade_result->place_date),
                         trade_request->expiry_time);
+                    trade_request->duration =
+                        duration > 0 &&
+                        duration <= static_cast<std::int64_t>((std::numeric_limits<std::uint32_t>::max)())
+                        ? static_cast<std::uint32_t>(duration)
+                        : 0;
                 } else
                 if (trade_request->expiry_time == 0 &&
                     trade_request->duration > 0) {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <sstream>
 #include <cmath>
+#include <limits>
 #include <optional>
 #include <regex>
 #include <stdexcept>
@@ -21,6 +22,16 @@
 #include "ApiResponses.hpp"
 
 namespace optionx::platforms::intrade_bar {
+
+    inline std::uint32_t duration_sec_from_ms_delta(std::int64_t delta_ms) noexcept {
+        if (delta_ms <= 0) return 0;
+        const auto seconds = time_shield::ms_to_sec(delta_ms);
+        if (seconds <= 0 ||
+            seconds > static_cast<std::int64_t>((std::numeric_limits<std::uint32_t>::max)())) {
+            return 0;
+        }
+        return static_cast<std::uint32_t>(seconds);
+    }
 
     /// \brief Parses the login response and extracts user ID and hash.
     /// \param content The HTTP response content to parse.
@@ -621,7 +632,7 @@ namespace optionx::platforms::intrade_bar {
             if (auto close_time = parse_history_row_close_time_ms(row)) {
                 record.close_date = *close_time;
                 if (record.open_date > 0 && record.close_date >= record.open_date) {
-                    record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
+                    record.duration = duration_sec_from_ms_delta(record.close_date - record.open_date);
                 }
             }
             if (auto status = utils::parse_int_attr(row, "data-status")) {
@@ -671,7 +682,7 @@ namespace optionx::platforms::intrade_bar {
             record.open_date = *open_time;
             record.close_date = *close_time;
             if (record.close_date >= record.open_date) {
-                record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
+                record.duration = duration_sec_from_ms_delta(record.close_date - record.open_date);
             }
             record.open_price = *open_price;
             record.close_price = *close_price;
@@ -863,7 +874,7 @@ namespace optionx::platforms::intrade_bar {
             record.open_date = *open_time;
             record.close_date = *close_time;
             if (record.close_date >= record.open_date) {
-                record.duration = time_shield::ms_to_sec(record.close_date - record.open_date);
+                record.duration = duration_sec_from_ms_delta(record.close_date - record.open_date);
             }
             record.open_price = *open_price;
             record.close_price = *close_price;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeMetaStatsCalculator.hpp
@@ -33,7 +33,7 @@ namespace optionx::storage {
             std::set<optionx::CurrencyType> currencies_set;
             std::set<std::string> symbols_set;
             std::set<std::string> signals_set;
-            std::set<std::int64_t> durations_set;
+            std::set<std::uint32_t> durations_set;
 
             for (const auto& rec : records) {
                 if (!TradeRecordFilterMatcher::match_filter(rec, config.filter, config.time_zone)) continue;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -69,6 +69,7 @@ namespace optionx::storage {
             if (!filter.account_ids.match(record.account_id)) return false;
             if (!filter.option_ids.match(record.option_id)) return false;
             if (!filter.trade_ids.match(record.trade_id)) return false;
+            if (!filter.signal_ids.match(record.signal_id)) return false;
             if (!filter.request_unique_ids.match(record.request_unique_id)) return false;
 
             if (!filter.durations.match(record.duration)) return false;

--- a/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
+++ b/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
@@ -619,7 +619,7 @@ public:
             const std::string& symbol,
             double amount,
             optionx::OrderType order_type,
-            int64_t duration_sec,
+            std::uint32_t duration_sec,
             int64_t timeout_ms) {
         LOGIT_SCOPE_INFO("intradebar.smoke.open_trade");
         struct SharedAttempt {
@@ -703,7 +703,7 @@ public:
             const std::string& symbol,
             double amount,
             optionx::OrderType order_type,
-            int64_t duration_sec,
+            std::uint32_t duration_sec,
             int64_t timeout_ms) {
         LOGIT_SCOPE_INFO("intradebar.smoke.open_trade_wait_result");
         struct SharedAttempt {

--- a/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
+++ b/tests/intrade_bar_api/intrade_bar_smoke_cli.cpp
@@ -7,7 +7,9 @@
 #include <cctype>
 #include <cmath>
 #include <iomanip>
+#include <limits>
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace smoke = optionx::tests::intrade_bar_smoke;
@@ -381,6 +383,17 @@ int run_switch_check(smoke::IntradeBarSmokeConfig config, const CliOptions& opti
     return recovered ? 0 : 1;
 }
 
+std::optional<std::uint32_t> trade_duration_from_cli(
+        int64_t duration,
+        std::ostream& err) {
+    if (duration <= 0 ||
+        duration > static_cast<int64_t>((std::numeric_limits<std::uint32_t>::max)())) {
+        err << "--duration must be a positive number of seconds within uint32 range.\n";
+        return std::nullopt;
+    }
+    return static_cast<std::uint32_t>(duration);
+}
+
 int run_open_trade(smoke::IntradeBarSmokeConfig config, const CliOptions& options) {
     if (!smoke::require_live_config(config, std::cerr)) return 2;
     const bool confirmed = options.confirm || config.allow_trade;
@@ -406,6 +419,8 @@ int run_open_trade(smoke::IntradeBarSmokeConfig config, const CliOptions& option
         options.values,
         "duration",
         config.trade_duration_sec);
+    const auto trade_duration = trade_duration_from_cli(duration, std::cerr);
+    if (!trade_duration) return 2;
     const auto order_type = smoke::parse_enum_or<optionx::OrderType>(
         smoke::option_value_or(
             options.values,
@@ -421,7 +436,7 @@ int run_open_trade(smoke::IntradeBarSmokeConfig config, const CliOptions& option
         symbol,
         amount,
         order_type,
-        duration,
+        *trade_duration,
         config.trade_open_timeout_ms);
     std::cout << "trade accepted=" << open.accepted
               << " callback=" << open.callback_received
@@ -484,6 +499,8 @@ int run_open_trades_sync_check(
         options.values,
         "duration",
         default_open_trades_sync_duration_sec(symbol));
+    const auto trade_duration = trade_duration_from_cli(duration, std::cerr);
+    if (!trade_duration) return 2;
     const double amount = smoke::option_double_or(
         options.values,
         "amount",
@@ -556,7 +573,7 @@ int run_open_trades_sync_check(
             symbol,
             amount,
             order_type,
-            duration,
+            *trade_duration,
             config.trade_open_timeout_ms);
 
         bool local_increment = false;
@@ -847,6 +864,8 @@ int run_open_check_result(smoke::IntradeBarSmokeConfig config, const CliOptions&
         options.values,
         "duration",
         5 * time_shield::SEC_PER_MIN);
+    const auto trade_duration = trade_duration_from_cli(duration, std::cerr);
+    if (!trade_duration) return 2;
     const int64_t result_timeout_ms = smoke::option_i64_or(
         options.values,
         "result-timeout-ms",
@@ -878,7 +897,7 @@ int run_open_check_result(smoke::IntradeBarSmokeConfig config, const CliOptions&
         symbol,
         amount,
         order_type,
-        duration,
+        *trade_duration,
         result_timeout_ms);
 
     std::cout << "lifecycle accepted=" << lifecycle.accepted

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -116,6 +116,19 @@ TEST(TradeRecordFilterMatcherTest, MatchesBySymbol) {
     EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
 }
 
+TEST(TradeRecordFilterMatcherTest, MatchesBySignalId) {
+    TradeRecord rec = make_win_record(1, 100000);
+    rec.signal_id = 7007;
+
+    TradeRecordQuery query;
+    query.filter.signal_ids.add_include(7007);
+    EXPECT_TRUE(TradeRecordFilterMatcher::match(rec, query));
+
+    query.filter.signal_ids.clear();
+    query.filter.signal_ids.add_include(7008);
+    EXPECT_FALSE(TradeRecordFilterMatcher::match(rec, query));
+}
+
 TEST(TradeRecordFilterMatcherTest, MatchesByPlatformAndState) {
     TradeRecord rec = make_win_record(1, 100000);
     rec.platform_type = optionx::PlatformType::INTRADE_BAR;

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -118,7 +118,7 @@ optionx::TradeRecord make_record() {
 
 } // namespace
 
-TEST(TradeRecordSerializationTest, RoundTripsBinaryV3) {
+TEST(TradeRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
     const auto record = make_record();
     const auto bytes = record.to_bytes();
     const auto restored = optionx::TradeRecord::from_bytes(bytes.data(), bytes.size());

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -73,6 +73,33 @@ optionx::TradeRequest make_request() {
     return request;
 }
 
+optionx::TradeSignal make_signal() {
+    optionx::TradeSignal signal;
+    signal.signal_id = 7007;
+    signal.unique_id = 42;
+    signal.unique_hash = "signal-hash";
+    signal.platform_type = optionx::PlatformType::INTRADE_BAR;
+    signal.account_id = 7001;
+    signal.account_type = optionx::AccountType::DEMO;
+    signal.currency = optionx::CurrencyType::USD;
+    signal.symbol = "EURUSD";
+    signal.signal_name = "mean-reversion";
+    signal.user_data = R"({"source":"test"})";
+    signal.comment = "round trip";
+    signal.option_type = optionx::OptionType::CLASSIC;
+    signal.order_type = optionx::OrderType::BUY;
+    signal.amount = 15.5;
+    signal.refund = 0.1;
+    signal.min_payout = 0.75;
+    signal.duration = 60;
+    signal.expiry_time = 1712345700;
+    signal.mm_step = 3;
+    signal.mm_group_id = 73;
+    signal.mm_group_hash = "signal-group-hash";
+    signal.mm_group_name = "signal-group";
+    return signal;
+}
+
 optionx::TradeResult make_result() {
     optionx::TradeResult result;
     result.trade_id = 9001;
@@ -140,9 +167,7 @@ TEST(TradeRecordSerializationTest, RejectsCorruptedPayloads) {
 }
 
 TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
-    optionx::TradeSignal signal;
-    signal.request = make_request();
-    signal.set_signal_id(7007);
+    auto signal = make_signal();
     signal.set_money_management(std::make_unique<TestMoneyManagementParams>(3));
     signal.decision_params = std::make_unique<TestDecisionParams>(0.65);
 
@@ -154,7 +179,7 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.symbol, "EURUSD");
     EXPECT_EQ(record.signal_name, "mean-reversion");
     EXPECT_EQ(record.request_unique_id, 42);
-    EXPECT_EQ(record.request_unique_hash, "request-hash");
+    EXPECT_EQ(record.request_unique_hash, "signal-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
     EXPECT_TRUE(record.has_open_balance());
@@ -163,14 +188,16 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_DOUBLE_EQ(record.close_balance, 1012.71);
     EXPECT_EQ(record.close_date, 1712345700000);
     EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
+    EXPECT_EQ(record.mm_step, 3);
+    EXPECT_EQ(record.mm_group_id, 73);
+    EXPECT_EQ(record.mm_group_hash, "signal-group-hash");
+    EXPECT_EQ(record.mm_group_name, "signal-group");
     EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
     EXPECT_EQ(nlohmann::json::parse(record.decision_params_json).at("threshold"), 0.65);
 }
 
 TEST(SignalRecordTest, AssignsSignalDataAndProducedTradeIds) {
-    optionx::TradeSignal signal;
-    signal.request = make_request();
-    signal.set_signal_id(7007);
+    auto signal = make_signal();
     signal.set_money_management(std::make_unique<TestMoneyManagementParams>(3));
     signal.decision_params = std::make_unique<TestDecisionParams>(0.65);
 
@@ -185,13 +212,17 @@ TEST(SignalRecordTest, AssignsSignalDataAndProducedTradeIds) {
     record.add_trade_id(8);
 
     EXPECT_TRUE(record.has_signal_id());
-    EXPECT_EQ(signal.request.signal_id, 7007u);
     EXPECT_EQ(record.signal_id, 7007u);
-    EXPECT_EQ(record.request_unique_id, 42);
-    EXPECT_EQ(record.request_unique_hash, "request-hash");
+    EXPECT_EQ(record.unique_id, 42);
+    EXPECT_EQ(record.unique_hash, "signal-hash");
+    EXPECT_EQ(record.platform_type, optionx::PlatformType::INTRADE_BAR);
     EXPECT_EQ(record.symbol, "EURUSD");
     EXPECT_EQ(record.signal_name, "mean-reversion");
     EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
+    EXPECT_EQ(record.mm_step, 3);
+    EXPECT_EQ(record.mm_group_id, 73);
+    EXPECT_EQ(record.mm_group_hash, "signal-group-hash");
+    EXPECT_EQ(record.mm_group_name, "signal-group");
     EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
     EXPECT_EQ(nlohmann::json::parse(record.decision_params_json).at("threshold"), 0.65);
     ASSERT_EQ(record.trade_ids.size(), 2u);
@@ -206,32 +237,73 @@ TEST(SignalRecordTest, AssignsSignalDataAndProducedTradeIds) {
     EXPECT_EQ(restored.trade_ids, record.trade_ids);
 }
 
-TEST(SignalRecordTest, ResolvesSignalIdFromRequestWhenTopLevelIdIsUnset) {
-    optionx::TradeSignal signal;
-    signal.request = make_request();
-    signal.signal_id = 0;
-    signal.request.signal_id = 901;
+TEST(SignalRecordTest, BuildsTradeRequestFromFlatSignalData) {
+    auto signal = make_signal();
 
-    const auto record = optionx::SignalRecord::from_signal(signal);
+    const auto request = signal.to_trade_request();
 
-    EXPECT_EQ(signal.resolved_signal_id(), 901u);
-    EXPECT_EQ(record.signal_id, 901u);
+    EXPECT_EQ(request.signal_id, 7007u);
+    EXPECT_EQ(request.unique_id, 42);
+    EXPECT_EQ(request.unique_hash, "signal-hash");
+    EXPECT_EQ(request.account_id, 7001);
+    EXPECT_EQ(request.account_type, optionx::AccountType::DEMO);
+    EXPECT_EQ(request.currency, optionx::CurrencyType::USD);
+    EXPECT_EQ(request.symbol, "EURUSD");
+    EXPECT_EQ(request.signal_name, "mean-reversion");
+    EXPECT_EQ(request.option_type, optionx::OptionType::CLASSIC);
+    EXPECT_EQ(request.order_type, optionx::OrderType::BUY);
+    EXPECT_DOUBLE_EQ(request.amount, 15.5);
+    EXPECT_DOUBLE_EQ(request.refund, 0.1);
+    EXPECT_DOUBLE_EQ(request.min_payout, 0.75);
+    EXPECT_EQ(request.duration, 60);
+    EXPECT_EQ(request.expiry_time, 1712345700);
 }
 
-TEST(SignalRecordTest, ClonesResolvedSignalIdAndDecisionParams) {
-    optionx::TradeSignal signal;
-    signal.request = make_request();
-    signal.signal_id = 0;
-    signal.request.signal_id = 901;
+TEST(SignalRecordTest, ClonesFlatSignalDataAndDecisionParams) {
+    auto signal = make_signal();
     signal.decision_params = std::make_unique<TestDecisionParams>(0.75);
 
     const auto clone = signal.clone();
 
     ASSERT_NE(clone, nullptr);
-    EXPECT_EQ(clone->signal_id, 901u);
-    EXPECT_EQ(clone->request.signal_id, 901u);
+    EXPECT_EQ(clone->signal_id, 7007u);
+    EXPECT_EQ(clone->unique_id, 42);
+    EXPECT_EQ(clone->unique_hash, "signal-hash");
+    EXPECT_EQ(clone->symbol, "EURUSD");
+    EXPECT_EQ(clone->mm_group_hash, "signal-group-hash");
     ASSERT_NE(clone->decision_params, nullptr);
     EXPECT_EQ(clone->decision_params->to_json().at("threshold"), 0.75);
+}
+
+TEST(SignalRecordTest, BuildsFromDirectTradeRequest) {
+    auto request = make_request();
+
+    const auto record = optionx::SignalRecord::from_signal(request);
+
+    EXPECT_EQ(record.signal_id, 501u);
+    EXPECT_EQ(record.unique_id, 42);
+    EXPECT_EQ(record.unique_hash, "request-hash");
+    EXPECT_EQ(record.symbol, "EURUSD");
+    EXPECT_EQ(record.signal_name, "mean-reversion");
+}
+
+TEST(TradeSignalTest, RoundTripsFlatJsonAndBuildsRequest) {
+    auto signal = make_signal();
+
+    const nlohmann::json json_signal = signal;
+    const auto restored = json_signal.get<optionx::TradeSignal>();
+    const auto request = restored.to_trade_request();
+
+    EXPECT_EQ(restored.signal_id, 7007u);
+    EXPECT_EQ(restored.unique_id, 42);
+    EXPECT_EQ(restored.unique_hash, "signal-hash");
+    EXPECT_EQ(restored.platform_type, optionx::PlatformType::INTRADE_BAR);
+    EXPECT_EQ(restored.mm_group_hash, "signal-group-hash");
+    EXPECT_EQ(request.signal_id, 7007u);
+    EXPECT_EQ(request.unique_id, 42);
+    EXPECT_EQ(request.unique_hash, "signal-hash");
+    EXPECT_EQ(request.symbol, "EURUSD");
+    EXPECT_EQ(request.signal_name, "mean-reversion");
 }
 
 TEST(TradeRecordFactoryTest, PreservesRequestContextWhenResultIsPartial) {

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -58,6 +58,7 @@ optionx::TradeRequest make_request() {
     request.user_data = R"({"source":"test"})";
     request.comment = "round trip";
     request.unique_hash = "request-hash";
+    request.signal_id = 501;
     request.unique_id = 42;
     request.account_id = 7001;
     request.option_type = optionx::OptionType::CLASSIC;
@@ -141,6 +142,7 @@ TEST(TradeRecordSerializationTest, RejectsCorruptedPayloads) {
 TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     optionx::TradeSignal signal;
     signal.request = make_request();
+    signal.set_signal_id(7007);
     signal.set_money_management(std::make_unique<TestMoneyManagementParams>(3));
     signal.decision_params = std::make_unique<TestDecisionParams>(0.65);
 
@@ -148,6 +150,7 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     record.trade_id = 7;
 
     EXPECT_EQ(record.trade_id, 7u);
+    EXPECT_EQ(record.signal_id, 7007u);
     EXPECT_EQ(record.symbol, "EURUSD");
     EXPECT_EQ(record.signal_name, "mean-reversion");
     EXPECT_EQ(record.request_unique_id, 42);
@@ -162,6 +165,73 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
     EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
     EXPECT_EQ(nlohmann::json::parse(record.decision_params_json).at("threshold"), 0.65);
+}
+
+TEST(SignalRecordTest, AssignsSignalDataAndProducedTradeIds) {
+    optionx::TradeSignal signal;
+    signal.request = make_request();
+    signal.set_signal_id(7007);
+    signal.set_money_management(std::make_unique<TestMoneyManagementParams>(3));
+    signal.decision_params = std::make_unique<TestDecisionParams>(0.65);
+
+    auto record = optionx::SignalRecord::from_signal(signal);
+    record.status = optionx::SignalStatus::ACCEPTED;
+    record.outcome = optionx::SignalOutcome::WIN;
+    record.total_profit = 12.71;
+
+    record.add_trade_id(0);
+    record.add_trade_id(7);
+    record.add_trade_id(7);
+    record.add_trade_id(8);
+
+    EXPECT_TRUE(record.has_signal_id());
+    EXPECT_EQ(signal.request.signal_id, 7007u);
+    EXPECT_EQ(record.signal_id, 7007u);
+    EXPECT_EQ(record.request_unique_id, 42);
+    EXPECT_EQ(record.request_unique_hash, "request-hash");
+    EXPECT_EQ(record.symbol, "EURUSD");
+    EXPECT_EQ(record.signal_name, "mean-reversion");
+    EXPECT_EQ(record.mm_type, optionx::MmSystemType::MARTINGALE_SIGNAL);
+    EXPECT_EQ(nlohmann::json::parse(record.mm_params_json).at("step"), 3);
+    EXPECT_EQ(nlohmann::json::parse(record.decision_params_json).at("threshold"), 0.65);
+    ASSERT_EQ(record.trade_ids.size(), 2u);
+    EXPECT_EQ(record.trade_ids[0], 7u);
+    EXPECT_EQ(record.trade_ids[1], 8u);
+
+    const nlohmann::json json_record = record;
+    const auto restored = json_record.get<optionx::SignalRecord>();
+    EXPECT_EQ(restored.signal_id, record.signal_id);
+    EXPECT_EQ(restored.status, optionx::SignalStatus::ACCEPTED);
+    EXPECT_EQ(restored.outcome, optionx::SignalOutcome::WIN);
+    EXPECT_EQ(restored.trade_ids, record.trade_ids);
+}
+
+TEST(SignalRecordTest, ResolvesSignalIdFromRequestWhenTopLevelIdIsUnset) {
+    optionx::TradeSignal signal;
+    signal.request = make_request();
+    signal.signal_id = 0;
+    signal.request.signal_id = 901;
+
+    const auto record = optionx::SignalRecord::from_signal(signal);
+
+    EXPECT_EQ(signal.resolved_signal_id(), 901u);
+    EXPECT_EQ(record.signal_id, 901u);
+}
+
+TEST(SignalRecordTest, ClonesResolvedSignalIdAndDecisionParams) {
+    optionx::TradeSignal signal;
+    signal.request = make_request();
+    signal.signal_id = 0;
+    signal.request.signal_id = 901;
+    signal.decision_params = std::make_unique<TestDecisionParams>(0.75);
+
+    const auto clone = signal.clone();
+
+    ASSERT_NE(clone, nullptr);
+    EXPECT_EQ(clone->signal_id, 901u);
+    EXPECT_EQ(clone->request.signal_id, 901u);
+    ASSERT_NE(clone->decision_params, nullptr);
+    EXPECT_EQ(clone->decision_params->to_json().at("threshold"), 0.75);
 }
 
 TEST(TradeRecordFactoryTest, PreservesRequestContextWhenResultIsPartial) {
@@ -179,6 +249,7 @@ TEST(TradeRecordFactoryTest, PreservesRequestContextWhenResultIsPartial) {
     const auto record = optionx::TradeRecord::from_trade(request, partial_result);
 
     EXPECT_EQ(record.trade_id, 321u);
+    EXPECT_EQ(record.signal_id, 501u);
     EXPECT_EQ(record.option_id, 98765);
     EXPECT_EQ(record.amount, 25.0);
     EXPECT_EQ(record.account_type, optionx::AccountType::DEMO);


### PR DESCRIPTION
## What Changed

- Added signal lifecycle enums and a flat SignalRecord DTO with produced TradeRecord IDs.
- Added signal_id propagation through TradeSignal, TradeRequest, and TradeRecord.
- Added TradeRecordFilter::signal_ids matching so existing TradeRecordDB queries can find trades produced by a signal.
- Cleaned up TradeSignal cloning so decision params and resolved signal IDs are preserved.
- Narrowed trade duration fields to `std::uint32_t` seconds while keeping timestamp fields signed 64-bit.

## Why

This starts the signal persistence contract before adding SignalRecordDB. Signals now have a stable ID, and trades can be linked back to the signal that produced them while still keeping the link on both sides.

Duration is an interval in seconds, not a timestamp. `std::uint32_t` keeps the DTO contract non-negative, preserves `0` as not-specified/invalid, and is still far beyond any broker-supported option duration.

## Validation

- cmake --build build-codex --target trade_record_storage_test trade_record_stats_test trade_manager_test --parallel 2
- ./build-codex/trade_record_storage_test.exe
- ./build-codex/trade_record_stats_test.exe
- ./build-codex/trade_manager_test.exe
- cmake --build build-codex --target trade_result_query_test trade_record_db_test --parallel 2
- ./build-codex/trade_result_query_test.exe
- ./build-codex/trade_record_db_test.exe
- cmake --build build-codex --target intrade_bar_smoke_cli --parallel 2
- git diff --check