### PR TITLE
[codex] Add SignalRecordDB storage

### DIFF
--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -5,6 +5,11 @@
 /// \file SignalRecord.hpp
 /// \brief Defines the persistent DTO used to store trading signals.
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#   error "SignalRecord binary format requires a little-endian target"
+#endif
+
 namespace optionx {
 
     /// \class SignalRecord
@@ -205,6 +210,9 @@ namespace optionx {
         }
 
         /// \brief Deserializes a signal record serialized by the current binary storage format.
+        /// \details Validates the binary structure, but does not semantically
+        /// validate enum values. Treat invalid enum payloads as local storage
+        /// corruption rather than as supported external input.
         static SignalRecord from_bytes(const void* data, std::size_t size) {
             BinaryReader reader(data, size);
 

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -143,6 +143,175 @@ namespace optionx {
             return record;
         }
 
+        /// \brief Serializes the record using the current binary storage format.
+        std::vector<std::uint8_t> to_bytes() const {
+            std::vector<std::uint8_t> bytes;
+            bytes.reserve(384 + unique_hash.size() + symbol.size() +
+                          signal_name.size() + user_data.size() +
+                          comment.size() + reject_desc.size() +
+                          mm_group_hash.size() + mm_group_name.size() +
+                          mm_params_json.size() + decision_params_json.size() +
+                          metadata_json.size() +
+                          trade_ids.size() * sizeof(std::uint32_t));
+
+            append_value(bytes, kBinaryMagic);
+            append_value(bytes, kBinaryVersion);
+
+            append_value(bytes, signal_id);
+            append_value(bytes, unique_id);
+            append_string(bytes, unique_hash);
+            append_value(bytes, account_id);
+
+            append_enum8(bytes, platform_type);
+            append_enum8(bytes, account_type);
+            append_enum8(bytes, currency);
+            append_string(bytes, symbol);
+            append_string(bytes, signal_name);
+            append_string(bytes, user_data);
+            append_string(bytes, comment);
+
+            append_enum8(bytes, option_type);
+            append_enum8(bytes, order_type);
+            append_value(bytes, amount);
+            append_value(bytes, refund);
+            append_value(bytes, min_payout);
+            append_value(bytes, duration);
+            append_value(bytes, expiry_time);
+
+            append_enum8(bytes, status);
+            append_enum8(bytes, reject_code);
+            append_string(bytes, reject_desc);
+            append_enum8(bytes, outcome);
+            append_enum8(bytes, trade_state);
+            append_value(bytes, total_amount);
+            append_value(bytes, total_profit);
+
+            append_value(bytes, create_date);
+            append_value(bytes, accept_date);
+            append_value(bytes, reject_date);
+            append_value(bytes, complete_date);
+
+            append_enum8(bytes, mm_type);
+            append_value(bytes, mm_step);
+            append_value(bytes, mm_group_id);
+            append_string(bytes, mm_group_hash);
+            append_string(bytes, mm_group_name);
+            append_string(bytes, mm_params_json);
+            append_string(bytes, decision_params_json);
+            append_string(bytes, metadata_json);
+
+            append_vector_u32(bytes, trade_ids);
+            return bytes;
+        }
+
+        /// \brief Deserializes a signal record serialized by the current binary storage format.
+        static SignalRecord from_bytes(const void* data, std::size_t size) {
+            BinaryReader reader(data, size);
+
+            const auto magic = reader.read<std::uint32_t>();
+            if (magic != kBinaryMagic) {
+                throw std::runtime_error("SignalRecord::from_bytes: invalid magic");
+            }
+
+            const auto version = reader.read<std::uint16_t>();
+            if (version != kBinaryVersion) {
+                throw std::runtime_error("SignalRecord::from_bytes: unsupported version");
+            }
+
+            SignalRecord record;
+            record.signal_id = reader.read<std::uint32_t>();
+            record.unique_id = reader.read<std::int64_t>();
+            record.unique_hash = reader.read_string();
+            record.account_id = reader.read<std::int64_t>();
+
+            record.platform_type = reader.read_enum8<PlatformType>();
+            record.account_type = reader.read_enum8<AccountType>();
+            record.currency = reader.read_enum8<CurrencyType>();
+            record.symbol = reader.read_string();
+            record.signal_name = reader.read_string();
+            record.user_data = reader.read_string();
+            record.comment = reader.read_string();
+
+            record.option_type = reader.read_enum8<OptionType>();
+            record.order_type = reader.read_enum8<OrderType>();
+            record.amount = reader.read<double>();
+            record.refund = reader.read<double>();
+            record.min_payout = reader.read<double>();
+            record.duration = reader.read<std::uint32_t>();
+            record.expiry_time = reader.read<std::int64_t>();
+
+            record.status = reader.read_enum8<SignalStatus>();
+            record.reject_code = reader.read_enum8<SignalRejectCode>();
+            record.reject_desc = reader.read_string();
+            record.outcome = reader.read_enum8<SignalOutcome>();
+            record.trade_state = reader.read_enum8<TradeState>();
+            record.total_amount = reader.read<double>();
+            record.total_profit = reader.read<double>();
+
+            record.create_date = reader.read<std::int64_t>();
+            record.accept_date = reader.read<std::int64_t>();
+            record.reject_date = reader.read<std::int64_t>();
+            record.complete_date = reader.read<std::int64_t>();
+
+            record.mm_type = reader.read_enum8<MmSystemType>();
+            record.mm_step = reader.read<std::int32_t>();
+            record.mm_group_id = reader.read<std::int64_t>();
+            record.mm_group_hash = reader.read_string();
+            record.mm_group_name = reader.read_string();
+            record.mm_params_json = reader.read_string();
+            record.decision_params_json = reader.read_string();
+            record.metadata_json = reader.read_string();
+
+            record.trade_ids = reader.read_vector_u32();
+            reader.ensure_finished();
+            return record;
+        }
+
+        bool operator==(const SignalRecord& other) const {
+            return signal_id == other.signal_id &&
+                   unique_id == other.unique_id &&
+                   unique_hash == other.unique_hash &&
+                   account_id == other.account_id &&
+                   platform_type == other.platform_type &&
+                   account_type == other.account_type &&
+                   currency == other.currency &&
+                   symbol == other.symbol &&
+                   signal_name == other.signal_name &&
+                   user_data == other.user_data &&
+                   comment == other.comment &&
+                   option_type == other.option_type &&
+                   order_type == other.order_type &&
+                   amount == other.amount &&
+                   refund == other.refund &&
+                   min_payout == other.min_payout &&
+                   duration == other.duration &&
+                   expiry_time == other.expiry_time &&
+                   status == other.status &&
+                   reject_code == other.reject_code &&
+                   reject_desc == other.reject_desc &&
+                   outcome == other.outcome &&
+                   trade_state == other.trade_state &&
+                   total_amount == other.total_amount &&
+                   total_profit == other.total_profit &&
+                   create_date == other.create_date &&
+                   accept_date == other.accept_date &&
+                   reject_date == other.reject_date &&
+                   complete_date == other.complete_date &&
+                   mm_type == other.mm_type &&
+                   mm_step == other.mm_step &&
+                   mm_group_id == other.mm_group_id &&
+                   mm_group_hash == other.mm_group_hash &&
+                   mm_group_name == other.mm_group_name &&
+                   mm_params_json == other.mm_params_json &&
+                   decision_params_json == other.decision_params_json &&
+                   metadata_json == other.metadata_json &&
+                   trade_ids == other.trade_ids;
+        }
+
+        bool operator!=(const SignalRecord& other) const {
+            return !(*this == other);
+        }
+
         NLOHMANN_DEFINE_TYPE_INTRUSIVE(
             SignalRecord,
             signal_id,
@@ -184,6 +353,104 @@ namespace optionx {
             metadata_json,
             trade_ids
         )
+
+    private:
+        static constexpr std::uint32_t kBinaryMagic = 0x5253584fU; // "OXSR" on little-endian hosts.
+        static constexpr std::uint16_t kBinaryVersion = 1;
+
+        template<class T>
+        static void append_value(std::vector<std::uint8_t>& bytes, const T& value) {
+            static_assert(std::is_trivially_copyable_v<T>, "SignalRecord binary value must be trivially copyable");
+            const auto* ptr = reinterpret_cast<const std::uint8_t*>(&value);
+            bytes.insert(bytes.end(), ptr, ptr + sizeof(T));
+        }
+
+        template<class Enum>
+        static void append_enum8(std::vector<std::uint8_t>& bytes, Enum value) {
+            append_value(bytes, static_cast<std::uint8_t>(value));
+        }
+
+        static void append_string(std::vector<std::uint8_t>& bytes, const std::string& value) {
+            if (value.size() > (std::numeric_limits<std::uint32_t>::max)()) {
+                throw std::length_error("SignalRecord string field is too large to serialize");
+            }
+            append_value(bytes, static_cast<std::uint32_t>(value.size()));
+            bytes.insert(bytes.end(), value.begin(), value.end());
+        }
+
+        static void append_vector_u32(
+                std::vector<std::uint8_t>& bytes,
+                const std::vector<std::uint32_t>& values) {
+            if (values.size() > (std::numeric_limits<std::uint32_t>::max)()) {
+                throw std::length_error("SignalRecord vector field is too large to serialize");
+            }
+            append_value(bytes, static_cast<std::uint32_t>(values.size()));
+            for (const auto value : values) {
+                append_value(bytes, value);
+            }
+        }
+
+        class BinaryReader {
+        public:
+            BinaryReader(const void* data, std::size_t size)
+                : m_data(static_cast<const std::uint8_t*>(data)), m_size(size) {
+                if (!m_data && size > 0) {
+                    throw std::runtime_error("SignalRecord::from_bytes: null data");
+                }
+            }
+
+            template<class T>
+            T read() {
+                static_assert(std::is_trivially_copyable_v<T>, "SignalRecord binary value must be trivially copyable");
+                ensure(sizeof(T));
+                T value{};
+                std::memcpy(&value, m_data + m_offset, sizeof(T));
+                m_offset += sizeof(T);
+                return value;
+            }
+
+            template<class Enum>
+            Enum read_enum8() {
+                return static_cast<Enum>(read<std::uint8_t>());
+            }
+
+            std::string read_string() {
+                const auto length = read<std::uint32_t>();
+                ensure(length);
+                std::string value(
+                    reinterpret_cast<const char*>(m_data + m_offset),
+                    reinterpret_cast<const char*>(m_data + m_offset + length));
+                m_offset += length;
+                return value;
+            }
+
+            std::vector<std::uint32_t> read_vector_u32() {
+                const auto length = read<std::uint32_t>();
+                std::vector<std::uint32_t> values;
+                values.reserve(length);
+                for (std::uint32_t i = 0; i < length; ++i) {
+                    values.push_back(read<std::uint32_t>());
+                }
+                return values;
+            }
+
+            void ensure_finished() const {
+                if (m_offset != m_size) {
+                    throw std::runtime_error("SignalRecord::from_bytes: trailing data");
+                }
+            }
+
+        private:
+            const std::uint8_t* m_data = nullptr;
+            std::size_t m_size = 0;
+            std::size_t m_offset = 0;
+
+            void ensure(std::size_t bytes) const {
+                if (bytes > m_size - m_offset) {
+                    throw std::runtime_error("SignalRecord::from_bytes: corrupted or truncated data");
+                }
+            }
+        };
     };
 
 } // namespace optionx

--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -357,6 +357,12 @@ namespace optionx {
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5253584fU; // "OXSR" on little-endian hosts.
         static constexpr std::uint16_t kBinaryVersion = 1;
+        static_assert(sizeof(double) == 8, "SignalRecord binary format requires 64-bit double");
+        static_assert(std::numeric_limits<double>::is_iec559,
+                      "SignalRecord binary format requires IEEE-754 double");
+
+        // This is a compact local storage format, not a cross-architecture wire format.
+        // It is intended for little-endian Windows/Linux targets with IEEE-754 doubles.
 
         template<class T>
         static void append_value(std::vector<std::uint8_t>& bytes, const T& value) {
@@ -426,6 +432,10 @@ namespace optionx {
 
             std::vector<std::uint32_t> read_vector_u32() {
                 const auto length = read<std::uint32_t>();
+                if (length > remaining() / sizeof(std::uint32_t)) {
+                    throw std::runtime_error("SignalRecord::from_bytes: corrupted vector length");
+                }
+
                 std::vector<std::uint32_t> values;
                 values.reserve(length);
                 for (std::uint32_t i = 0; i < length; ++i) {
@@ -438,6 +448,10 @@ namespace optionx {
                 if (m_offset != m_size) {
                     throw std::runtime_error("SignalRecord::from_bytes: trailing data");
                 }
+            }
+
+            std::size_t remaining() const noexcept {
+                return m_size - m_offset;
             }
 
         private:

--- a/include/optionx_cpp/storages.hpp
+++ b/include/optionx_cpp/storages.hpp
@@ -7,5 +7,6 @@
 #include "storages/common.hpp"
 #include "storages/ServiceSessionDB.hpp"
 #include "storages/TradeRecordDB.hpp"
+#include "storages/SignalRecordDB.hpp"
 
 #endif // _OPTIONX_STORAGES_HPP_INCLUDED

--- a/include/optionx_cpp/storages/SignalRecordDB.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB.hpp
@@ -1,0 +1,264 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_SIGNAL_RECORD_DB_HPP_INCLUDED
+#define _OPTIONX_STORAGE_SIGNAL_RECORD_DB_HPP_INCLUDED
+
+/// \file SignalRecordDB.hpp
+/// \brief Provides persistent storage for SignalRecord objects using MDBX containers.
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <mdbx_containers/KeyValueTable.hpp>
+#include <mdbx_containers/ValueTable.hpp>
+
+#include "data/trading.hpp"
+#include "common.hpp"
+#include "SignalRecordDB/enums.hpp"
+#include "SignalRecordDB/data.hpp"
+#include "SignalRecordDB/detail.hpp"
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#   ifndef OPTIONX_DATA_PATH
+#   define OPTIONX_DATA_PATH "data"
+#   endif
+
+#   ifndef OPTIONX_DB_PATH
+#   define OPTIONX_DB_PATH OPTIONX_DATA_PATH "\\db"
+#   endif
+
+#   ifndef OPTIONX_SIGNAL_RECORD_DB_FILE
+#   define OPTIONX_SIGNAL_RECORD_DB_FILE OPTIONX_DB_PATH "\\signal_records"
+#   endif
+
+#else
+
+#   ifndef OPTIONX_DATA_PATH
+#   define OPTIONX_DATA_PATH "data"
+#   endif
+
+#   ifndef OPTIONX_DB_PATH
+#   define OPTIONX_DB_PATH OPTIONX_DATA_PATH "/db"
+#   endif
+
+#   ifndef OPTIONX_SIGNAL_RECORD_DB_FILE
+#   define OPTIONX_SIGNAL_RECORD_DB_FILE OPTIONX_DB_PATH "/signal_records"
+#   endif
+
+#endif
+
+namespace optionx::storage {
+
+    /// \class SignalRecordDB
+    /// \brief Header-only MDBX-backed storage service for SignalRecord objects.
+    ///
+    /// SignalRecordDB owns the persistent linear signal_id sequence used by
+    /// TradeSignal::signal_id, TradeRequest::signal_id, TradeRecord::signal_id
+    /// and SignalRecord::signal_id. The signal_id itself is a 32-bit monotonic
+    /// value; 0 means "not assigned".
+    ///
+    /// Direct methods execute synchronously. Buffered enqueue_* methods mirror
+    /// TradeRecordDB: process() executes queued work on the caller thread when
+    /// no worker is running, run() starts a worker, flush() waits for queued
+    /// work, and callbacks are delivered by process(), flush() or shutdown().
+    class SignalRecordDB {
+    public:
+        using write_callback_t = std::function<void(SignalRecordDBWriteResult)>;
+        using read_callback_t = std::function<void(SignalRecordDBReadResult)>;
+        using list_callback_t = std::function<void(SignalRecordDBListResult)>;
+        using status_callback_t = std::function<void(SignalRecordDBStatus)>;
+
+        /// \brief Creates default MDBX configuration for the signal records database.
+        static mdbxc::Config default_config();
+
+        /// \brief Constructs storage with the default configuration and table names.
+        SignalRecordDB();
+
+        /// \brief Constructs storage with custom MDBX configuration and optional table names.
+        explicit SignalRecordDB(
+            mdbxc::Config config,
+            std::string records_table = "signal_records",
+            std::string uid_index_table = "signal_record_uid_index",
+            std::string signal_id_index_table = "signal_record_signal_id_index",
+            std::string trade_id_index_table = "signal_record_trade_id_index",
+            std::string meta_table = "signal_record_meta");
+
+        ~SignalRecordDB();
+
+        SignalRecordDB(const SignalRecordDB&) = delete;
+        SignalRecordDB& operator=(const SignalRecordDB&) = delete;
+        SignalRecordDB(SignalRecordDB&&) = delete;
+        SignalRecordDB& operator=(SignalRecordDB&&) = delete;
+
+        /// \brief Returns true when the MDBX environment and all tables are open.
+        bool is_open() const;
+
+        /// \brief Reserves and persists a new linear signal ID.
+        std::uint32_t get_signal_id();
+
+        /// \brief Assigns a persistent signal ID to a signal when it does not have one.
+        bool assign_signal_id(TradeSignal& signal);
+
+        /// \brief Assigns a persistent signal ID to a signal record when it does not have one.
+        bool assign_signal_id(SignalRecord& record);
+
+        /// \brief Assigns a persistent signal ID to a request when it does not have one.
+        bool assign_signal_id(TradeRequest& request);
+
+        /// \brief Inserts or updates a signal record, allocating or reusing signal_id as needed.
+        SignalRecordDBWriteResult upsert(SignalRecord record);
+
+        /// \brief Writes a signal record that already has a signal_id.
+        SignalRecordDBWriteResult write(SignalRecord record);
+
+        /// \brief Finds a signal by persistent signal_id.
+        SignalRecordDBReadResult find_by_signal_id(std::uint32_t signal_id) const;
+
+        /// \brief Finds a signal through its optional unique_id index.
+        SignalRecordDBReadResult find_by_uid(std::int64_t unique_id) const;
+
+        /// \brief Finds the signal that currently owns the given produced trade_id.
+        SignalRecordDBReadResult find_by_trade_id(std::uint32_t trade_id) const;
+
+        /// \brief Finds all signal records whose canonical timestamp equals timestamp_ms.
+        SignalRecordDBListResult find_by_timestamp(std::int64_t timestamp_ms) const;
+
+        /// \brief Finds all signal records whose canonical timestamp is inside [start_ms, stop_ms].
+        SignalRecordDBListResult find_range(std::int64_t start_ms, std::int64_t stop_ms) const;
+
+        /// \brief Returns all signal records sorted by canonical timestamp and signal_id.
+        SignalRecordDBListResult find_records() const;
+
+        /// \brief Convenience overload returning only the record vector.
+        std::vector<optionx::SignalRecord> find_records_vector() const;
+
+        /// \brief Erases a signal record by signal_id and removes its indexes.
+        SignalRecordDBStatus erase_by_signal_id(std::uint32_t signal_id);
+
+        /// \brief Clears records, indices and meta table, then re-initializes meta.
+        SignalRecordDBStatus clear();
+
+        /// \brief Returns number of persisted signal records.
+        std::size_t count() const;
+
+        /// \brief Enqueues an upsert operation.
+        SignalRecordDBStatus enqueue_upsert(SignalRecord record, write_callback_t callback = {});
+
+        /// \brief Enqueues a write operation.
+        SignalRecordDBStatus enqueue_write(SignalRecord record, write_callback_t callback = {});
+
+        /// \brief Enqueues a find-by-signal-id operation.
+        SignalRecordDBStatus enqueue_find_by_signal_id(std::uint32_t signal_id, read_callback_t callback = {});
+
+        /// \brief Enqueues a find-by-UID operation.
+        SignalRecordDBStatus enqueue_find_by_uid(std::int64_t unique_id, read_callback_t callback = {});
+
+        /// \brief Enqueues a find-by-trade-id operation.
+        SignalRecordDBStatus enqueue_find_by_trade_id(std::uint32_t trade_id, read_callback_t callback = {});
+
+        /// \brief Enqueues a range query operation.
+        SignalRecordDBStatus enqueue_find_range(std::int64_t start_ms, std::int64_t stop_ms, list_callback_t callback = {});
+
+        /// \brief Enqueues a find-all operation.
+        SignalRecordDBStatus enqueue_find_records(list_callback_t callback = {});
+
+        /// \brief Enqueues an erase-by-signal-id operation.
+        SignalRecordDBStatus enqueue_erase_by_signal_id(std::uint32_t signal_id, status_callback_t callback = {});
+
+        /// \brief Enqueues a clear operation.
+        SignalRecordDBStatus enqueue_clear(status_callback_t callback = {});
+
+        /// \brief Starts internal worker thread. Callbacks are still delivered only by process() or flush().
+        bool run();
+
+        /// \brief Executes queued work when no worker is running and delivers ready callbacks on the caller thread.
+        void process();
+
+        /// \brief Blocks until queued DB work is complete, then delivers callbacks on the caller thread.
+        void flush();
+
+        /// \brief Stops queue intake, waits for worker, delivers pending callbacks, and closes the database.
+        void shutdown();
+
+    private:
+        using records_table_t = mdbxc::KeyValueTable<std::uint64_t, SignalRecord>;
+        using uid_index_table_t = mdbxc::KeyValueTable<std::int64_t, std::uint64_t>;
+        using signal_id_index_table_t = mdbxc::KeyValueTable<std::uint32_t, std::uint64_t>;
+        using trade_id_index_table_t = mdbxc::KeyValueTable<std::uint32_t, std::uint64_t>;
+        using meta_table_t = mdbxc::ValueTable<SignalRecordDBMeta>;
+
+        mdbxc::Config m_config;
+        std::string m_records_table_name;
+        std::string m_uid_index_table_name;
+        std::string m_signal_id_index_table_name;
+        std::string m_trade_id_index_table_name;
+        std::string m_meta_table_name;
+
+        mutable std::mutex m_db_mutex;
+        std::shared_ptr<mdbxc::Connection> m_connection;
+        std::unique_ptr<records_table_t> m_records;
+        std::unique_ptr<uid_index_table_t> m_uid_index;
+        std::unique_ptr<signal_id_index_table_t> m_signal_id_index;
+        std::unique_ptr<trade_id_index_table_t> m_trade_id_index;
+        std::unique_ptr<meta_table_t> m_meta;
+        bool m_open = false;
+        bool m_read_only = false;
+
+        mutable std::mutex m_queue_mutex;
+        std::condition_variable m_work_cv;
+        std::condition_variable m_idle_cv;
+        std::deque<std::function<void()>> m_work_queue;
+        std::size_t m_active_work = 0;
+        bool m_accepting = true;
+        bool m_worker_stop = false;
+        bool m_worker_running = false;
+        std::thread m_worker_thread;
+
+        std::mutex m_callback_mutex;
+        std::deque<std::function<void()>> m_callback_queue;
+
+        void open();
+        bool is_open_no_lock() const noexcept;
+        void init_meta_no_lock(MDBX_txn* txn);
+        void update_last_update_no_lock(MDBX_txn* txn);
+        std::uint32_t reserve_signal_id_no_lock(MDBX_txn* txn);
+        void bump_next_signal_id_no_lock(std::uint32_t used_signal_id, MDBX_txn* txn);
+        void remove_indexes_no_lock(const SignalRecord& record, MDBX_txn* txn);
+        void write_indexes_no_lock(const SignalRecord& record, std::uint64_t composite_key, MDBX_txn* txn);
+        void store_record_no_lock(const SignalRecord& record, MDBX_txn* txn);
+        std::uint32_t find_existing_signal_id_no_lock(const SignalRecord& record, MDBX_txn* txn);
+
+        SignalRecordDBWriteResult write_no_lock(SignalRecord record);
+        SignalRecordDBWriteResult upsert_no_lock(SignalRecord record);
+        SignalRecordDBReadResult find_by_signal_id_no_lock(std::uint32_t signal_id) const;
+        SignalRecordDBReadResult find_by_uid_no_lock(std::int64_t unique_id) const;
+        SignalRecordDBReadResult find_by_trade_id_no_lock(std::uint32_t trade_id) const;
+        SignalRecordDBListResult find_by_timestamp_no_lock(std::int64_t timestamp_ms) const;
+        SignalRecordDBListResult find_range_no_lock(std::int64_t start_ms, std::int64_t stop_ms) const;
+        SignalRecordDBListResult find_records_no_lock() const;
+        SignalRecordDBStatus erase_by_signal_id_no_lock(std::uint32_t signal_id);
+        SignalRecordDBStatus clear_no_lock();
+
+        bool worker_running() const;
+        SignalRecordDBStatus enqueue_command(std::function<void()> command);
+        void enqueue_callback(std::function<void()> callback);
+        bool pop_command(std::function<void()>& command);
+        void finish_command();
+        void execute_command(std::function<void()> command);
+        void drain_work_on_caller();
+        void deliver_callbacks();
+        void worker_loop();
+    };
+
+} // namespace optionx::storage
+
+#include "SignalRecordDB/SignalRecordDB.ipp"
+
+#endif // _OPTIONX_STORAGE_SIGNAL_RECORD_DB_HPP_INCLUDED

--- a/include/optionx_cpp/storages/SignalRecordDB.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB.hpp
@@ -85,7 +85,6 @@ namespace optionx::storage {
         explicit SignalRecordDB(
             mdbxc::Config config,
             std::string records_table = "signal_records",
-            std::string uid_index_table = "signal_record_uid_index",
             std::string signal_id_index_table = "signal_record_signal_id_index",
             std::string trade_id_index_table = "signal_record_trade_id_index",
             std::string meta_table = "signal_record_meta");
@@ -121,8 +120,8 @@ namespace optionx::storage {
         /// \brief Finds a signal by persistent signal_id.
         SignalRecordDBReadResult find_by_signal_id(std::uint32_t signal_id) const;
 
-        /// \brief Finds a signal through its optional unique_id index.
-        SignalRecordDBReadResult find_by_uid(std::int64_t unique_id) const;
+        /// \brief Finds all signals with the user-defined unique_id value.
+        SignalRecordDBListResult find_by_uid(std::int64_t unique_id) const;
 
         /// \brief Finds the signal that currently owns the given produced trade_id.
         SignalRecordDBReadResult find_by_trade_id(std::uint32_t trade_id) const;
@@ -158,7 +157,7 @@ namespace optionx::storage {
         SignalRecordDBStatus enqueue_find_by_signal_id(std::uint32_t signal_id, read_callback_t callback = {});
 
         /// \brief Enqueues a find-by-UID operation.
-        SignalRecordDBStatus enqueue_find_by_uid(std::int64_t unique_id, read_callback_t callback = {});
+        SignalRecordDBStatus enqueue_find_by_uid(std::int64_t unique_id, list_callback_t callback = {});
 
         /// \brief Enqueues a find-by-trade-id operation.
         SignalRecordDBStatus enqueue_find_by_trade_id(std::uint32_t trade_id, read_callback_t callback = {});
@@ -189,14 +188,12 @@ namespace optionx::storage {
 
     private:
         using records_table_t = mdbxc::KeyValueTable<std::uint64_t, SignalRecord>;
-        using uid_index_table_t = mdbxc::KeyValueTable<std::int64_t, std::uint64_t>;
         using signal_id_index_table_t = mdbxc::KeyValueTable<std::uint32_t, std::uint64_t>;
         using trade_id_index_table_t = mdbxc::KeyValueTable<std::uint32_t, std::uint64_t>;
         using meta_table_t = mdbxc::ValueTable<SignalRecordDBMeta>;
 
         mdbxc::Config m_config;
         std::string m_records_table_name;
-        std::string m_uid_index_table_name;
         std::string m_signal_id_index_table_name;
         std::string m_trade_id_index_table_name;
         std::string m_meta_table_name;
@@ -204,7 +201,6 @@ namespace optionx::storage {
         mutable std::mutex m_db_mutex;
         std::shared_ptr<mdbxc::Connection> m_connection;
         std::unique_ptr<records_table_t> m_records;
-        std::unique_ptr<uid_index_table_t> m_uid_index;
         std::unique_ptr<signal_id_index_table_t> m_signal_id_index;
         std::unique_ptr<trade_id_index_table_t> m_trade_id_index;
         std::unique_ptr<meta_table_t> m_meta;
@@ -234,11 +230,12 @@ namespace optionx::storage {
         void write_indexes_no_lock(const SignalRecord& record, std::uint64_t composite_key, MDBX_txn* txn);
         void store_record_no_lock(const SignalRecord& record, MDBX_txn* txn);
         std::uint32_t find_existing_signal_id_no_lock(const SignalRecord& record, MDBX_txn* txn);
+        bool trade_id_conflicts_no_lock(const SignalRecord& record, MDBX_txn* txn, std::string* message = nullptr);
 
         SignalRecordDBWriteResult write_no_lock(SignalRecord record);
         SignalRecordDBWriteResult upsert_no_lock(SignalRecord record);
         SignalRecordDBReadResult find_by_signal_id_no_lock(std::uint32_t signal_id) const;
-        SignalRecordDBReadResult find_by_uid_no_lock(std::int64_t unique_id) const;
+        SignalRecordDBListResult find_by_uid_no_lock(std::int64_t unique_id) const;
         SignalRecordDBReadResult find_by_trade_id_no_lock(std::uint32_t trade_id) const;
         SignalRecordDBListResult find_by_timestamp_no_lock(std::int64_t timestamp_ms) const;
         SignalRecordDBListResult find_range_no_lock(std::int64_t start_ms, std::int64_t stop_ms) const;

--- a/include/optionx_cpp/storages/SignalRecordDB.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB.hpp
@@ -121,7 +121,15 @@ namespace optionx::storage {
         SignalRecordDBReadResult find_by_signal_id(std::uint32_t signal_id) const;
 
         /// \brief Finds all signals with the user-defined unique_id value.
+        /// \details Convenience full-scan search over all signal records.
+        /// For large journals prefer the overload with an explicit time range.
         SignalRecordDBListResult find_by_uid(std::int64_t unique_id) const;
+
+        /// \brief Finds all signals with unique_id inside [start_ms, stop_ms].
+        SignalRecordDBListResult find_by_uid(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms) const;
 
         /// \brief Finds the signal that currently owns the given produced trade_id.
         SignalRecordDBReadResult find_by_trade_id(std::uint32_t trade_id) const;
@@ -156,8 +164,15 @@ namespace optionx::storage {
         /// \brief Enqueues a find-by-signal-id operation.
         SignalRecordDBStatus enqueue_find_by_signal_id(std::uint32_t signal_id, read_callback_t callback = {});
 
-        /// \brief Enqueues a find-by-UID operation.
+        /// \brief Enqueues a full-scan find-by-UID operation.
         SignalRecordDBStatus enqueue_find_by_uid(std::int64_t unique_id, list_callback_t callback = {});
+
+        /// \brief Enqueues a time-range find-by-UID operation.
+        SignalRecordDBStatus enqueue_find_by_uid(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms,
+            list_callback_t callback = {});
 
         /// \brief Enqueues a find-by-trade-id operation.
         SignalRecordDBStatus enqueue_find_by_trade_id(std::uint32_t trade_id, read_callback_t callback = {});
@@ -224,6 +239,7 @@ namespace optionx::storage {
         bool is_open_no_lock() const noexcept;
         void init_meta_no_lock(MDBX_txn* txn);
         void update_last_update_no_lock(MDBX_txn* txn);
+        void close_storage_no_lock() noexcept;
         std::uint32_t reserve_signal_id_no_lock(MDBX_txn* txn);
         void bump_next_signal_id_no_lock(std::uint32_t used_signal_id, MDBX_txn* txn);
         void remove_indexes_no_lock(const SignalRecord& record, MDBX_txn* txn);
@@ -236,6 +252,10 @@ namespace optionx::storage {
         SignalRecordDBWriteResult upsert_no_lock(SignalRecord record);
         SignalRecordDBReadResult find_by_signal_id_no_lock(std::uint32_t signal_id) const;
         SignalRecordDBListResult find_by_uid_no_lock(std::int64_t unique_id) const;
+        SignalRecordDBListResult find_by_uid_no_lock(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms) const;
         SignalRecordDBReadResult find_by_trade_id_no_lock(std::uint32_t trade_id) const;
         SignalRecordDBListResult find_by_timestamp_no_lock(std::int64_t timestamp_ms) const;
         SignalRecordDBListResult find_range_no_lock(std::int64_t start_ms, std::int64_t stop_ms) const;

--- a/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
+++ b/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
@@ -92,26 +92,26 @@ namespace optionx::storage {
     inline SignalRecordDBWriteResult SignalRecordDB::upsert(SignalRecord record) {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            return upsert_no_lock(std::move(record));
+            return upsert_no_lock(record);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB upsert database error: ", ex);
-            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, record, ex.what());
         } catch (const std::exception& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB upsert error: ", ex);
-            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, record, ex.what());
         }
     }
 
     inline SignalRecordDBWriteResult SignalRecordDB::write(SignalRecord record) {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            return write_no_lock(std::move(record));
+            return write_no_lock(record);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB write database error: ", ex);
-            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, record, ex.what());
         } catch (const std::exception& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB write error: ", ex);
-            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, record, ex.what());
         }
     }
 
@@ -137,6 +137,22 @@ namespace optionx::storage {
             return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
         } catch (const std::exception& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_by_uid(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_by_uid_no_lock(unique_id, start_ms, stop_ms);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid range database error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid range error: ", ex);
             return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
         }
     }
@@ -278,6 +294,19 @@ namespace optionx::storage {
         });
     }
 
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_uid(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms,
+            list_callback_t callback) {
+        return enqueue_command([this, unique_id, start_ms, stop_ms, callback = std::move(callback)]() mutable {
+            auto result = find_by_uid(unique_id, start_ms, stop_ms);
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
     inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_trade_id(
             std::uint32_t trade_id,
             read_callback_t callback) {
@@ -390,21 +419,7 @@ namespace optionx::storage {
         deliver_callbacks();
 
         std::lock_guard<std::mutex> lock(m_db_mutex);
-        try {
-            m_records.reset();
-            m_signal_id_index.reset();
-            m_trade_id_index.reset();
-            m_meta.reset();
-            if (m_connection && m_connection->is_connected()) {
-                m_connection->shutdown();
-            }
-            m_connection.reset();
-        } catch (const mdbxc::MdbxException& ex) {
-            LOGIT_PRINT_ERROR("SignalRecordDB shutdown database error: ", ex);
-        } catch (const std::exception& ex) {
-            LOGIT_PRINT_ERROR("SignalRecordDB shutdown error: ", ex);
-        }
-        m_open = false;
+        close_storage_no_lock();
     }
 
     inline void SignalRecordDB::open() {
@@ -430,10 +445,10 @@ namespace optionx::storage {
             }
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB connection error: ", ex);
-            m_open = false;
+            close_storage_no_lock();
         } catch (const std::exception& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB initialization error: ", ex);
-            m_open = false;
+            close_storage_no_lock();
         }
     }
 
@@ -457,6 +472,28 @@ namespace optionx::storage {
         auto meta = m_meta->get_or(SignalRecordDBMeta{}, txn);
         meta.last_update_ms = time_shield::timestamp_ms();
         m_meta->set(meta, txn);
+    }
+
+    inline void SignalRecordDB::close_storage_no_lock() noexcept {
+        m_records.reset();
+        m_signal_id_index.reset();
+        m_trade_id_index.reset();
+        m_meta.reset();
+
+        try {
+            if (m_connection && m_connection->is_connected()) {
+                m_connection->shutdown();
+            }
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB cleanup database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB cleanup error: ", ex);
+        } catch (...) {
+            LOGIT_PRINT_ERROR("SignalRecordDB cleanup unknown error");
+        }
+
+        m_connection.reset();
+        m_open = false;
     }
 
     inline std::uint32_t SignalRecordDB::reserve_signal_id_no_lock(MDBX_txn* txn) {
@@ -726,6 +763,44 @@ namespace optionx::storage {
             stop_key,
             [&result, unique_id](const std::uint64_t&, const SignalRecord& record) {
                 if (record.unique_id == unique_id) {
+                    result.records.push_back(record);
+                }
+                return true;
+            },
+            txn.handle());
+
+        txn.commit();
+        return result;
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_by_uid_no_lock(
+            std::int64_t unique_id,
+            std::int64_t start_ms,
+            std::int64_t stop_ms) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (start_ms < 0 || stop_ms < 0 || start_ms > stop_ms) {
+            return signal_detail::list_error(
+                SignalRecordDBStatus::INVALID_ARGUMENT,
+                "SignalRecord timestamp range is invalid");
+        }
+
+        const auto start_min = signal_detail::timestamp_ms_to_unix_minutes(start_ms);
+        const auto stop_min = signal_detail::timestamp_ms_to_unix_minutes(stop_ms);
+        const auto start_key = signal_detail::make_composite_key(start_min, 0);
+        const auto stop_key = signal_detail::make_composite_key(stop_min, 0xFFFFFFFFu);
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SignalRecordDBListResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+
+        m_records->for_each_range(
+            start_key,
+            stop_key,
+            [&result, unique_id, start_ms, stop_ms](const std::uint64_t&, const SignalRecord& record) {
+                const auto timestamp = signal_detail::selected_timestamp_ms(record);
+                if (record.unique_id == unique_id && timestamp >= start_ms && timestamp <= stop_ms) {
                     result.records.push_back(record);
                 }
                 return true;

--- a/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
+++ b/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
@@ -711,11 +711,6 @@ namespace optionx::storage {
         if (!is_open_no_lock()) {
             return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
         }
-        if (unique_id <= 0) {
-            return signal_detail::list_error(
-                SignalRecordDBStatus::INVALID_ARGUMENT,
-                "SignalRecord unique_id is required");
-        }
 
         const auto start_key = signal_detail::make_composite_key(std::numeric_limits<std::int32_t>::min(), 0);
         const auto stop_key = signal_detail::make_composite_key(

--- a/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
+++ b/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
@@ -1,0 +1,1024 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_SIGNAL_RECORD_DB_IPP_INCLUDED
+#define _OPTIONX_STORAGE_SIGNAL_RECORD_DB_IPP_INCLUDED
+
+/// \file SignalRecordDB.ipp
+/// \brief Inline implementation of SignalRecordDB.
+
+#include <algorithm>
+#include <exception>
+#include <limits>
+#include <utility>
+
+#include <time_shield.hpp>
+
+#include "utils.hpp"
+
+namespace optionx::storage {
+
+    inline mdbxc::Config SignalRecordDB::default_config() {
+        mdbxc::Config config;
+        config.pathname = OPTIONX_SIGNAL_RECORD_DB_FILE;
+        config.max_dbs = 5;
+        config.no_subdir = false;
+        config.relative_to_exe = true;
+        return config;
+    }
+
+    inline SignalRecordDB::SignalRecordDB()
+        : SignalRecordDB(default_config()) {}
+
+    inline SignalRecordDB::SignalRecordDB(
+        mdbxc::Config config,
+        std::string records_table,
+        std::string uid_index_table,
+        std::string signal_id_index_table,
+        std::string trade_id_index_table,
+        std::string meta_table)
+        : m_config(std::move(config)),
+          m_records_table_name(std::move(records_table)),
+          m_uid_index_table_name(std::move(uid_index_table)),
+          m_signal_id_index_table_name(std::move(signal_id_index_table)),
+          m_trade_id_index_table_name(std::move(trade_id_index_table)),
+          m_meta_table_name(std::move(meta_table)) {
+        open();
+    }
+
+    inline SignalRecordDB::~SignalRecordDB() {
+        shutdown();
+    }
+
+    inline bool SignalRecordDB::is_open() const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        return is_open_no_lock();
+    }
+
+    inline std::uint32_t SignalRecordDB::get_signal_id() {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            if (!is_open_no_lock()) return 0;
+            if (m_read_only) return 0;
+
+            auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+            const auto signal_id = reserve_signal_id_no_lock(txn.handle());
+            if (signal_id == 0) return 0;
+            update_last_update_no_lock(txn.handle());
+            txn.commit();
+            return signal_id;
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB signal_id database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB signal_id error: ", ex);
+        }
+        return 0;
+    }
+
+    inline bool SignalRecordDB::assign_signal_id(TradeSignal& signal) {
+        if (signal.signal_id > 0) return true;
+        signal.signal_id = get_signal_id();
+        return signal.signal_id > 0;
+    }
+
+    inline bool SignalRecordDB::assign_signal_id(SignalRecord& record) {
+        if (record.signal_id > 0) return true;
+        record.signal_id = get_signal_id();
+        return record.signal_id > 0;
+    }
+
+    inline bool SignalRecordDB::assign_signal_id(TradeRequest& request) {
+        if (request.signal_id > 0) return true;
+        request.signal_id = get_signal_id();
+        return request.signal_id > 0;
+    }
+
+    inline SignalRecordDBWriteResult SignalRecordDB::upsert(SignalRecord record) {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return upsert_no_lock(std::move(record));
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB upsert database error: ", ex);
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB upsert error: ", ex);
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+        }
+    }
+
+    inline SignalRecordDBWriteResult SignalRecordDB::write(SignalRecord record) {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return write_no_lock(std::move(record));
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB write database error: ", ex);
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB write error: ", ex);
+            return signal_detail::write_error(SignalRecordDBStatus::DB_ERROR, std::move(record), ex.what());
+        }
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_signal_id(std::uint32_t signal_id) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_by_signal_id_no_lock(signal_id);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_signal_id database error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_signal_id error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_uid(std::int64_t unique_id) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_by_uid_no_lock(unique_id);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid database error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_trade_id(std::uint32_t trade_id) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_by_trade_id_no_lock(trade_id);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_trade_id database error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_trade_id error: ", ex);
+            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_by_timestamp(std::int64_t timestamp_ms) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_by_timestamp_no_lock(timestamp_ms);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_timestamp database error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_by_timestamp error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_range(std::int64_t start_ms, std::int64_t stop_ms) const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_range_no_lock(start_ms, stop_ms);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_range database error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_range error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_records() const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return find_records_no_lock();
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_records database error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB find_records error: ", ex);
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+        }
+    }
+
+    inline std::vector<optionx::SignalRecord> SignalRecordDB::find_records_vector() const {
+        auto result = find_records();
+        if (!result.ok()) {
+            return {};
+        }
+        return std::move(result.records);
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::erase_by_signal_id(std::uint32_t signal_id) {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return erase_by_signal_id_no_lock(signal_id);
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB erase_by_signal_id database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB erase_by_signal_id error: ", ex);
+        }
+        return SignalRecordDBStatus::DB_ERROR;
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::clear() {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            return clear_no_lock();
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB clear database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB clear error: ", ex);
+        }
+        return SignalRecordDBStatus::DB_ERROR;
+    }
+
+    inline std::size_t SignalRecordDB::count() const {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            if (!is_open_no_lock()) return 0;
+            return m_records->count();
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB count database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB count error: ", ex);
+        }
+        return 0;
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_upsert(SignalRecord record, write_callback_t callback) {
+        return enqueue_command([this, record = std::move(record), callback = std::move(callback)]() mutable {
+            auto result = upsert(std::move(record));
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_write(SignalRecord record, write_callback_t callback) {
+        return enqueue_command([this, record = std::move(record), callback = std::move(callback)]() mutable {
+            auto result = write(std::move(record));
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_signal_id(
+            std::uint32_t signal_id,
+            read_callback_t callback) {
+        return enqueue_command([this, signal_id, callback = std::move(callback)]() mutable {
+            auto result = find_by_signal_id(signal_id);
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_uid(
+            std::int64_t unique_id,
+            read_callback_t callback) {
+        return enqueue_command([this, unique_id, callback = std::move(callback)]() mutable {
+            auto result = find_by_uid(unique_id);
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_trade_id(
+            std::uint32_t trade_id,
+            read_callback_t callback) {
+        return enqueue_command([this, trade_id, callback = std::move(callback)]() mutable {
+            auto result = find_by_trade_id(trade_id);
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_range(
+            std::int64_t start_ms,
+            std::int64_t stop_ms,
+            list_callback_t callback) {
+        return enqueue_command([this, start_ms, stop_ms, callback = std::move(callback)]() mutable {
+            auto result = find_range(start_ms, stop_ms);
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_find_records(list_callback_t callback) {
+        return enqueue_command([this, callback = std::move(callback)]() mutable {
+            auto result = find_records();
+            enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
+                if (callback) callback(std::move(result));
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_erase_by_signal_id(
+            std::uint32_t signal_id,
+            status_callback_t callback) {
+        return enqueue_command([this, signal_id, callback = std::move(callback)]() mutable {
+            auto status = erase_by_signal_id(signal_id);
+            enqueue_callback([callback = std::move(callback), status]() mutable {
+                if (callback) callback(status);
+            });
+        });
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_clear(status_callback_t callback) {
+        return enqueue_command([this, callback = std::move(callback)]() mutable {
+            auto status = clear();
+            enqueue_callback([callback = std::move(callback), status]() mutable {
+                if (callback) callback(status);
+            });
+        });
+    }
+
+    inline bool SignalRecordDB::run() {
+        if (!is_open()) return false;
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            if (!m_accepting || m_worker_running) return false;
+            m_worker_stop = false;
+            m_worker_running = true;
+        }
+
+        try {
+            m_worker_thread = std::thread([this]() { worker_loop(); });
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB worker start error: ", ex);
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            m_worker_running = false;
+            return false;
+        }
+        return true;
+    }
+
+    inline void SignalRecordDB::process() {
+        if (!worker_running()) {
+            drain_work_on_caller();
+        }
+        deliver_callbacks();
+    }
+
+    inline void SignalRecordDB::flush() {
+        if (worker_running()) {
+            std::unique_lock<std::mutex> lock(m_queue_mutex);
+            m_idle_cv.wait(lock, [this]() {
+                return m_work_queue.empty() && m_active_work == 0;
+            });
+        } else {
+            drain_work_on_caller();
+        }
+        deliver_callbacks();
+    }
+
+    inline void SignalRecordDB::shutdown() {
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            if (!m_accepting && !m_worker_running && !m_open) return;
+            m_accepting = false;
+            m_worker_stop = true;
+        }
+        m_work_cv.notify_all();
+
+        if (m_worker_thread.joinable()) {
+            m_worker_thread.join();
+        }
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            m_worker_running = false;
+        }
+
+        drain_work_on_caller();
+        deliver_callbacks();
+
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            m_records.reset();
+            m_uid_index.reset();
+            m_signal_id_index.reset();
+            m_trade_id_index.reset();
+            m_meta.reset();
+            if (m_connection && m_connection->is_connected()) {
+                m_connection->shutdown();
+            }
+            m_connection.reset();
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB shutdown database error: ", ex);
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB shutdown error: ", ex);
+        }
+        m_open = false;
+    }
+
+    inline void SignalRecordDB::open() {
+        std::lock_guard<std::mutex> lock(m_db_mutex);
+        try {
+            if (m_config.max_dbs < 5) {
+                m_config.max_dbs = 5;
+            }
+            m_read_only = m_config.read_only;
+            m_connection = mdbxc::Connection::create(m_config);
+            m_records = std::make_unique<records_table_t>(m_connection, m_records_table_name);
+            m_uid_index = std::make_unique<uid_index_table_t>(m_connection, m_uid_index_table_name);
+            m_signal_id_index = std::make_unique<signal_id_index_table_t>(
+                m_connection,
+                m_signal_id_index_table_name);
+            m_trade_id_index = std::make_unique<trade_id_index_table_t>(m_connection, m_trade_id_index_table_name);
+            m_meta = std::make_unique<meta_table_t>(m_connection, m_meta_table_name);
+            m_open = true;
+
+            if (!m_read_only) {
+                auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+                init_meta_no_lock(txn.handle());
+                txn.commit();
+            }
+        } catch (const mdbxc::MdbxException& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB connection error: ", ex);
+            m_open = false;
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB initialization error: ", ex);
+            m_open = false;
+        }
+    }
+
+    inline bool SignalRecordDB::is_open_no_lock() const noexcept {
+        return m_open && m_connection && m_connection->is_connected() &&
+               m_records && m_uid_index && m_signal_id_index && m_trade_id_index && m_meta;
+    }
+
+    inline void SignalRecordDB::init_meta_no_lock(MDBX_txn* txn) {
+        auto meta = m_meta->get_or(SignalRecordDBMeta{}, txn);
+        if (meta.db_version == 0) {
+            meta.db_version = 1;
+        }
+        if (meta.next_signal_id == 0) {
+            meta.next_signal_id = 1;
+        }
+        m_meta->set(meta, txn);
+    }
+
+    inline void SignalRecordDB::update_last_update_no_lock(MDBX_txn* txn) {
+        auto meta = m_meta->get_or(SignalRecordDBMeta{}, txn);
+        meta.last_update_ms = time_shield::timestamp_ms();
+        m_meta->set(meta, txn);
+    }
+
+    inline std::uint32_t SignalRecordDB::reserve_signal_id_no_lock(MDBX_txn* txn) {
+        auto meta = m_meta->get_or(SignalRecordDBMeta{}, txn);
+        auto candidate = meta.next_signal_id;
+        if (candidate == 0) candidate = 1;
+
+        const auto start = candidate;
+        bool wrapped = false;
+        while (candidate != 0 && m_signal_id_index->contains(candidate, txn)) {
+            if (++candidate == 0) {
+                candidate = 1;
+                wrapped = true;
+            }
+            if (wrapped && candidate == start) {
+                return 0;
+            }
+        }
+        if (candidate == 0) return 0;
+
+        meta.next_signal_id = candidate + 1;
+        if (meta.next_signal_id == 0) meta.next_signal_id = 1;
+        m_meta->set(meta, txn);
+        return candidate;
+    }
+
+    inline void SignalRecordDB::bump_next_signal_id_no_lock(std::uint32_t used_signal_id, MDBX_txn* txn) {
+        constexpr auto max_uint32 = std::numeric_limits<std::uint32_t>::max();
+        if (used_signal_id == 0) return;
+
+        auto meta = m_meta->get_or(SignalRecordDBMeta{}, txn);
+        if (meta.next_signal_id == 0) meta.next_signal_id = 1;
+        const auto next = meta.next_signal_id;
+        if (next <= used_signal_id) {
+            if (used_signal_id == max_uint32) {
+                meta.next_signal_id = 1;
+            } else {
+                meta.next_signal_id = static_cast<std::uint32_t>(used_signal_id + 1);
+            }
+            m_meta->set(meta, txn);
+        }
+    }
+
+    inline void SignalRecordDB::remove_indexes_no_lock(const SignalRecord& record, MDBX_txn* txn) {
+        const auto erase_if_same_signal =
+            [this, &record, txn](auto& table, const auto& key) {
+                const auto composite = table->find(key, txn);
+                if (!composite) return;
+                const auto indexed_record = m_records->find(*composite, txn);
+                if (!indexed_record || indexed_record->signal_id == record.signal_id) {
+                    table->erase(key, txn);
+                }
+            };
+
+        if (record.signal_id > 0) {
+            erase_if_same_signal(m_signal_id_index, record.signal_id);
+        }
+        if (record.unique_id > 0) {
+            erase_if_same_signal(m_uid_index, record.unique_id);
+        }
+        for (const auto trade_id : record.trade_ids) {
+            if (trade_id == 0) continue;
+            erase_if_same_signal(m_trade_id_index, trade_id);
+        }
+    }
+
+    inline void SignalRecordDB::write_indexes_no_lock(
+            const SignalRecord& record,
+            std::uint64_t composite_key,
+            MDBX_txn* txn) {
+        if (record.signal_id > 0) {
+            m_signal_id_index->insert_or_assign(record.signal_id, composite_key, txn);
+        }
+        if (record.unique_id > 0) {
+            m_uid_index->insert_or_assign(record.unique_id, composite_key, txn);
+        }
+        for (const auto trade_id : record.trade_ids) {
+            if (trade_id == 0) continue;
+            m_trade_id_index->insert_or_assign(trade_id, composite_key, txn);
+        }
+    }
+
+    inline void SignalRecordDB::store_record_no_lock(const SignalRecord& record, MDBX_txn* txn) {
+        const auto existing_composite = m_signal_id_index->find(record.signal_id, txn);
+        const auto ts_ms = signal_detail::selected_timestamp_ms(record);
+        const auto unix_minutes = signal_detail::timestamp_ms_to_unix_minutes(ts_ms);
+        const auto new_composite_key = signal_detail::make_composite_key(unix_minutes, record.signal_id);
+
+        if (existing_composite) {
+            const auto old_record = m_records->find(*existing_composite, txn);
+            if (old_record) {
+                remove_indexes_no_lock(*old_record, txn);
+            }
+            if (*existing_composite != new_composite_key) {
+                m_records->erase(*existing_composite, txn);
+            }
+        }
+
+        m_records->insert_or_assign(new_composite_key, record, txn);
+        write_indexes_no_lock(record, new_composite_key, txn);
+        bump_next_signal_id_no_lock(record.signal_id, txn);
+        update_last_update_no_lock(txn);
+    }
+
+    inline std::uint32_t SignalRecordDB::find_existing_signal_id_no_lock(
+            const SignalRecord& record,
+            MDBX_txn* txn) {
+        if (record.signal_id > 0) return record.signal_id;
+
+        if (record.unique_id > 0) {
+            const auto composite = m_uid_index->find(record.unique_id, txn);
+            if (composite) {
+                const auto existing_record = m_records->find(*composite, txn);
+                if (existing_record) return existing_record->signal_id;
+                m_uid_index->erase(record.unique_id, txn);
+            }
+        }
+
+        for (const auto trade_id : record.trade_ids) {
+            if (trade_id == 0) continue;
+            const auto composite = m_trade_id_index->find(trade_id, txn);
+            if (!composite) continue;
+            const auto existing_record = m_records->find(*composite, txn);
+            if (existing_record) return existing_record->signal_id;
+            m_trade_id_index->erase(trade_id, txn);
+        }
+
+        return 0;
+    }
+
+    inline SignalRecordDBWriteResult SignalRecordDB::write_no_lock(SignalRecord record) {
+        if (!is_open_no_lock()) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::NOT_OPEN,
+                std::move(record),
+                "SignalRecordDB is not open");
+        }
+        if (m_read_only) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::READ_ONLY,
+                std::move(record),
+                "SignalRecordDB is read-only");
+        }
+        if (record.signal_id == 0) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::INVALID_ARGUMENT,
+                std::move(record),
+                "SignalRecord signal_id is required");
+        }
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        store_record_no_lock(record, txn.handle());
+        txn.commit();
+        return signal_detail::write_success(std::move(record));
+    }
+
+    inline SignalRecordDBWriteResult SignalRecordDB::upsert_no_lock(SignalRecord record) {
+        if (!is_open_no_lock()) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::NOT_OPEN,
+                std::move(record),
+                "SignalRecordDB is not open");
+        }
+        if (m_read_only) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::READ_ONLY,
+                std::move(record),
+                "SignalRecordDB is read-only");
+        }
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+
+        auto selected_signal_id = find_existing_signal_id_no_lock(record, txn.handle());
+        if (selected_signal_id == 0) {
+            selected_signal_id = reserve_signal_id_no_lock(txn.handle());
+            if (selected_signal_id == 0) {
+                return signal_detail::write_error(
+                    SignalRecordDBStatus::SEQUENCE_EXHAUSTED,
+                    std::move(record),
+                    "SignalRecordDB could not reserve a signal_id");
+            }
+        }
+
+        record.signal_id = selected_signal_id;
+        store_record_no_lock(record, txn.handle());
+        txn.commit();
+        return signal_detail::write_success(std::move(record));
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_signal_id_no_lock(std::uint32_t signal_id) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::read_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (signal_id == 0) {
+            return signal_detail::read_error(SignalRecordDBStatus::INVALID_ARGUMENT, "SignalRecord signal_id is required");
+        }
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const auto composite = m_signal_id_index->find(signal_id, txn);
+        if (!composite) {
+            txn.commit();
+            return signal_detail::read_error(SignalRecordDBStatus::NOT_FOUND, "SignalRecord was not found");
+        }
+
+        const auto record = m_records->find(*composite, txn);
+        txn.commit();
+        if (!record) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord signal_id index points to missing record");
+        }
+        if (record->signal_id != signal_id) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord signal_id index points to a different signal_id");
+        }
+
+        SignalRecordDBReadResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+        result.record = *record;
+        result.found = true;
+        return result;
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_uid_no_lock(std::int64_t unique_id) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::read_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (unique_id <= 0) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::INVALID_ARGUMENT,
+                "SignalRecord unique_id is required");
+        }
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const auto composite = m_uid_index->find(unique_id, txn);
+        if (!composite) {
+            txn.commit();
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord UID index entry was not found");
+        }
+
+        const auto record = m_records->find(*composite, txn);
+        txn.commit();
+        if (!record) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord UID index points to missing record");
+        }
+        if (record->unique_id != unique_id) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord UID index points to a different unique_id");
+        }
+
+        SignalRecordDBReadResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+        result.record = *record;
+        result.found = true;
+        return result;
+    }
+
+    inline SignalRecordDBReadResult SignalRecordDB::find_by_trade_id_no_lock(std::uint32_t trade_id) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::read_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (trade_id == 0) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::INVALID_ARGUMENT,
+                "SignalRecord produced trade_id is required");
+        }
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        const auto composite = m_trade_id_index->find(trade_id, txn);
+        if (!composite) {
+            txn.commit();
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord trade_id index entry was not found");
+        }
+
+        const auto record = m_records->find(*composite, txn);
+        txn.commit();
+        if (!record) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord trade_id index points to missing record");
+        }
+        if (!record->has_trade_id(trade_id)) {
+            return signal_detail::read_error(
+                SignalRecordDBStatus::NOT_FOUND,
+                "SignalRecord trade_id index points to a record without that trade_id");
+        }
+
+        SignalRecordDBReadResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+        result.record = *record;
+        result.found = true;
+        return result;
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_by_timestamp_no_lock(std::int64_t timestamp_ms) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (timestamp_ms < 0) {
+            return signal_detail::list_error(SignalRecordDBStatus::INVALID_ARGUMENT, "SignalRecord timestamp is invalid");
+        }
+
+        const auto target_min = signal_detail::timestamp_ms_to_unix_minutes(timestamp_ms);
+        const auto start_key = signal_detail::make_composite_key(target_min, 0);
+        const auto stop_key = signal_detail::make_composite_key(target_min, 0xFFFFFFFFu);
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SignalRecordDBListResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+
+        m_records->for_each_range(
+            start_key,
+            stop_key,
+            [&result, timestamp_ms](const std::uint64_t&, const SignalRecord& record) {
+                if (signal_detail::selected_timestamp_ms(record) == timestamp_ms) {
+                    result.records.push_back(record);
+                }
+                return true;
+            },
+            txn.handle());
+
+        txn.commit();
+
+        std::sort(result.records.begin(), result.records.end(), [](const SignalRecord& lhs, const SignalRecord& rhs) {
+            const auto lhs_timestamp = signal_detail::selected_timestamp_ms(lhs);
+            const auto rhs_timestamp = signal_detail::selected_timestamp_ms(rhs);
+            if (lhs_timestamp != rhs_timestamp) return lhs_timestamp < rhs_timestamp;
+            return lhs.signal_id < rhs.signal_id;
+        });
+        return result;
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_range_no_lock(
+            std::int64_t start_ms,
+            std::int64_t stop_ms) const {
+        if (!is_open_no_lock()) {
+            return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+        if (start_ms < 0 || stop_ms < 0 || start_ms > stop_ms) {
+            return signal_detail::list_error(SignalRecordDBStatus::INVALID_ARGUMENT, "SignalRecord timestamp range is invalid");
+        }
+
+        const auto start_min = signal_detail::timestamp_ms_to_unix_minutes(start_ms);
+        const auto stop_min = signal_detail::timestamp_ms_to_unix_minutes(stop_ms);
+        const auto start_key = signal_detail::make_composite_key(start_min, 0);
+        const auto stop_key = signal_detail::make_composite_key(stop_min, 0xFFFFFFFFu);
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SignalRecordDBListResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+
+        m_records->for_each_range(
+            start_key,
+            stop_key,
+            [&result, start_ms, stop_ms](const std::uint64_t&, const SignalRecord& record) {
+                const auto timestamp = signal_detail::selected_timestamp_ms(record);
+                if (timestamp >= start_ms && timestamp <= stop_ms) {
+                    result.records.push_back(record);
+                }
+                return true;
+            },
+            txn.handle());
+
+        txn.commit();
+
+        std::sort(result.records.begin(), result.records.end(), [](const SignalRecord& lhs, const SignalRecord& rhs) {
+            const auto lhs_timestamp = signal_detail::selected_timestamp_ms(lhs);
+            const auto rhs_timestamp = signal_detail::selected_timestamp_ms(rhs);
+            if (lhs_timestamp != rhs_timestamp) return lhs_timestamp < rhs_timestamp;
+            return lhs.signal_id < rhs.signal_id;
+        });
+        return result;
+    }
+
+    inline SignalRecordDBListResult SignalRecordDB::find_records_no_lock() const {
+        if (!is_open_no_lock()) {
+            return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+        }
+
+        const auto start_key = signal_detail::make_composite_key(std::numeric_limits<std::int32_t>::min(), 0);
+        const auto stop_key = signal_detail::make_composite_key(
+            std::numeric_limits<std::int32_t>::max(),
+            0xFFFFFFFFu);
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
+        SignalRecordDBListResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+
+        m_records->for_each_range(
+            start_key,
+            stop_key,
+            [&result](const std::uint64_t&, const SignalRecord& record) {
+                result.records.push_back(record);
+                return true;
+            },
+            txn.handle());
+
+        txn.commit();
+
+        std::sort(result.records.begin(), result.records.end(), [](const SignalRecord& lhs, const SignalRecord& rhs) {
+            const auto lhs_timestamp = signal_detail::selected_timestamp_ms(lhs);
+            const auto rhs_timestamp = signal_detail::selected_timestamp_ms(rhs);
+            if (lhs_timestamp != rhs_timestamp) return lhs_timestamp < rhs_timestamp;
+            return lhs.signal_id < rhs.signal_id;
+        });
+        return result;
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::erase_by_signal_id_no_lock(std::uint32_t signal_id) {
+        if (!is_open_no_lock()) return SignalRecordDBStatus::NOT_OPEN;
+        if (m_read_only) return SignalRecordDBStatus::READ_ONLY;
+        if (signal_id == 0) return SignalRecordDBStatus::INVALID_ARGUMENT;
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        const auto composite = m_signal_id_index->find(signal_id, txn);
+        if (!composite) {
+            txn.commit();
+            return SignalRecordDBStatus::NOT_FOUND;
+        }
+
+        const auto record = m_records->find(*composite, txn);
+        if (!record) {
+            m_signal_id_index->erase(signal_id, txn);
+            update_last_update_no_lock(txn.handle());
+            txn.commit();
+            return SignalRecordDBStatus::NOT_FOUND;
+        }
+
+        remove_indexes_no_lock(*record, txn.handle());
+        m_records->erase(*composite, txn);
+        update_last_update_no_lock(txn.handle());
+        txn.commit();
+        return SignalRecordDBStatus::SUCCESS;
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::clear_no_lock() {
+        if (!is_open_no_lock()) return SignalRecordDBStatus::NOT_OPEN;
+        if (m_read_only) return SignalRecordDBStatus::READ_ONLY;
+
+        auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        m_records->clear(txn);
+        m_uid_index->clear(txn);
+        m_signal_id_index->clear(txn);
+        m_trade_id_index->clear(txn);
+        m_meta->clear(txn);
+        init_meta_no_lock(txn.handle());
+        update_last_update_no_lock(txn.handle());
+        txn.commit();
+        return SignalRecordDBStatus::SUCCESS;
+    }
+
+    inline bool SignalRecordDB::worker_running() const {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        return m_worker_running;
+    }
+
+    inline SignalRecordDBStatus SignalRecordDB::enqueue_command(std::function<void()> command) {
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            if (!m_accepting) return SignalRecordDBStatus::QUEUE_CLOSED;
+            m_work_queue.push_back(std::move(command));
+        }
+        m_work_cv.notify_one();
+        return SignalRecordDBStatus::SUCCESS;
+    }
+
+    inline void SignalRecordDB::enqueue_callback(std::function<void()> callback) {
+        std::lock_guard<std::mutex> lock(m_callback_mutex);
+        m_callback_queue.push_back(std::move(callback));
+    }
+
+    inline bool SignalRecordDB::pop_command(std::function<void()>& command) {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        if (m_work_queue.empty()) return false;
+        command = std::move(m_work_queue.front());
+        m_work_queue.pop_front();
+        ++m_active_work;
+        return true;
+    }
+
+    inline void SignalRecordDB::finish_command() {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        if (m_active_work > 0) --m_active_work;
+        if (m_work_queue.empty() && m_active_work == 0) {
+            m_idle_cv.notify_all();
+        }
+    }
+
+    inline void SignalRecordDB::execute_command(std::function<void()> command) {
+        try {
+            if (command) command();
+        } catch (const std::exception& ex) {
+            LOGIT_PRINT_ERROR("SignalRecordDB queued command error: ", ex);
+        } catch (...) {
+            LOGIT_PRINT_ERROR("SignalRecordDB queued command unknown error");
+        }
+        finish_command();
+    }
+
+    inline void SignalRecordDB::drain_work_on_caller() {
+        std::function<void()> command;
+        while (pop_command(command)) {
+            execute_command(std::move(command));
+        }
+    }
+
+    inline void SignalRecordDB::deliver_callbacks() {
+        for (;;) {
+            std::function<void()> callback;
+            {
+                std::lock_guard<std::mutex> lock(m_callback_mutex);
+                if (m_callback_queue.empty()) break;
+                callback = std::move(m_callback_queue.front());
+                m_callback_queue.pop_front();
+            }
+            try {
+                if (callback) callback();
+            } catch (const std::exception& ex) {
+                LOGIT_PRINT_ERROR("SignalRecordDB callback error: ", ex);
+            } catch (...) {
+                LOGIT_PRINT_ERROR("SignalRecordDB callback unknown error");
+            }
+        }
+    }
+
+    inline void SignalRecordDB::worker_loop() {
+        for (;;) {
+            std::function<void()> command;
+            {
+                std::unique_lock<std::mutex> lock(m_queue_mutex);
+                m_work_cv.wait(lock, [this]() {
+                    return m_worker_stop || !m_work_queue.empty();
+                });
+                if (m_worker_stop && m_work_queue.empty()) {
+                    break;
+                }
+                command = std::move(m_work_queue.front());
+                m_work_queue.pop_front();
+                ++m_active_work;
+            }
+            execute_command(std::move(command));
+        }
+
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        m_worker_running = false;
+        if (m_work_queue.empty() && m_active_work == 0) {
+            m_idle_cv.notify_all();
+        }
+    }
+
+} // namespace optionx::storage
+
+#endif // _OPTIONX_STORAGE_SIGNAL_RECORD_DB_IPP_INCLUDED

--- a/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
+++ b/include/optionx_cpp/storages/SignalRecordDB/SignalRecordDB.ipp
@@ -19,7 +19,7 @@ namespace optionx::storage {
     inline mdbxc::Config SignalRecordDB::default_config() {
         mdbxc::Config config;
         config.pathname = OPTIONX_SIGNAL_RECORD_DB_FILE;
-        config.max_dbs = 5;
+        config.max_dbs = 4;
         config.no_subdir = false;
         config.relative_to_exe = true;
         return config;
@@ -31,13 +31,11 @@ namespace optionx::storage {
     inline SignalRecordDB::SignalRecordDB(
         mdbxc::Config config,
         std::string records_table,
-        std::string uid_index_table,
         std::string signal_id_index_table,
         std::string trade_id_index_table,
         std::string meta_table)
         : m_config(std::move(config)),
           m_records_table_name(std::move(records_table)),
-          m_uid_index_table_name(std::move(uid_index_table)),
           m_signal_id_index_table_name(std::move(signal_id_index_table)),
           m_trade_id_index_table_name(std::move(trade_id_index_table)),
           m_meta_table_name(std::move(meta_table)) {
@@ -130,16 +128,16 @@ namespace optionx::storage {
         }
     }
 
-    inline SignalRecordDBReadResult SignalRecordDB::find_by_uid(std::int64_t unique_id) const {
+    inline SignalRecordDBListResult SignalRecordDB::find_by_uid(std::int64_t unique_id) const {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
             return find_by_uid_no_lock(unique_id);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid database error: ", ex);
-            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
         } catch (const std::exception& ex) {
             LOGIT_PRINT_ERROR("SignalRecordDB find_by_uid error: ", ex);
-            return signal_detail::read_error(SignalRecordDBStatus::DB_ERROR, ex.what());
+            return signal_detail::list_error(SignalRecordDBStatus::DB_ERROR, ex.what());
         }
     }
 
@@ -271,7 +269,7 @@ namespace optionx::storage {
 
     inline SignalRecordDBStatus SignalRecordDB::enqueue_find_by_uid(
             std::int64_t unique_id,
-            read_callback_t callback) {
+            list_callback_t callback) {
         return enqueue_command([this, unique_id, callback = std::move(callback)]() mutable {
             auto result = find_by_uid(unique_id);
             enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
@@ -394,7 +392,6 @@ namespace optionx::storage {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
             m_records.reset();
-            m_uid_index.reset();
             m_signal_id_index.reset();
             m_trade_id_index.reset();
             m_meta.reset();
@@ -413,13 +410,12 @@ namespace optionx::storage {
     inline void SignalRecordDB::open() {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            if (m_config.max_dbs < 5) {
-                m_config.max_dbs = 5;
+            if (m_config.max_dbs < 4) {
+                m_config.max_dbs = 4;
             }
             m_read_only = m_config.read_only;
             m_connection = mdbxc::Connection::create(m_config);
             m_records = std::make_unique<records_table_t>(m_connection, m_records_table_name);
-            m_uid_index = std::make_unique<uid_index_table_t>(m_connection, m_uid_index_table_name);
             m_signal_id_index = std::make_unique<signal_id_index_table_t>(
                 m_connection,
                 m_signal_id_index_table_name);
@@ -443,7 +439,7 @@ namespace optionx::storage {
 
     inline bool SignalRecordDB::is_open_no_lock() const noexcept {
         return m_open && m_connection && m_connection->is_connected() &&
-               m_records && m_uid_index && m_signal_id_index && m_trade_id_index && m_meta;
+               m_records && m_signal_id_index && m_trade_id_index && m_meta;
     }
 
     inline void SignalRecordDB::init_meta_no_lock(MDBX_txn* txn) {
@@ -518,9 +514,6 @@ namespace optionx::storage {
         if (record.signal_id > 0) {
             erase_if_same_signal(m_signal_id_index, record.signal_id);
         }
-        if (record.unique_id > 0) {
-            erase_if_same_signal(m_uid_index, record.unique_id);
-        }
         for (const auto trade_id : record.trade_ids) {
             if (trade_id == 0) continue;
             erase_if_same_signal(m_trade_id_index, trade_id);
@@ -533,9 +526,6 @@ namespace optionx::storage {
             MDBX_txn* txn) {
         if (record.signal_id > 0) {
             m_signal_id_index->insert_or_assign(record.signal_id, composite_key, txn);
-        }
-        if (record.unique_id > 0) {
-            m_uid_index->insert_or_assign(record.unique_id, composite_key, txn);
         }
         for (const auto trade_id : record.trade_ids) {
             if (trade_id == 0) continue;
@@ -570,15 +560,6 @@ namespace optionx::storage {
             MDBX_txn* txn) {
         if (record.signal_id > 0) return record.signal_id;
 
-        if (record.unique_id > 0) {
-            const auto composite = m_uid_index->find(record.unique_id, txn);
-            if (composite) {
-                const auto existing_record = m_records->find(*composite, txn);
-                if (existing_record) return existing_record->signal_id;
-                m_uid_index->erase(record.unique_id, txn);
-            }
-        }
-
         for (const auto trade_id : record.trade_ids) {
             if (trade_id == 0) continue;
             const auto composite = m_trade_id_index->find(trade_id, txn);
@@ -589,6 +570,31 @@ namespace optionx::storage {
         }
 
         return 0;
+    }
+
+    inline bool SignalRecordDB::trade_id_conflicts_no_lock(
+            const SignalRecord& record,
+            MDBX_txn* txn,
+            std::string* message) {
+        for (const auto trade_id : record.trade_ids) {
+            if (trade_id == 0) continue;
+
+            const auto composite = m_trade_id_index->find(trade_id, txn);
+            if (!composite) continue;
+
+            const auto existing_record = m_records->find(*composite, txn);
+            if (!existing_record) {
+                m_trade_id_index->erase(trade_id, txn);
+                continue;
+            }
+            if (existing_record->signal_id == record.signal_id) continue;
+
+            if (message) {
+                *message = "SignalRecord trade_id already belongs to another signal";
+            }
+            return true;
+        }
+        return false;
     }
 
     inline SignalRecordDBWriteResult SignalRecordDB::write_no_lock(SignalRecord record) {
@@ -612,6 +618,14 @@ namespace optionx::storage {
         }
 
         auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
+        std::string conflict_message;
+        if (trade_id_conflicts_no_lock(record, txn.handle(), &conflict_message)) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::CONFLICT,
+                std::move(record),
+                conflict_message);
+        }
+
         store_record_no_lock(record, txn.handle());
         txn.commit();
         return signal_detail::write_success(std::move(record));
@@ -645,6 +659,14 @@ namespace optionx::storage {
         }
 
         record.signal_id = selected_signal_id;
+        std::string conflict_message;
+        if (trade_id_conflicts_no_lock(record, txn.handle(), &conflict_message)) {
+            return signal_detail::write_error(
+                SignalRecordDBStatus::CONFLICT,
+                std::move(record),
+                conflict_message);
+        }
+
         store_record_no_lock(record, txn.handle());
         txn.commit();
         return signal_detail::write_success(std::move(record));
@@ -685,42 +707,37 @@ namespace optionx::storage {
         return result;
     }
 
-    inline SignalRecordDBReadResult SignalRecordDB::find_by_uid_no_lock(std::int64_t unique_id) const {
+    inline SignalRecordDBListResult SignalRecordDB::find_by_uid_no_lock(std::int64_t unique_id) const {
         if (!is_open_no_lock()) {
-            return signal_detail::read_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
+            return signal_detail::list_error(SignalRecordDBStatus::NOT_OPEN, "SignalRecordDB is not open");
         }
         if (unique_id <= 0) {
-            return signal_detail::read_error(
+            return signal_detail::list_error(
                 SignalRecordDBStatus::INVALID_ARGUMENT,
                 "SignalRecord unique_id is required");
         }
 
+        const auto start_key = signal_detail::make_composite_key(std::numeric_limits<std::int32_t>::min(), 0);
+        const auto stop_key = signal_detail::make_composite_key(
+            std::numeric_limits<std::int32_t>::max(),
+            0xFFFFFFFFu);
+
         auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
-        const auto composite = m_uid_index->find(unique_id, txn);
-        if (!composite) {
-            txn.commit();
-            return signal_detail::read_error(
-                SignalRecordDBStatus::NOT_FOUND,
-                "SignalRecord UID index entry was not found");
-        }
-
-        const auto record = m_records->find(*composite, txn);
-        txn.commit();
-        if (!record) {
-            return signal_detail::read_error(
-                SignalRecordDBStatus::NOT_FOUND,
-                "SignalRecord UID index points to missing record");
-        }
-        if (record->unique_id != unique_id) {
-            return signal_detail::read_error(
-                SignalRecordDBStatus::NOT_FOUND,
-                "SignalRecord UID index points to a different unique_id");
-        }
-
-        SignalRecordDBReadResult result;
+        SignalRecordDBListResult result;
         result.status = SignalRecordDBStatus::SUCCESS;
-        result.record = *record;
-        result.found = true;
+
+        m_records->for_each_range(
+            start_key,
+            stop_key,
+            [&result, unique_id](const std::uint64_t&, const SignalRecord& record) {
+                if (record.unique_id == unique_id) {
+                    result.records.push_back(record);
+                }
+                return true;
+            },
+            txn.handle());
+
+        txn.commit();
         return result;
     }
 
@@ -910,7 +927,6 @@ namespace optionx::storage {
 
         auto txn = m_connection->transaction(mdbxc::TransactionMode::WRITABLE);
         m_records->clear(txn);
-        m_uid_index->clear(txn);
         m_signal_id_index->clear(txn);
         m_trade_id_index->clear(txn);
         m_meta->clear(txn);

--- a/include/optionx_cpp/storages/SignalRecordDB/data.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB/data.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DATA_HPP_INCLUDED
+#define _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DATA_HPP_INCLUDED
+
+/// \file data.hpp
+/// \brief Defines SignalRecordDB operation result DTOs.
+
+#include <type_traits>
+
+#include "data/trading.hpp"
+#include "enums.hpp"
+
+namespace optionx::storage {
+
+    /// \struct SignalRecordDBMeta
+    /// \brief Singleton metadata stored via ValueTable in SignalRecordDB.
+    struct SignalRecordDBMeta {
+        std::uint64_t db_version = 1;       ///< Database schema version.
+        std::uint32_t next_signal_id = 1;   ///< Next monotonic signal ID (1..UINT32_MAX).
+        std::int64_t  last_update_ms = 0;   ///< Last wall-clock update time in milliseconds.
+    };
+    static_assert(std::is_trivially_copyable_v<SignalRecordDBMeta>,
+                  "SignalRecordDBMeta must be trivially copyable for ValueTable storage");
+
+    /// \brief Result of a SignalRecord write operation.
+    using SignalRecordDBWriteResult = StorageWriteResult<SignalRecord>;
+
+    /// \brief Result of a single-record SignalRecord read operation.
+    using SignalRecordDBReadResult = StorageReadResult<SignalRecord>;
+
+    /// \brief Result of a multi-record SignalRecord read operation.
+    using SignalRecordDBListResult = StorageListResult<SignalRecord>;
+
+} // namespace optionx::storage
+
+#endif // _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/storages/SignalRecordDB/detail.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB/detail.hpp
@@ -1,0 +1,108 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DETAIL_HPP_INCLUDED
+#define _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DETAIL_HPP_INCLUDED
+
+/// \file detail.hpp
+/// \brief Internal helpers used only by SignalRecordDB.
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include <time_shield/time_unit_conversions.hpp>
+
+#include "data.hpp"
+
+namespace optionx::storage::signal_detail {
+
+    /// \brief Selects canonical timestamp used by SignalRecordDB range queries.
+    /// \details Signal creation is the primary event; accepted/rejected/completed
+    /// timestamps are fallbacks for imported or partially reconstructed records.
+    inline std::int64_t selected_timestamp_ms(const SignalRecord& record) noexcept {
+        if (record.create_date > 0) return record.create_date;
+        if (record.accept_date > 0) return record.accept_date;
+        if (record.reject_date > 0) return record.reject_date;
+        if (record.complete_date > 0) return record.complete_date;
+        return 0;
+    }
+
+    constexpr std::uint32_t kMinutesBias = 0x80000000u;
+
+    /// \brief Biases a signed unix-minutes value for unsigned MDBX ordering.
+    inline std::uint32_t bias_minutes(std::int32_t m) noexcept {
+        return static_cast<std::uint32_t>(m) + kMinutesBias;
+    }
+
+    /// \brief Reverses bias_minutes to recover signed unix-minutes.
+    inline std::int32_t unbias_minutes(std::uint32_t b) noexcept {
+        return static_cast<std::int32_t>(b - kMinutesBias);
+    }
+
+    /// \brief Builds a composite uint64_t key from unix minutes and signal_id.
+    inline std::uint64_t make_composite_key(
+            std::int32_t unix_minutes,
+            std::uint32_t signal_id) noexcept {
+        return (static_cast<std::uint64_t>(bias_minutes(unix_minutes)) << 32) | signal_id;
+    }
+
+    /// \brief Extracts unix minutes from a composite key.
+    inline std::int32_t composite_key_minutes(std::uint64_t key) noexcept {
+        return unbias_minutes(static_cast<std::uint32_t>(key >> 32));
+    }
+
+    /// \brief Converts milliseconds to unix minutes with int32 composite-key bounds.
+    inline std::int32_t timestamp_ms_to_unix_minutes(std::int64_t timestamp_ms) noexcept {
+        constexpr auto kMinMinutes = std::numeric_limits<std::int32_t>::min();
+        constexpr auto kMaxMinutes = std::numeric_limits<std::int32_t>::max();
+        const auto minutes = time_shield::ms_to_min<std::int64_t>(timestamp_ms);
+
+        if (minutes <= static_cast<std::int64_t>(kMinMinutes)) return kMinMinutes;
+        if (minutes >= static_cast<std::int64_t>(kMaxMinutes)) return kMaxMinutes;
+        return static_cast<std::int32_t>(minutes);
+    }
+
+    /// \brief Extracts signal_id from a composite key.
+    inline std::uint32_t composite_key_signal_id(std::uint64_t key) noexcept {
+        return static_cast<std::uint32_t>(key & 0xFFFFFFFFu);
+    }
+
+    /// \brief Creates successful write result.
+    inline SignalRecordDBWriteResult write_success(SignalRecord record) {
+        SignalRecordDBWriteResult result;
+        result.status = SignalRecordDBStatus::SUCCESS;
+        result.record = std::move(record);
+        return result;
+    }
+
+    /// \brief Creates failed write result.
+    inline SignalRecordDBWriteResult write_error(
+            SignalRecordDBStatus status,
+            SignalRecord record,
+            std::string message) {
+        SignalRecordDBWriteResult result;
+        result.status = status;
+        result.record = std::move(record);
+        result.message = std::move(message);
+        return result;
+    }
+
+    /// \brief Creates failed read result.
+    inline SignalRecordDBReadResult read_error(SignalRecordDBStatus status, std::string message) {
+        SignalRecordDBReadResult result;
+        result.status = status;
+        result.message = std::move(message);
+        return result;
+    }
+
+    /// \brief Creates failed list result.
+    inline SignalRecordDBListResult list_error(SignalRecordDBStatus status, std::string message) {
+        SignalRecordDBListResult result;
+        result.status = status;
+        result.message = std::move(message);
+        return result;
+    }
+
+} // namespace optionx::storage::signal_detail
+
+#endif // _OPTIONX_STORAGE_SIGNAL_RECORD_DB_DETAIL_HPP_INCLUDED

--- a/include/optionx_cpp/storages/SignalRecordDB/enums.hpp
+++ b/include/optionx_cpp/storages/SignalRecordDB/enums.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef _OPTIONX_STORAGE_SIGNAL_RECORD_DB_ENUMS_HPP_INCLUDED
+#define _OPTIONX_STORAGE_SIGNAL_RECORD_DB_ENUMS_HPP_INCLUDED
+
+/// \file enums.hpp
+/// \brief Defines SignalRecordDB status codes.
+
+namespace optionx::storage {
+
+    /// \brief Status codes returned by SignalRecordDB operations.
+    using SignalRecordDBStatus = StorageStatus;
+
+} // namespace optionx::storage
+
+#endif // _OPTIONX_STORAGE_SIGNAL_RECORD_DB_ENUMS_HPP_INCLUDED

--- a/include/optionx_cpp/storages/common/StorageStatus.hpp
+++ b/include/optionx_cpp/storages/common/StorageStatus.hpp
@@ -16,6 +16,7 @@ namespace optionx::storage {
         NOT_OPEN,
         READ_ONLY,
         QUEUE_CLOSED,
+        CONFLICT,
         DB_ERROR,
         STORAGE_ERROR = DB_ERROR,
         SEQUENCE_EXHAUSTED

--- a/tests/signal_record_db_test.cpp
+++ b/tests/signal_record_db_test.cpp
@@ -295,8 +295,11 @@ TEST(SignalRecordDBTest, FindByUidReturnsAllMatchingUserIdsWithoutMerging) {
     SignalRecordDB db(config);
     ASSERT_TRUE(db.is_open());
 
-    auto first = make_record(77, 1712345600000, 7701);
-    auto second = make_record(77, 1712345660000, 7801);
+    constexpr std::int64_t first_ts = 1712345600000;
+    constexpr std::int64_t second_ts = 1712345660000;
+
+    auto first = make_record(77, first_ts, 7701);
+    auto second = make_record(77, second_ts, 7801);
 
     auto first_write = db.upsert(first);
     ASSERT_TRUE(first_write.ok()) << first_write.message;
@@ -311,6 +314,19 @@ TEST(SignalRecordDBTest, FindByUidReturnsAllMatchingUserIdsWithoutMerging) {
     EXPECT_TRUE(contains_uid(by_uid.records, 77));
     EXPECT_TRUE(db.find_by_signal_id(first_write.record.signal_id).ok());
     EXPECT_TRUE(db.find_by_signal_id(second_write.record.signal_id).ok());
+
+    auto first_range = db.find_by_uid(77, first_ts, first_ts + 999);
+    ASSERT_TRUE(first_range.ok()) << first_range.message;
+    ASSERT_EQ(first_range.records.size(), 1u);
+    EXPECT_EQ(first_range.records[0].signal_id, first_write.record.signal_id);
+
+    auto second_range = db.find_by_uid(77, second_ts, second_ts + 999);
+    ASSERT_TRUE(second_range.ok()) << second_range.message;
+    ASSERT_EQ(second_range.records.size(), 1u);
+    EXPECT_EQ(second_range.records[0].signal_id, second_write.record.signal_id);
+
+    auto invalid_range = db.find_by_uid(77, second_ts, first_ts);
+    EXPECT_EQ(invalid_range.status, SignalRecordDBStatus::INVALID_ARGUMENT);
 }
 
 TEST(SignalRecordDBTest, FindByUidAllowsZeroAndNegativeUserIds) {
@@ -396,11 +412,12 @@ TEST(SignalRecordDBTest, ProcessRunsQueuedWorkOnCallerThread) {
     SignalRecordDB db(config);
     ASSERT_TRUE(db.is_open());
 
+    constexpr std::int64_t record_ts = 1712345600100;
     std::atomic<int> callback_count{0};
     std::uint32_t callback_signal_id = 0;
     ASSERT_EQ(
         db.enqueue_upsert(
-            make_record(70, 1712345600100, 7001),
+            make_record(70, record_ts, 7001),
             [&](optionx::storage::SignalRecordDBWriteResult result) {
                 ASSERT_TRUE(result.ok()) << result.message;
                 callback_signal_id = result.record.signal_id;
@@ -412,6 +429,23 @@ TEST(SignalRecordDBTest, ProcessRunsQueuedWorkOnCallerThread) {
     db.process();
     EXPECT_EQ(callback_count.load(), 1);
     EXPECT_TRUE(db.find_by_signal_id(callback_signal_id).ok());
+
+    std::size_t range_count = 0;
+    ASSERT_EQ(
+        db.enqueue_find_by_uid(
+            70,
+            record_ts,
+            record_ts + 999,
+            [&](optionx::storage::SignalRecordDBListResult result) {
+                ASSERT_TRUE(result.ok()) << result.message;
+                range_count = result.records.size();
+                ++callback_count;
+            }),
+        SignalRecordDBStatus::SUCCESS);
+
+    db.process();
+    EXPECT_EQ(callback_count.load(), 2);
+    EXPECT_EQ(range_count, 1u);
 }
 
 TEST(SignalRecordDBTest, WorkerFlushDeliversCallbacksOnFlushThread) {

--- a/tests/signal_record_db_test.cpp
+++ b/tests/signal_record_db_test.cpp
@@ -1,0 +1,323 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <optionx_cpp/storages.hpp>
+
+namespace {
+
+using optionx::SignalRecord;
+using optionx::storage::SignalRecordDB;
+using optionx::storage::SignalRecordDBStatus;
+using optionx::storage::signal_detail::selected_timestamp_ms;
+
+std::string unique_db_path(const std::string& name) {
+    static std::atomic<std::uint64_t> counter{0};
+    const auto stamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    return "data/" + name + "_" + std::to_string(stamp) + "_" +
+        std::to_string(counter.fetch_add(1));
+}
+
+mdbxc::Config make_config(const std::string& name) {
+    mdbxc::Config config;
+    config.pathname = unique_db_path(name);
+    config.max_dbs = 5;
+    config.no_subdir = false;
+    config.relative_to_exe = true;
+    return config;
+}
+
+SignalRecord make_record(
+        std::int64_t uid,
+        std::int64_t create_date,
+        std::uint32_t first_trade_id = 1001) {
+    SignalRecord record;
+    record.unique_id = uid;
+    record.unique_hash = "signal-" + std::to_string(uid);
+    record.account_id = 7001;
+    record.platform_type = optionx::PlatformType::INTRADE_BAR;
+    record.account_type = optionx::AccountType::DEMO;
+    record.currency = optionx::CurrencyType::USD;
+    record.symbol = "EURUSD";
+    record.signal_name = "mean-reversion";
+    record.user_data = "user-data";
+    record.comment = "signal-db-test";
+    record.option_type = optionx::OptionType::SPRINT;
+    record.order_type = optionx::OrderType::BUY;
+    record.amount = 15.0;
+    record.refund = 0.1;
+    record.min_payout = 0.75;
+    record.duration = 180;
+    record.expiry_time = 1712345900;
+    record.status = optionx::SignalStatus::ACCEPTED;
+    record.reject_code = optionx::SignalRejectCode::NONE;
+    record.reject_desc = "";
+    record.outcome = optionx::SignalOutcome::WIN;
+    record.trade_state = optionx::TradeState::WIN;
+    record.total_amount = 15.0;
+    record.total_profit = 12.3;
+    record.create_date = create_date;
+    record.accept_date = create_date + 10;
+    record.complete_date = create_date + 180000;
+    record.mm_type = optionx::MmSystemType::MARTINGALE_SIGNAL;
+    record.mm_step = 2;
+    record.mm_group_id = 10;
+    record.mm_group_hash = "group-hash";
+    record.mm_group_name = "EURUSD-demo";
+    record.mm_params_json = R"({"step":2})";
+    record.decision_params_json = R"({"threshold":0.6})";
+    record.metadata_json = R"({"source":"test"})";
+    record.add_trade_id(first_trade_id);
+    record.add_trade_id(first_trade_id + 1);
+    return record;
+}
+
+bool contains_uid(const std::vector<SignalRecord>& records, std::int64_t uid) {
+    return std::any_of(records.begin(), records.end(), [uid](const SignalRecord& record) {
+        return record.unique_id == uid;
+    });
+}
+
+} // namespace
+
+TEST(SignalRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
+    auto record = make_record(42, 1712345600100);
+    record.signal_id = 77;
+
+    const auto bytes = record.to_bytes();
+    const auto restored = SignalRecord::from_bytes(bytes.data(), bytes.size());
+
+    EXPECT_EQ(restored, record);
+    EXPECT_EQ(selected_timestamp_ms(restored), record.create_date);
+}
+
+TEST(SignalRecordSerializationTest, RejectsCorruptedPayloads) {
+    auto record = make_record(42, 1712345600100);
+    record.signal_id = 77;
+
+    auto bytes = record.to_bytes();
+    ASSERT_FALSE(bytes.empty());
+
+    bytes.resize(bytes.size() - 1);
+    EXPECT_THROW(
+        static_cast<void>(SignalRecord::from_bytes(bytes.data(), bytes.size())),
+        std::runtime_error);
+
+    const std::uint32_t bad_magic = 0;
+    EXPECT_THROW(
+        static_cast<void>(SignalRecord::from_bytes(&bad_magic, sizeof(bad_magic))),
+        std::runtime_error);
+}
+
+TEST(SignalRecordDBTest, ReservesPersistentSignalIdAndAssignsCarriers) {
+    const auto config = make_config("signal_record_db_ids");
+
+    {
+        SignalRecordDB db(config);
+        ASSERT_TRUE(db.is_open());
+
+        EXPECT_EQ(db.get_signal_id(), 1u);
+
+        optionx::TradeSignal signal;
+        ASSERT_TRUE(db.assign_signal_id(signal));
+        EXPECT_EQ(signal.signal_id, 2u);
+
+        SignalRecord record;
+        ASSERT_TRUE(db.assign_signal_id(record));
+        EXPECT_EQ(record.signal_id, 3u);
+
+        optionx::TradeRequest request;
+        ASSERT_TRUE(db.assign_signal_id(request));
+        EXPECT_EQ(request.signal_id, 4u);
+    }
+
+    {
+        SignalRecordDB reopened(config);
+        ASSERT_TRUE(reopened.is_open());
+        EXPECT_EQ(reopened.get_signal_id(), 5u);
+    }
+}
+
+TEST(SignalRecordDBTest, UpsertFindMigrateEraseClearAndCount) {
+    const auto config = make_config("signal_record_db_direct");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    const std::int64_t ts = 1712345600100;
+    auto first = make_record(42, ts, 1001);
+    auto write = db.upsert(first);
+    ASSERT_TRUE(write.ok()) << write.message;
+    EXPECT_EQ(write.record.signal_id, 1u);
+    EXPECT_EQ(db.count(), 1u);
+
+    const auto first_id = write.record.signal_id;
+    auto by_id = db.find_by_signal_id(first_id);
+    ASSERT_TRUE(by_id.ok()) << by_id.message;
+    EXPECT_EQ(by_id.record.unique_id, 42);
+
+    auto by_uid = db.find_by_uid(42);
+    ASSERT_TRUE(by_uid.ok()) << by_uid.message;
+    EXPECT_EQ(by_uid.record.signal_id, first_id);
+
+    auto by_trade = db.find_by_trade_id(1001);
+    ASSERT_TRUE(by_trade.ok()) << by_trade.message;
+    EXPECT_EQ(by_trade.record.signal_id, first_id);
+
+    auto updated = make_record(42, ts + 1, 2001);
+    updated.total_profit = 20.5;
+    auto update = db.upsert(updated);
+    ASSERT_TRUE(update.ok()) << update.message;
+    EXPECT_EQ(update.record.signal_id, first_id);
+    EXPECT_DOUBLE_EQ(db.find_by_signal_id(first_id).record.total_profit, 20.5);
+    EXPECT_EQ(db.find_by_trade_id(1001).status, SignalRecordDBStatus::NOT_FOUND);
+    ASSERT_TRUE(db.find_by_trade_id(2001).ok());
+
+    auto second = make_record(43, ts + 2, 3001);
+    auto second_write = db.upsert(second);
+    ASSERT_TRUE(second_write.ok()) << second_write.message;
+    EXPECT_EQ(second_write.record.signal_id, 2u);
+    EXPECT_EQ(db.count(), 2u);
+
+    auto by_timestamp = db.find_by_timestamp(ts + 1);
+    ASSERT_TRUE(by_timestamp.ok()) << by_timestamp.message;
+    ASSERT_EQ(by_timestamp.records.size(), 1u);
+    EXPECT_EQ(by_timestamp.records[0].unique_id, 42);
+
+    auto range = db.find_range(ts, ts + 2);
+    ASSERT_TRUE(range.ok()) << range.message;
+    EXPECT_EQ(range.records.size(), 2u);
+    EXPECT_TRUE(contains_uid(range.records, 42));
+    EXPECT_TRUE(contains_uid(range.records, 43));
+
+    EXPECT_EQ(db.erase_by_signal_id(first_id), SignalRecordDBStatus::SUCCESS);
+    EXPECT_EQ(db.find_by_uid(42).status, SignalRecordDBStatus::NOT_FOUND);
+    EXPECT_EQ(db.find_by_trade_id(2001).status, SignalRecordDBStatus::NOT_FOUND);
+    EXPECT_EQ(db.count(), 1u);
+
+    EXPECT_EQ(db.clear(), SignalRecordDBStatus::SUCCESS);
+    EXPECT_EQ(db.count(), 0u);
+    EXPECT_EQ(db.get_signal_id(), 1u);
+}
+
+TEST(SignalRecordDBTest, WriteRemovesStaleIndexesWhenFieldsChange) {
+    const auto config = make_config("signal_record_db_stale_index");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    auto original = make_record(50, 1712345600125, 1501);
+    original.signal_id = 10;
+    ASSERT_TRUE(db.write(original).ok());
+
+    auto updated = make_record(51, 1712345600125, 2501);
+    updated.signal_id = 10;
+    ASSERT_TRUE(db.write(updated).ok());
+
+    EXPECT_EQ(db.find_by_uid(50).status, SignalRecordDBStatus::NOT_FOUND);
+    EXPECT_EQ(db.find_by_trade_id(1501).status, SignalRecordDBStatus::NOT_FOUND);
+    ASSERT_TRUE(db.find_by_uid(51).ok());
+    ASSERT_TRUE(db.find_by_trade_id(2501).ok());
+}
+
+TEST(SignalRecordDBTest, WriteMovesRecordWhenCanonicalTimestampChanges) {
+    const auto config = make_config("signal_record_db_composite_move");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    const std::int64_t old_ts = 1712345600000;
+    const std::int64_t new_ts = old_ts + 120000;
+
+    auto original = make_record(60, old_ts, 1601);
+    original.signal_id = 12;
+    ASSERT_TRUE(db.write(original).ok());
+
+    auto old_range = db.find_range(old_ts, old_ts + 999);
+    ASSERT_TRUE(old_range.ok()) << old_range.message;
+    ASSERT_EQ(old_range.records.size(), 1u);
+    EXPECT_EQ(old_range.records[0].signal_id, 12u);
+
+    auto updated = make_record(60, new_ts, 1601);
+    updated.signal_id = 12;
+    updated.total_profit = 44.0;
+    ASSERT_TRUE(db.write(updated).ok());
+
+    old_range = db.find_range(old_ts, old_ts + 999);
+    ASSERT_TRUE(old_range.ok()) << old_range.message;
+    EXPECT_TRUE(old_range.records.empty());
+
+    const auto new_range = db.find_range(new_ts, new_ts + 999);
+    ASSERT_TRUE(new_range.ok()) << new_range.message;
+    ASSERT_EQ(new_range.records.size(), 1u);
+    EXPECT_EQ(new_range.records[0].signal_id, 12u);
+    EXPECT_DOUBLE_EQ(new_range.records[0].total_profit, 44.0);
+    EXPECT_EQ(db.count(), 1u);
+    ASSERT_TRUE(db.find_by_uid(60).ok());
+    ASSERT_TRUE(db.find_by_trade_id(1601).ok());
+}
+
+TEST(SignalRecordDBTest, ProcessRunsQueuedWorkOnCallerThread) {
+    const auto config = make_config("signal_record_db_queue_process");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    std::atomic<int> callback_count{0};
+    std::uint32_t callback_signal_id = 0;
+    ASSERT_EQ(
+        db.enqueue_upsert(
+            make_record(70, 1712345600100, 7001),
+            [&](optionx::storage::SignalRecordDBWriteResult result) {
+                ASSERT_TRUE(result.ok()) << result.message;
+                callback_signal_id = result.record.signal_id;
+                ++callback_count;
+            }),
+        SignalRecordDBStatus::SUCCESS);
+
+    EXPECT_EQ(callback_count.load(), 0);
+    db.process();
+    EXPECT_EQ(callback_count.load(), 1);
+    EXPECT_TRUE(db.find_by_signal_id(callback_signal_id).ok());
+}
+
+TEST(SignalRecordDBTest, WorkerFlushDeliversCallbacksOnFlushThread) {
+    const auto config = make_config("signal_record_db_queue_worker");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+    ASSERT_TRUE(db.run());
+
+    std::atomic<int> callback_count{0};
+    ASSERT_EQ(
+        db.enqueue_upsert(
+            make_record(80, 1712345600100, 8001),
+            [&](optionx::storage::SignalRecordDBWriteResult result) {
+                ASSERT_TRUE(result.ok()) << result.message;
+                ++callback_count;
+            }),
+        SignalRecordDBStatus::SUCCESS);
+
+    db.flush();
+    EXPECT_EQ(callback_count.load(), 1);
+}
+
+TEST(SignalRecordDBTest, ShutdownRejectsQueuedWork) {
+    const auto config = make_config("signal_record_db_shutdown");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    db.shutdown();
+    EXPECT_FALSE(db.is_open());
+    EXPECT_EQ(
+        db.enqueue_upsert(make_record(90, 1712345600100, 9001)),
+        SignalRecordDBStatus::QUEUE_CLOSED);
+    EXPECT_EQ(db.find_by_signal_id(1).status, SignalRecordDBStatus::NOT_OPEN);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/signal_record_db_test.cpp
+++ b/tests/signal_record_db_test.cpp
@@ -4,6 +4,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -28,7 +30,7 @@ std::string unique_db_path(const std::string& name) {
 mdbxc::Config make_config(const std::string& name) {
     mdbxc::Config config;
     config.pathname = unique_db_path(name);
-    config.max_dbs = 5;
+    config.max_dbs = 4;
     config.no_subdir = false;
     config.relative_to_exe = true;
     return config;
@@ -116,6 +118,23 @@ TEST(SignalRecordSerializationTest, RejectsCorruptedPayloads) {
         std::runtime_error);
 }
 
+TEST(SignalRecordSerializationTest, RejectsCorruptedTradeIdVectorLengthBeforeReserve) {
+    auto record = make_record(42, 1712345600100);
+    record.signal_id = 77;
+
+    auto bytes = record.to_bytes();
+    ASSERT_GT(bytes.size(), sizeof(std::uint32_t) * (record.trade_ids.size() + 1));
+
+    const auto vector_length_offset =
+        bytes.size() - sizeof(std::uint32_t) * (record.trade_ids.size() + 1);
+    const auto bad_length = (std::numeric_limits<std::uint32_t>::max)();
+    std::memcpy(bytes.data() + vector_length_offset, &bad_length, sizeof(bad_length));
+
+    EXPECT_THROW(
+        static_cast<void>(SignalRecord::from_bytes(bytes.data(), bytes.size())),
+        std::runtime_error);
+}
+
 TEST(SignalRecordDBTest, ReservesPersistentSignalIdAndAssignsCarriers) {
     const auto config = make_config("signal_record_db_ids");
 
@@ -164,13 +183,15 @@ TEST(SignalRecordDBTest, UpsertFindMigrateEraseClearAndCount) {
 
     auto by_uid = db.find_by_uid(42);
     ASSERT_TRUE(by_uid.ok()) << by_uid.message;
-    EXPECT_EQ(by_uid.record.signal_id, first_id);
+    ASSERT_EQ(by_uid.records.size(), 1u);
+    EXPECT_EQ(by_uid.records[0].signal_id, first_id);
 
     auto by_trade = db.find_by_trade_id(1001);
     ASSERT_TRUE(by_trade.ok()) << by_trade.message;
     EXPECT_EQ(by_trade.record.signal_id, first_id);
 
     auto updated = make_record(42, ts + 1, 2001);
+    updated.signal_id = first_id;
     updated.total_profit = 20.5;
     auto update = db.upsert(updated);
     ASSERT_TRUE(update.ok()) << update.message;
@@ -197,7 +218,9 @@ TEST(SignalRecordDBTest, UpsertFindMigrateEraseClearAndCount) {
     EXPECT_TRUE(contains_uid(range.records, 43));
 
     EXPECT_EQ(db.erase_by_signal_id(first_id), SignalRecordDBStatus::SUCCESS);
-    EXPECT_EQ(db.find_by_uid(42).status, SignalRecordDBStatus::NOT_FOUND);
+    auto missing_uid = db.find_by_uid(42);
+    ASSERT_TRUE(missing_uid.ok()) << missing_uid.message;
+    EXPECT_TRUE(missing_uid.records.empty());
     EXPECT_EQ(db.find_by_trade_id(2001).status, SignalRecordDBStatus::NOT_FOUND);
     EXPECT_EQ(db.count(), 1u);
 
@@ -219,9 +242,13 @@ TEST(SignalRecordDBTest, WriteRemovesStaleIndexesWhenFieldsChange) {
     updated.signal_id = 10;
     ASSERT_TRUE(db.write(updated).ok());
 
-    EXPECT_EQ(db.find_by_uid(50).status, SignalRecordDBStatus::NOT_FOUND);
+    auto old_uid = db.find_by_uid(50);
+    ASSERT_TRUE(old_uid.ok()) << old_uid.message;
+    EXPECT_TRUE(old_uid.records.empty());
     EXPECT_EQ(db.find_by_trade_id(1501).status, SignalRecordDBStatus::NOT_FOUND);
-    ASSERT_TRUE(db.find_by_uid(51).ok());
+    auto new_uid = db.find_by_uid(51);
+    ASSERT_TRUE(new_uid.ok()) << new_uid.message;
+    ASSERT_EQ(new_uid.records.size(), 1u);
     ASSERT_TRUE(db.find_by_trade_id(2501).ok());
 }
 
@@ -257,8 +284,74 @@ TEST(SignalRecordDBTest, WriteMovesRecordWhenCanonicalTimestampChanges) {
     EXPECT_EQ(new_range.records[0].signal_id, 12u);
     EXPECT_DOUBLE_EQ(new_range.records[0].total_profit, 44.0);
     EXPECT_EQ(db.count(), 1u);
-    ASSERT_TRUE(db.find_by_uid(60).ok());
+    auto by_uid = db.find_by_uid(60);
+    ASSERT_TRUE(by_uid.ok()) << by_uid.message;
+    ASSERT_EQ(by_uid.records.size(), 1u);
     ASSERT_TRUE(db.find_by_trade_id(1601).ok());
+}
+
+TEST(SignalRecordDBTest, FindByUidReturnsAllMatchingUserIdsWithoutMerging) {
+    const auto config = make_config("signal_record_db_duplicate_uid");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    auto first = make_record(77, 1712345600000, 7701);
+    auto second = make_record(77, 1712345660000, 7801);
+
+    auto first_write = db.upsert(first);
+    ASSERT_TRUE(first_write.ok()) << first_write.message;
+    auto second_write = db.upsert(second);
+    ASSERT_TRUE(second_write.ok()) << second_write.message;
+
+    EXPECT_NE(first_write.record.signal_id, second_write.record.signal_id);
+
+    auto by_uid = db.find_by_uid(77);
+    ASSERT_TRUE(by_uid.ok()) << by_uid.message;
+    ASSERT_EQ(by_uid.records.size(), 2u);
+    EXPECT_TRUE(contains_uid(by_uid.records, 77));
+    EXPECT_TRUE(db.find_by_signal_id(first_write.record.signal_id).ok());
+    EXPECT_TRUE(db.find_by_signal_id(second_write.record.signal_id).ok());
+}
+
+TEST(SignalRecordDBTest, WriteRejectsTradeIdOwnedByAnotherSignal) {
+    const auto config = make_config("signal_record_db_trade_conflict_write");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    auto first = make_record(81, 1712345600000, 8101);
+    first.signal_id = 1;
+    ASSERT_TRUE(db.write(first).ok());
+
+    auto second = make_record(82, 1712345601000, 8101);
+    second.signal_id = 2;
+    auto conflict = db.write(second);
+    EXPECT_EQ(conflict.status, SignalRecordDBStatus::CONFLICT);
+
+    auto owner = db.find_by_trade_id(8101);
+    ASSERT_TRUE(owner.ok()) << owner.message;
+    EXPECT_EQ(owner.record.signal_id, 1u);
+}
+
+TEST(SignalRecordDBTest, UpsertRejectsAmbiguousTradeIdOwners) {
+    const auto config = make_config("signal_record_db_trade_conflict_upsert");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    auto first = make_record(91, 1712345600000, 9101);
+    first.signal_id = 1;
+    ASSERT_TRUE(db.write(first).ok());
+
+    auto second = make_record(92, 1712345601000, 9201);
+    second.signal_id = 2;
+    ASSERT_TRUE(db.write(second).ok());
+
+    auto ambiguous = make_record(93, 1712345602000, 9301);
+    ambiguous.trade_ids.clear();
+    ambiguous.add_trade_id(9101);
+    ambiguous.add_trade_id(9201);
+
+    auto conflict = db.upsert(ambiguous);
+    EXPECT_EQ(conflict.status, SignalRecordDBStatus::CONFLICT);
 }
 
 TEST(SignalRecordDBTest, ProcessRunsQueuedWorkOnCallerThread) {

--- a/tests/signal_record_db_test.cpp
+++ b/tests/signal_record_db_test.cpp
@@ -313,6 +313,30 @@ TEST(SignalRecordDBTest, FindByUidReturnsAllMatchingUserIdsWithoutMerging) {
     EXPECT_TRUE(db.find_by_signal_id(second_write.record.signal_id).ok());
 }
 
+TEST(SignalRecordDBTest, FindByUidAllowsZeroAndNegativeUserIds) {
+    const auto config = make_config("signal_record_db_zero_negative_uid");
+    SignalRecordDB db(config);
+    ASSERT_TRUE(db.is_open());
+
+    auto zero = make_record(0, 1712345600000, 7901);
+    auto negative = make_record(-7, 1712345660000, 7903);
+
+    auto zero_write = db.upsert(zero);
+    ASSERT_TRUE(zero_write.ok()) << zero_write.message;
+    auto negative_write = db.upsert(negative);
+    ASSERT_TRUE(negative_write.ok()) << negative_write.message;
+
+    auto zero_uid = db.find_by_uid(0);
+    ASSERT_TRUE(zero_uid.ok()) << zero_uid.message;
+    ASSERT_EQ(zero_uid.records.size(), 1u);
+    EXPECT_EQ(zero_uid.records[0].signal_id, zero_write.record.signal_id);
+
+    auto negative_uid = db.find_by_uid(-7);
+    ASSERT_TRUE(negative_uid.ok()) << negative_uid.message;
+    ASSERT_EQ(negative_uid.records.size(), 1u);
+    EXPECT_EQ(negative_uid.records[0].signal_id, negative_write.record.signal_id);
+}
+
 TEST(SignalRecordDBTest, WriteRejectsTradeIdOwnedByAnotherSignal) {
     const auto config = make_config("signal_record_db_trade_conflict_write");
     SignalRecordDB db(config);
@@ -352,6 +376,19 @@ TEST(SignalRecordDBTest, UpsertRejectsAmbiguousTradeIdOwners) {
 
     auto conflict = db.upsert(ambiguous);
     EXPECT_EQ(conflict.status, SignalRecordDBStatus::CONFLICT);
+    EXPECT_EQ(db.count(), 2u);
+
+    auto first_owner = db.find_by_trade_id(9101);
+    ASSERT_TRUE(first_owner.ok()) << first_owner.message;
+    EXPECT_EQ(first_owner.record.signal_id, 1u);
+
+    auto second_owner = db.find_by_trade_id(9201);
+    ASSERT_TRUE(second_owner.ok()) << second_owner.message;
+    EXPECT_EQ(second_owner.record.signal_id, 2u);
+
+    auto conflict_uid = db.find_by_uid(93);
+    ASSERT_TRUE(conflict_uid.ok()) << conflict_uid.message;
+    EXPECT_TRUE(conflict_uid.records.empty());
 }
 
 TEST(SignalRecordDBTest, ProcessRunsQueuedWorkOnCallerThread) {


### PR DESCRIPTION
## What Changed
- Added binary serialization support for `SignalRecord`, including round-trip equality checks used by MDBX storage.
- Added `SignalRecordDB` with the same synchronous/queued lifecycle model as `TradeRecordDB`.
- Stored signal records under a composite MDBX key: `unix_minutes + signal_id`, with separate indexes for persistent `signal_id` and produced `trade_id` values.
- Kept `unique_id` as a user-defined `int64_t` metadata field: `find_by_uid()` returns a list, accepts the full signed range, and duplicate user IDs are allowed.
- Added a time-range `find_by_uid(unique_id, start_ms, stop_ms)` overload for the common filtered scan case; the one-argument overload remains a documented full-scan convenience.
- Added conflict protection for produced trade IDs so one `trade_id` cannot silently move to another signal.
- Centralized storage cleanup in a private close helper and preserved the caller's record data in public write/upsert error results.
- Exposed the new storage through `storages.hpp`.
- Added coverage for ID reservation, upsert/write, stale index cleanup, timestamp bucket migration, duplicate/zero/negative user IDs, trade ID conflicts, UID range scans, range queries, async queue processing, shutdown behavior, and corrupted binary vector lengths.

## Why
Signal records need date-first storage just like trades. A plain `signal_id` primary key would make date range queries require full scans and would diverge from the trading storage model. The composite key keeps range queries cheap while preserving direct lookup through indexes.

`unique_id` is intentionally treated as caller-owned metadata rather than internal identity. It may repeat and may use the full signed integer range, so `upsert()` does not merge records by `unique_id`; durable identity is `signal_id`, and trade ownership is represented by `trade_id` links.

`external/mdbx-containers` already provides `for_each_range`, which is the right API here: it streams records over an inclusive key range without loading the whole table. `TradeRecordDB` already uses that helper, so no dependency refactor was needed in this PR.

## Validation
- `cmake --build build-codex --target signal_record_db_test --parallel 4`
- `./build-codex/signal_record_db_test.exe` — 14/14 passed
- `cmake --build build-codex --target trade_record_db_test trade_record_storage_test header_only_odr_test --parallel 4`
- `./build-codex/trade_record_db_test.exe` — 21/21 passed
- `./build-codex/trade_record_storage_test.exe` — 17/17 passed
- `./build-codex/header_only_odr_test.exe` — 4/4 passed
- `git diff --check`