### PR TITLE
[codex] Rename TradeRecord unique fields

### DIFF
--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -177,7 +177,7 @@ Trade statistics ordering:
   by result timestamp (`close_date`, then `open_date`, then automatic fallback).
   If several outcomes have the same result timestamp, their tie breaker is the
   decision timeline (`place_date`, then `send_date`, then `open_date`), followed
-  by `trade_id` and `request_unique_id`.
+  by `trade_id` and `unique_id`.
 - `TradeStatsInputOrder` is a legacy hint and must not be used to promise input
   order semantics for realized curves or win/loss series.
 

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -16,8 +16,8 @@ namespace optionx {
         // Storage identity
         std::uint32_t trade_id = 0;           ///< Linear persistent trade ID; 0 means "not assigned".
         std::uint32_t signal_id = 0;          ///< Persistent signal ID; 0 means "not attached to a signal".
-        std::int64_t request_unique_id = 0;   ///< Unique ID from TradeRequest.
-        std::string request_unique_hash;      ///< Unique hash from TradeRequest.
+        std::int64_t unique_id = 0;          ///< User-defined request/signal correlation ID; 0 means "not assigned".
+        std::string unique_hash;             ///< User-defined request/signal correlation hash.
         std::int64_t account_id = 0;          ///< Trading account ID.
         std::int64_t option_id = 0;           ///< Numeric broker-side order ID.
         std::string option_hash;              ///< String broker-side order ID.
@@ -108,8 +108,8 @@ namespace optionx {
         void assign_request(const TradeRequest& request) {
             trade_id = request.trade_id;
             signal_id = request.signal_id;
-            request_unique_id = request.unique_id;
-            request_unique_hash = request.unique_hash;
+            unique_id = request.unique_id;
+            unique_hash = request.unique_hash;
             account_id = request.account_id;
             account_type = request.account_type;
             currency = request.currency;
@@ -364,7 +364,7 @@ namespace optionx {
         /// \brief Serializes the record using the current binary storage format.
         std::vector<std::uint8_t> to_bytes() const {
             std::vector<std::uint8_t> bytes;
-            bytes.reserve(512 + request_unique_hash.size() + option_hash.size() +
+            bytes.reserve(512 + unique_hash.size() + option_hash.size() +
                           symbol.size() + signal_name.size() + user_data.size() +
                           comment.size() + error_desc.size() + mm_group_hash.size() +
                           mm_group_name.size() + mm_params_json.size() +
@@ -375,8 +375,8 @@ namespace optionx {
 
             append_value(bytes, trade_id);
             append_value(bytes, signal_id);
-            append_value(bytes, request_unique_id);
-            append_string(bytes, request_unique_hash);
+            append_value(bytes, unique_id);
+            append_string(bytes, unique_hash);
             append_value(bytes, account_id);
             append_value(bytes, option_id);
             append_string(bytes, option_hash);
@@ -447,8 +447,8 @@ namespace optionx {
             TradeRecord record;
             record.trade_id = reader.read<std::uint32_t>();
             record.signal_id = reader.read<std::uint32_t>();
-            record.request_unique_id = reader.read<std::int64_t>();
-            record.request_unique_hash = reader.read_string();
+            record.unique_id = reader.read<std::int64_t>();
+            record.unique_hash = reader.read_string();
             record.account_id = reader.read<std::int64_t>();
             record.option_id = reader.read<std::int64_t>();
             record.option_hash = reader.read_string();
@@ -507,8 +507,8 @@ namespace optionx {
         bool operator==(const TradeRecord& other) const {
             return trade_id == other.trade_id &&
                    signal_id == other.signal_id &&
-                   request_unique_id == other.request_unique_id &&
-                   request_unique_hash == other.request_unique_hash &&
+                   unique_id == other.unique_id &&
+                   unique_hash == other.unique_hash &&
                    account_id == other.account_id &&
                    option_id == other.option_id &&
                    option_hash == other.option_hash &&

--- a/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecordFilter.hpp
@@ -78,7 +78,7 @@ namespace optionx {
         IncludeExcludeFilter<std::int64_t> option_ids;
         IncludeExcludeFilter<std::uint32_t> trade_ids;
         IncludeExcludeFilter<std::uint32_t> signal_ids;
-        IncludeExcludeFilter<std::int64_t> request_unique_ids;
+        IncludeExcludeFilter<std::int64_t> unique_ids;
 
         IncludeExcludeFilter<std::uint32_t> durations;
         IncludeExcludeFilter<std::int32_t> mm_steps;

--- a/include/optionx_cpp/storages/TradeRecordDB.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB.hpp
@@ -99,7 +99,7 @@ namespace optionx::storage {
         /// \brief Constructs storage with custom MDBX configuration and optional table names.
         /// \param config MDBX connection configuration.
         /// \param records_table Main table name for composite_key -> TradeRecord.
-        /// \param uid_index_table Optional request_unique_id -> composite_key index table.
+        /// \param uid_index_table Optional unique_id -> composite_key index table.
         /// \param trade_id_index_table Optional trade_id -> composite_key index table.
         /// \param meta_table Metadata table for version and next trade ID.
         explicit TradeRecordDB(
@@ -148,7 +148,7 @@ namespace optionx::storage {
         /// \param record Full trade snapshot to store.
         /// \return Write result with the normalized record.
         ///
-        /// Match order is: explicit trade_id, request_unique_id index, broker identity,
+        /// Match order is: explicit trade_id, unique_id index, broker identity,
         /// then a newly reserved linear trade_id. The stored snapshot is not field-merged;
         /// incoming data replaces the previous record.
         TradeRecordDBWriteResult upsert(TradeRecord record);
@@ -165,13 +165,13 @@ namespace optionx::storage {
         /// \return Read result with found=true when the record exists.
         TradeRecordDBReadResult find_by_trade_id(std::uint32_t trade_id) const;
 
-        /// \brief Finds a record through the optional request_unique_id index.
-        /// \param request_unique_id Legacy/request-side ID copied from TradeRequest::unique_id.
+        /// \brief Finds a record through the optional user unique_id index.
+        /// \param unique_id Positive user-defined correlation ID copied from TradeRequest::unique_id.
         /// \return Read result with found=true when an index entry and record exist.
         ///
-        /// TradeRequest::unique_id is not the database identity. Prefer find_by_trade_id(trade_id)
+        /// TradeRecord::unique_id is not the database identity. Prefer find_by_trade_id(trade_id)
         /// for persistent trade lookup.
-        TradeRecordDBReadResult find_by_uid(std::int64_t request_unique_id) const;
+        TradeRecordDBReadResult find_by_uid(std::int64_t unique_id) const;
 
         /// \brief Finds all records whose selected trade timestamp equals timestamp_ms.
         /// \param timestamp_ms Millisecond timestamp matched against open/place/send/close date.
@@ -254,10 +254,10 @@ namespace optionx::storage {
         TradeRecordDBStatus enqueue_find_by_trade_id(std::uint32_t trade_id, read_callback_t callback = {});
 
         /// \brief Enqueues a find-by-UID operation.
-        /// \param request_unique_id Legacy/request-side ID copied from TradeRequest::unique_id.
+        /// \param unique_id Positive user-defined correlation ID copied from TradeRequest::unique_id.
         /// \param callback Optional callback delivered by process(), flush() or shutdown().
         /// \return SUCCESS when the command was accepted, QUEUE_CLOSED otherwise.
-        TradeRecordDBStatus enqueue_find_by_uid(std::int64_t request_unique_id, read_callback_t callback = {});
+        TradeRecordDBStatus enqueue_find_by_uid(std::int64_t unique_id, read_callback_t callback = {});
 
         /// \brief Enqueues a find-by-timestamp operation.
         /// \param timestamp_ms Millisecond timestamp to match.
@@ -359,7 +359,7 @@ namespace optionx::storage {
         TradeRecordDBWriteResult write_no_lock(TradeRecord record);
         TradeRecordDBWriteResult upsert_no_lock(TradeRecord record);
         TradeRecordDBReadResult find_by_trade_id_no_lock(std::uint32_t trade_id) const;
-        TradeRecordDBReadResult find_by_uid_no_lock(std::int64_t request_unique_id) const;
+        TradeRecordDBReadResult find_by_uid_no_lock(std::int64_t unique_id) const;
         TradeRecordDBListResult find_by_timestamp_no_lock(std::int64_t timestamp_ms) const;
         TradeRecordDBListResult find_range_no_lock(std::int64_t start_ms, std::int64_t stop_ms) const;
         TradeRecordDBListResult find_records_no_lock(const optionx::TradeRecordQuery& query) const;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordDB.ipp
@@ -125,10 +125,10 @@ namespace optionx::storage {
         }
     }
 
-    inline TradeRecordDBReadResult TradeRecordDB::find_by_uid(std::int64_t request_unique_id) const {
+    inline TradeRecordDBReadResult TradeRecordDB::find_by_uid(std::int64_t unique_id) const {
         std::lock_guard<std::mutex> lock(m_db_mutex);
         try {
-            return find_by_uid_no_lock(request_unique_id);
+            return find_by_uid_no_lock(unique_id);
         } catch (const mdbxc::MdbxException& ex) {
             LOGIT_PRINT_ERROR("TradeRecordDB find_by_uid database error: ", ex);
             return detail::read_error(TradeRecordDBStatus::DB_ERROR, ex.what());
@@ -292,10 +292,10 @@ namespace optionx::storage {
     }
 
     inline TradeRecordDBStatus TradeRecordDB::enqueue_find_by_uid(
-        std::int64_t request_unique_id,
+        std::int64_t unique_id,
         read_callback_t callback) {
-        return enqueue_command([this, request_unique_id, callback = std::move(callback)]() mutable {
-            auto result = find_by_uid(request_unique_id);
+        return enqueue_command([this, unique_id, callback = std::move(callback)]() mutable {
+            auto result = find_by_uid(unique_id);
             enqueue_callback([callback = std::move(callback), result = std::move(result)]() mutable {
                 if (callback) callback(std::move(result));
             });
@@ -551,16 +551,16 @@ namespace optionx::storage {
 
         if (existing_composite_opt && *existing_composite_opt != new_composite_key) {
             const auto old_record = m_records->find(*existing_composite_opt, txn);
-            if (old_record && old_record->request_unique_id > 0 &&
-                old_record->request_unique_id != record.request_unique_id) {
-                m_uid_index->erase(old_record->request_unique_id, txn);
+            if (old_record && old_record->unique_id > 0 &&
+                old_record->unique_id != record.unique_id) {
+                m_uid_index->erase(old_record->unique_id, txn);
             }
             m_records->erase(*existing_composite_opt, txn);
         }
 
         m_records->insert_or_assign(new_composite_key, record, txn);
-        if (record.request_unique_id > 0) {
-            m_uid_index->insert_or_assign(record.request_unique_id, new_composite_key, txn);
+        if (record.unique_id > 0) {
+            m_uid_index->insert_or_assign(record.unique_id, new_composite_key, txn);
         }
         m_trade_id_index->insert_or_assign(record.trade_id, new_composite_key, txn);
         bump_next_trade_id_no_lock(record.trade_id, txn.handle());
@@ -588,14 +588,14 @@ namespace optionx::storage {
 
         std::uint32_t selected_trade_id = record.trade_id;
 
-        if (selected_trade_id == 0 && record.request_unique_id > 0) {
-            const auto existing_composite = m_uid_index->find(record.request_unique_id, txn);
+        if (selected_trade_id == 0 && record.unique_id > 0) {
+            const auto existing_composite = m_uid_index->find(record.unique_id, txn);
             if (existing_composite) {
                 const auto existing_record = m_records->find(*existing_composite, txn);
                 if (existing_record) {
                     selected_trade_id = existing_record->trade_id;
                 } else {
-                    m_uid_index->erase(record.request_unique_id, txn);
+                    m_uid_index->erase(record.unique_id, txn);
                 }
             }
         }
@@ -624,16 +624,16 @@ namespace optionx::storage {
 
         if (existing_composite_opt && *existing_composite_opt != new_composite_key) {
             const auto old_record = m_records->find(*existing_composite_opt, txn);
-            if (old_record && old_record->request_unique_id > 0 &&
-                old_record->request_unique_id != record.request_unique_id) {
-                m_uid_index->erase(old_record->request_unique_id, txn);
+            if (old_record && old_record->unique_id > 0 &&
+                old_record->unique_id != record.unique_id) {
+                m_uid_index->erase(old_record->unique_id, txn);
             }
             m_records->erase(*existing_composite_opt, txn);
         }
 
         m_records->insert_or_assign(new_composite_key, record, txn);
-        if (record.request_unique_id > 0) {
-            m_uid_index->insert_or_assign(record.request_unique_id, new_composite_key, txn);
+        if (record.unique_id > 0) {
+            m_uid_index->insert_or_assign(record.unique_id, new_composite_key, txn);
         }
         m_trade_id_index->insert_or_assign(selected_trade_id, new_composite_key, txn);
         bump_next_trade_id_no_lock(selected_trade_id, txn.handle());
@@ -670,18 +670,18 @@ namespace optionx::storage {
         return result;
     }
 
-    inline TradeRecordDBReadResult TradeRecordDB::find_by_uid_no_lock(std::int64_t request_unique_id) const {
+    inline TradeRecordDBReadResult TradeRecordDB::find_by_uid_no_lock(std::int64_t unique_id) const {
         if (!is_open_no_lock()) {
             return detail::read_error(TradeRecordDBStatus::NOT_OPEN, "TradeRecordDB is not open");
         }
-        if (request_unique_id <= 0) {
+        if (unique_id <= 0) {
             return detail::read_error(
                 TradeRecordDBStatus::INVALID_ARGUMENT,
-                "TradeRecord request_unique_id is required");
+                "TradeRecord unique_id is required");
         }
 
         auto txn = m_connection->transaction(mdbxc::TransactionMode::READ_ONLY);
-        const auto composite_opt = m_uid_index->find(request_unique_id, txn);
+        const auto composite_opt = m_uid_index->find(unique_id, txn);
         if (!composite_opt) {
             txn.commit();
             return detail::read_error(
@@ -696,10 +696,10 @@ namespace optionx::storage {
                 TradeRecordDBStatus::NOT_FOUND,
                 "TradeRecord UID index points to missing record");
         }
-        if (record->request_unique_id != request_unique_id) {
+        if (record->unique_id != unique_id) {
             return detail::read_error(
                 TradeRecordDBStatus::NOT_FOUND,
-                "TradeRecord UID index points to a different request_unique_id");
+                "TradeRecord UID index points to a different unique_id");
         }
 
         TradeRecordDBReadResult result;
@@ -902,8 +902,8 @@ namespace optionx::storage {
         }
 
         const auto record = m_records->find(*composite_opt, txn);
-        if (record && record->request_unique_id > 0) {
-            m_uid_index->erase(record->request_unique_id, txn);
+        if (record && record->unique_id > 0) {
+            m_uid_index->erase(record->unique_id, txn);
         }
         m_records->erase(*composite_opt, txn);
         m_trade_id_index->erase(trade_id, txn);

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeRecordFilterMatcher.hpp
@@ -70,7 +70,7 @@ namespace optionx::storage {
             if (!filter.option_ids.match(record.option_id)) return false;
             if (!filter.trade_ids.match(record.trade_id)) return false;
             if (!filter.signal_ids.match(record.signal_id)) return false;
-            if (!filter.request_unique_ids.match(record.request_unique_id)) return false;
+            if (!filter.unique_ids.match(record.unique_id)) return false;
 
             if (!filter.durations.match(record.duration)) return false;
             if (!filter.mm_steps.match(record.mm_step)) return false;

--- a/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
+++ b/include/optionx_cpp/storages/TradeRecordDB/TradeStatsCalculator.hpp
@@ -309,7 +309,7 @@ namespace optionx::storage {
             std::int64_t result_ts = 0;
             std::int64_t decision_ts = 0;
             std::uint32_t trade_id = 0;
-            std::int64_t request_unique_id = 0;
+            std::int64_t unique_id = 0;
             optionx::TradeState trade_state = optionx::TradeState::UNKNOWN;
         };
 
@@ -336,7 +336,7 @@ namespace optionx::storage {
                 result_ts,
                 outcome_decision_timestamp(rec, result_ts),
                 rec.trade_id,
-                rec.request_unique_id,
+                rec.unique_id,
                 rec.trade_state
             };
         }
@@ -554,7 +554,7 @@ namespace optionx::storage {
                     if (lhs.result_ts != rhs.result_ts) return lhs.result_ts < rhs.result_ts;
                     if (lhs.decision_ts != rhs.decision_ts) return lhs.decision_ts < rhs.decision_ts;
                     if (lhs.trade_id != rhs.trade_id) return lhs.trade_id < rhs.trade_id;
-                    return lhs.request_unique_id < rhs.request_unique_id;
+                    return lhs.unique_id < rhs.unique_id;
                 });
 
             std::uint64_t cur_win = 0, cur_loss = 0;

--- a/tests/trade_record_db_test.cpp
+++ b/tests/trade_record_db_test.cpp
@@ -42,8 +42,8 @@ TradeRecord make_record(
     const std::string& option_hash = "broker-a",
     const std::string& symbol = "EURUSD") {
     TradeRecord record;
-    record.request_unique_id = uid;
-    record.request_unique_hash = "request-" + std::to_string(uid);
+    record.unique_id = uid;
+    record.unique_hash = "request-" + std::to_string(uid);
     record.account_id = 7001;
     record.option_id = option_id;
     record.option_hash = option_hash;
@@ -86,7 +86,7 @@ TradeRecord make_record(
 
 bool contains_uid(const std::vector<TradeRecord>& records, std::int64_t uid) {
     return std::any_of(records.begin(), records.end(), [uid](const TradeRecord& record) {
-        return record.request_unique_id == uid;
+        return record.unique_id == uid;
     });
 }
 
@@ -134,7 +134,7 @@ TEST(TradeRecordDBTest, UpsertFindMigrateEraseClearAndCount) {
     const auto first_id = write.record.trade_id;
     auto by_id = db.find_by_trade_id(first_id);
     ASSERT_TRUE(by_id.ok()) << by_id.message;
-    EXPECT_EQ(by_id.record.request_unique_id, 42);
+    EXPECT_EQ(by_id.record.unique_id, 42);
 
     auto by_uid = db.find_by_uid(42);
     ASSERT_TRUE(by_uid.ok()) << by_uid.message;
@@ -193,7 +193,7 @@ TEST(TradeRecordDBTest, DefaultQueryReturnsAllModernRecords) {
     const auto result = db.find_records(optionx::TradeRecordQuery{});
     ASSERT_TRUE(result.ok()) << result.message;
     ASSERT_EQ(result.records.size(), 1u);
-    EXPECT_EQ(result.records[0].request_unique_id, 1);
+    EXPECT_EQ(result.records[0].unique_id, 1);
 }
 
 TEST(TradeRecordDBTest, AllQueryReturnsAllStoredRecords) {

--- a/tests/trade_record_stats_test.cpp
+++ b/tests/trade_record_stats_test.cpp
@@ -25,7 +25,7 @@ using optionx::storage::detail::selected_timestamp_ms;
 
 bool contains_uid(const std::vector<TradeRecord>& records, std::int64_t uid) {
     return std::any_of(records.begin(), records.end(), [uid](const TradeRecord& record) {
-        return record.request_unique_id == uid;
+        return record.unique_id == uid;
     });
 }
 
@@ -73,7 +73,7 @@ TradeRecord make_win_record(
     const std::string& symbol = "EURUSD",
     optionx::TradeState state = optionx::TradeState::WIN) {
     TradeRecord record;
-    record.request_unique_id = uid;
+    record.unique_id = uid;
     record.account_id = 7001;
     record.option_id = 1000 + uid;
     record.platform_type = optionx::PlatformType::INTRADE_BAR;

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -178,8 +178,8 @@ TEST(TradeRecordFactoryTest, AssignsRequestResultAndSignalData) {
     EXPECT_EQ(record.signal_id, 7007u);
     EXPECT_EQ(record.symbol, "EURUSD");
     EXPECT_EQ(record.signal_name, "mean-reversion");
-    EXPECT_EQ(record.request_unique_id, 42);
-    EXPECT_EQ(record.request_unique_hash, "signal-hash");
+    EXPECT_EQ(record.unique_id, 42);
+    EXPECT_EQ(record.unique_hash, "signal-hash");
     EXPECT_EQ(record.option_id, 123456);
     EXPECT_EQ(record.option_hash, "broker-hash");
     EXPECT_TRUE(record.has_open_balance());


### PR DESCRIPTION
## What Changed
- Renamed `TradeRecord::request_unique_id` to `TradeRecord::unique_id`.
- Renamed `TradeRecord::request_unique_hash` to `TradeRecord::unique_hash`.
- Renamed `TradeRecordFilter::request_unique_ids` to `TradeRecordFilter::unique_ids`.
- Updated `TradeRecordDB`, filter matcher, stats ordering, tests, and API docs to use the shorter user-owned naming.

## Why
`unique_id` and `unique_hash` are caller-owned correlation fields. Keeping the `request_` prefix in `TradeRecord` made the persistent DTO look less aligned with `TradeRequest`, `TradeSignal`, and `SignalRecord`, where the same concept already uses the shorter names.

The binary storage order is unchanged; this is a source/API rename. JSON field names follow the new public field names.

## Validation
- `cmake --build build-codex --target trade_record_storage_test --parallel 4`
- `cmake --build build-codex --target trade_record_db_test --parallel 4`
- `cmake --build build-codex --target trade_record_stats_test --parallel 4`
- `cmake --build build-codex --target header_only_odr_test --parallel 4`
- `./build-codex/trade_record_storage_test.exe` — 17/17 passed
- `./build-codex/trade_record_db_test.exe` — 21/21 passed
- `./build-codex/trade_record_stats_test.exe` — 42/42 passed
- `./build-codex/header_only_odr_test.exe` — 4/4 passed
- `git diff --check`

Note: an initial combined parallel build command timed out, and one concurrently launched target hit a transient MinGW `objects.a` removal error. Re-running the targets individually passed cleanly.