### PR TITLE
[codex] Use TimeShield for MT4 legacy timing

### DIFF
--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/lib/legacy-time-utils.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/lib/legacy-time-utils.mqh
@@ -7,72 +7,38 @@
 
 #property strict
 
-const int LEGACY_TRADING_SEC_PER_MIN = 60;
-const int LEGACY_TRADING_SEC_PER_DAY = 86400;
+#include <TimeShield.mqh>
+
+const long LEGACY_TRADING_SEC_PER_MIN = time_shield::SEC_PER_MIN;
+const long LEGACY_TRADING_SEC_PER_DAY = time_shield::SEC_PER_DAY;
 
 uint legacy_trading_sec_of_day(const datetime timestamp) {
-    return (uint)((ulong)timestamp % LEGACY_TRADING_SEC_PER_DAY);
+    return (uint)time_shield::sec_of_day((long)timestamp);
 }
 
 uint legacy_trading_sec_of_day(const int hour, const int minute, const int second) {
-    return (uint)(hour * LEGACY_TRADING_SEC_PER_MIN * 60 + minute * LEGACY_TRADING_SEC_PER_MIN + second);
+    return (uint)time_shield::sec_of_day(hour, minute, second);
 }
 
 uint legacy_trading_sec_of_day(const string value) {
-    uint hour = 0;
-    uint minute = 0;
-    uint second = 0;
-
-    string parts[];
-    const ushort separator = StringGetCharacter(":", 0);
-    const int count = StringSplit(value, separator, parts);
-    if (count == 0 || count > 3) {
-        ArrayFree(parts);
-        return LEGACY_TRADING_SEC_PER_DAY;
-    }
-
-    if (count >= 1) hour = (uint)StringToInteger(parts[0]);
-    if (count >= 2) minute = (uint)StringToInteger(parts[1]);
-    if (count >= 3) second = (uint)StringToInteger(parts[2]);
-
-    ArrayFree(parts);
-
-    if (hour >= 24 || minute >= 60 || second >= 60) {
-        return LEGACY_TRADING_SEC_PER_DAY;
-    }
-
-    return legacy_trading_sec_of_day((int)hour, (int)minute, (int)second);
+    return (uint)time_shield::sec_of_day(value);
 }
 
 class LegacyTradingTimer {
 private:
-    ulong m_start_time;
-    uint m_prev_tick_count;
-    ulong m_tick_count_offset;
-
-    ulong tick_count64() {
-        const ulong max_tick_count = 4294967295;
-        const uint current = GetTickCount();
-        if (current < m_prev_tick_count) {
-            m_tick_count_offset += max_tick_count;
-        }
-        m_prev_tick_count = current;
-        return m_tick_count_offset + current;
-    }
+    long m_start_time_ms;
 
 public:
     LegacyTradingTimer() {
-        m_tick_count_offset = 0;
-        m_prev_tick_count = 0;
         reset();
     }
 
     void reset() {
-        m_start_time = tick_count64();
+        m_start_time_ms = time_shield::monotonic_ms();
     }
 
     ulong get_elapsed_ms() {
-        return tick_count64() - m_start_time;
+        return (ulong)(time_shield::monotonic_ms() - m_start_time_ms);
     }
 
     double get_elapsed() {

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/lib/legacy-time-utils.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/lib/legacy-time-utils.mqh
@@ -9,24 +9,21 @@
 
 #include <TimeShield.mqh>
 
-const long LEGACY_TRADING_SEC_PER_MIN = time_shield::SEC_PER_MIN;
-const long LEGACY_TRADING_SEC_PER_DAY = time_shield::SEC_PER_DAY;
-
 uint legacy_trading_sec_of_day(const datetime timestamp) {
-    return (uint)time_shield::sec_of_day((long)timestamp);
+    return (uint)TimeShield::sec_of_day((long)timestamp);
 }
 
 uint legacy_trading_sec_of_day(const int hour, const int minute, const int second) {
-    return (uint)time_shield::sec_of_day(hour, minute, second);
+    return (uint)TimeShield::sec_of_day(hour, minute, second);
 }
 
 uint legacy_trading_sec_of_day(const string value) {
-    return (uint)time_shield::sec_of_day(value);
+    return (uint)TimeShield::sec_of_day(value);
 }
 
 class LegacyTradingTimer {
 private:
-    long m_start_time_ms;
+    ulong m_start_time_ms;
 
 public:
     LegacyTradingTimer() {
@@ -34,11 +31,11 @@ public:
     }
 
     void reset() {
-        m_start_time_ms = time_shield::monotonic_ms();
+        m_start_time_ms = TimeShield::monotonic_ms();
     }
 
     ulong get_elapsed_ms() {
-        return (ulong)(time_shield::monotonic_ms() - m_start_time_ms);
+        return TimeShield::monotonic_ms() - m_start_time_ms;
     }
 
     double get_elapsed() {

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
@@ -378,7 +378,7 @@ private:
 		datetime signal_bar_time = 0;
 
 		const datetime current_time = TimeCurrent();
-		const long period_duration = config.period * TimeShield::SEC_PER_MIN;
+		const long period_duration = config.period * SEC_PER_MIN;
 		const datetime close_bar_time = open_bar_time + (datetime)period_duration;
 
 		// обрабатываем событие, когда бар еще не закрылся

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
@@ -378,7 +378,7 @@ private:
 		datetime signal_bar_time = 0;
 
 		const datetime current_time = TimeCurrent();
-		const long period_duration = config.period * SEC_PER_MIN;
+		const long period_duration = config.period * TimeShield::sec_per_min();
 		const datetime close_bar_time = open_bar_time + (datetime)period_duration;
 
 		// обрабатываем событие, когда бар еще не закрылся

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
@@ -378,7 +378,7 @@ private:
 		datetime signal_bar_time = 0;
 
 		const datetime current_time = TimeCurrent();
-		const long period_duration = config.period * LEGACY_TRADING_SEC_PER_MIN;
+		const long period_duration = config.period * TimeShield::SEC_PER_MIN;
 		const datetime close_bar_time = open_bar_time + (datetime)period_duration;
 
 		// обрабатываем событие, когда бар еще не закрылся

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/signal-capture.mqh
@@ -378,7 +378,7 @@ private:
 		datetime signal_bar_time = 0;
 
 		const datetime current_time = TimeCurrent();
-		const long period_duration = config.period * TimeShield::sec_per_min();
+		const long period_duration = config.period * TSHIELD_SEC_PER_MIN;
 		const datetime close_bar_time = open_bar_time + (datetime)period_duration;
 
 		// обрабатываем событие, когда бар еще не закрылся

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
@@ -164,12 +164,12 @@ public:
 
     bool set(const string &arg_str_start_time, const string &arg_str_stop_time) {
         time_start = legacy_trading_sec_of_day(arg_str_start_time);
-        if (time_start == SEC_PER_DAY) {
+        if (time_start == TimeShield::sec_per_day()) {
             error_code = 1;
             return false;
         }
         time_stop = legacy_trading_sec_of_day(arg_str_stop_time);
-        if (time_stop == SEC_PER_DAY) {
+        if (time_stop == TimeShield::sec_per_day()) {
             error_code = 2;
             return false;
         }
@@ -311,7 +311,7 @@ public:
         block_bar_time         	= 0;
         block_time             	= 0;
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * SEC_PER_MIN;
+        const long period_duration = Period() * TimeShield::sec_per_min();
         last_open_bar_time      = (datetime)((long)current_time - ((long)current_time % period_duration));
         prev_bar_time           = Time[0];
         logger                  = NULL;
@@ -371,7 +371,7 @@ public:
         const datetime gmt_time = TimeGMT();
         const datetime current_time = TimeCurrent();
         const datetime open_bar_time = Time[0];
-        const long period_duration = Period() * SEC_PER_MIN;
+        const long period_duration = Period() * TimeShield::sec_per_min();
         const datetime last_close_bar_time = last_open_bar_time + (datetime)period_duration;
 
         if (current_time >= last_close_bar_time) {

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
@@ -164,12 +164,12 @@ public:
 
     bool set(const string &arg_str_start_time, const string &arg_str_stop_time) {
         time_start = legacy_trading_sec_of_day(arg_str_start_time);
-        if (time_start == LEGACY_TRADING_SEC_PER_DAY) {
+        if (time_start == TimeShield::SEC_PER_DAY) {
             error_code = 1;
             return false;
         }
         time_stop = legacy_trading_sec_of_day(arg_str_stop_time);
-        if (time_stop == LEGACY_TRADING_SEC_PER_DAY) {
+        if (time_stop == TimeShield::SEC_PER_DAY) {
             error_code = 2;
             return false;
         }
@@ -311,7 +311,7 @@ public:
         block_bar_time         	= 0;
         block_time             	= 0;
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * LEGACY_TRADING_SEC_PER_MIN;
+        const long period_duration = Period() * TimeShield::SEC_PER_MIN;
         last_open_bar_time      = (datetime)((long)current_time - ((long)current_time % period_duration));
         prev_bar_time           = Time[0];
         logger                  = NULL;
@@ -371,7 +371,7 @@ public:
         const datetime gmt_time = TimeGMT();
         const datetime current_time = TimeCurrent();
         const datetime open_bar_time = Time[0];
-        const long period_duration = Period() * LEGACY_TRADING_SEC_PER_MIN;
+        const long period_duration = Period() * TimeShield::SEC_PER_MIN;
         const datetime last_close_bar_time = last_open_bar_time + (datetime)period_duration;
 
         if (current_time >= last_close_bar_time) {

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
@@ -164,12 +164,12 @@ public:
 
     bool set(const string &arg_str_start_time, const string &arg_str_stop_time) {
         time_start = legacy_trading_sec_of_day(arg_str_start_time);
-        if (time_start == TimeShield::sec_per_day()) {
+        if (time_start == TSHIELD_SEC_PER_DAY) {
             error_code = 1;
             return false;
         }
         time_stop = legacy_trading_sec_of_day(arg_str_stop_time);
-        if (time_stop == TimeShield::sec_per_day()) {
+        if (time_stop == TSHIELD_SEC_PER_DAY) {
             error_code = 2;
             return false;
         }
@@ -311,7 +311,7 @@ public:
         block_bar_time         	= 0;
         block_time             	= 0;
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * TimeShield::sec_per_min();
+        const long period_duration = Period() * TSHIELD_SEC_PER_MIN;
         last_open_bar_time      = (datetime)((long)current_time - ((long)current_time % period_duration));
         prev_bar_time           = Time[0];
         logger                  = NULL;
@@ -371,7 +371,7 @@ public:
         const datetime gmt_time = TimeGMT();
         const datetime current_time = TimeCurrent();
         const datetime open_bar_time = Time[0];
-        const long period_duration = Period() * TimeShield::sec_per_min();
+        const long period_duration = Period() * TSHIELD_SEC_PER_MIN;
         const datetime last_close_bar_time = last_open_bar_time + (datetime)period_duration;
 
         if (current_time >= last_close_bar_time) {

--- a/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
+++ b/mql/legacy_trading_connector/MQL4/Include/OptionX/v1/utils/tools.mqh
@@ -164,12 +164,12 @@ public:
 
     bool set(const string &arg_str_start_time, const string &arg_str_stop_time) {
         time_start = legacy_trading_sec_of_day(arg_str_start_time);
-        if (time_start == TimeShield::SEC_PER_DAY) {
+        if (time_start == SEC_PER_DAY) {
             error_code = 1;
             return false;
         }
         time_stop = legacy_trading_sec_of_day(arg_str_stop_time);
-        if (time_stop == TimeShield::SEC_PER_DAY) {
+        if (time_stop == SEC_PER_DAY) {
             error_code = 2;
             return false;
         }
@@ -311,7 +311,7 @@ public:
         block_bar_time         	= 0;
         block_time             	= 0;
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * TimeShield::SEC_PER_MIN;
+        const long period_duration = Period() * SEC_PER_MIN;
         last_open_bar_time      = (datetime)((long)current_time - ((long)current_time % period_duration));
         prev_bar_time           = Time[0];
         logger                  = NULL;
@@ -371,7 +371,7 @@ public:
         const datetime gmt_time = TimeGMT();
         const datetime current_time = TimeCurrent();
         const datetime open_bar_time = Time[0];
-        const long period_duration = Period() * TimeShield::SEC_PER_MIN;
+        const long period_duration = Period() * SEC_PER_MIN;
         const datetime last_close_bar_time = last_open_bar_time + (datetime)period_duration;
 
         if (current_time >= last_close_bar_time) {

--- a/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/api/legacy-trading-api.mqh
+++ b/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/api/legacy-trading-api.mqh
@@ -124,8 +124,10 @@ private:
                         //MC_BO_WIN
                         //MC_BO_LOSS
 
-                        updated_bo.getInt("step", bo.step);
-                        updated_bo.getInt("max_step", bo.max_step);
+                        int step = 0;
+                        int max_step = 0;
+                        if(updated_bo.getInt("step", step)) bo.step = (uint)step;
+                        if(updated_bo.getInt("max_step", max_step)) bo.max_step = (uint)max_step;
 
                         string status_str = updated_bo.getString("status");
                         if(status_str == "win") bo.status = MegaConnectorBoStatus::MC_BO_WIN;

--- a/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/lib/legacy-time-utils.mqh
+++ b/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/lib/legacy-time-utils.mqh
@@ -9,9 +9,6 @@
 
 #include <TimeShield.mqh>
 
-const long LEGACY_TRADING_SEC_PER_MIN = time_shield::SEC_PER_MIN;
-const long LEGACY_TRADING_SEC_PER_DAY = time_shield::SEC_PER_DAY;
-
 int legacy_trading_sec_of_day(const datetime timestamp) {
     return time_shield::sec_of_day((long)timestamp);
 }

--- a/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/lib/simple-named-pipe-server/named_pipe_client.mqh
+++ b/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/lib/simple-named-pipe-server/named_pipe_client.mqh
@@ -26,7 +26,7 @@ ulong CreateNamedPipe(string pipeName,int openMode,int pipeMode,int maxInstances
 int   WaitNamedPipeW(string lpNamedPipeName,int nTimeOut);
 bool  SetNamedPipeHandleState(HANDLE fileHandle,int &lpMode, int lpMaxCollectionCount,int lpCollectDataTimeout);
 int   WriteFile(HANDLE file,uchar &buffer[],uint number_of_bytes_to_write,uint &number_of_bytes_written,PVOID overlapped);
-int   ReadFile(HANDLE file,char &buffer[],uint number_of_bytes_to_read,uint &number_of_bytes_read,PVOID overlapped);
+int   ReadFile(HANDLE file,uchar &buffer[],uint number_of_bytes_to_read,uint &number_of_bytes_read,PVOID overlapped);
 bool  PeekNamedPipe(HANDLE fileHandle, int buffer, int bytes, int bytesRead, int &numOfBytes, int bytesLeftThisMessage);
 #import
 //+------------------------------------------------------------------+
@@ -190,7 +190,8 @@ public:
 	bool write(string message) {
 		if (pipe_handle == INVALID_HANDLE_VALUE) return false;
         if (StringLen(message) == 0) return false;
-        int bytes_to_write, bytes_written;
+        int bytes_to_write;
+        uint bytes_written = 0;
         uchar utf8_array[];
         bytes_to_write = StringToCharArray(message, utf8_array, 0, -1, CP_UTF8);
         bytes_to_write = ArraySize(utf8_array);
@@ -198,10 +199,10 @@ public:
         WriteFile(
 			pipe_handle,
 			utf8_array,
-			bytes_to_write,
+			(uint)bytes_to_write,
 			bytes_written,
 			NULL);
-        if(bytes_written != bytes_to_write) {
+        if(bytes_written != (uint)bytes_to_write) {
             close();
             return false;
         }
@@ -216,14 +217,14 @@ public:
         string ret;
         uchar char_array[];
         ArrayResize(char_array, buffer_size);
-        int bytes_read;
+        uint bytes_read = 0;
         ReadFile(
             pipe_handle,
             char_array,
-            buffer_size,
+            (uint)buffer_size,
             bytes_read,
             0);
-        if(bytes_read != 0) ret = CharArrayToString(char_array, 0, bytes_read, CP_UTF8);
+        if(bytes_read != 0) ret = CharArrayToString(char_array, 0, (int)bytes_read, CP_UTF8);
         return ret;
 	}
 

--- a/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/utils/signal-capture.mqh
+++ b/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/utils/signal-capture.mqh
@@ -185,7 +185,7 @@ private:
             if (StringLen(arrow_name) > 4 && StringSubstr(arrow_name, 0, 4) == "#MC_") continue;
 
             datetime arrow_time = (datetime)ObjectGetInteger(0, arrow_name, OBJPROP_TIME);
-            const datetime period_duration = config.period * LEGACY_TRADING_SEC_PER_MIN;
+            const datetime period_duration = config.period * time_shield::SEC_PER_MIN;
             arrow_time -= arrow_time % period_duration;
             const datetime open_bar_time = get_candle_time(shift);
             //Print("arrow " + TimeToString(arrow_time, TIME_DATE | TIME_MINUTES | TIME_SECONDS), " t: " + TimeToString(open_bar_time, TIME_DATE | TIME_MINUTES | TIME_SECONDS));
@@ -358,7 +358,7 @@ private:
 		datetime signal_bar_time = 0;
 
 		const datetime current_time = TimeCurrent();
-		const long period_duration = config.period * LEGACY_TRADING_SEC_PER_MIN;
+		const long period_duration = config.period * time_shield::SEC_PER_MIN;
 		const datetime close_bar_time = open_bar_time + (datetime)period_duration;
 
 		// обрабатываем событие, когда бар еще не закрылся

--- a/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/utils/tools.mqh
+++ b/mql/legacy_trading_connector/MQL5/Include/OptionX/v1/utils/tools.mqh
@@ -238,12 +238,12 @@ public:
 
     bool set(const string &arg_str_time_start, const string &arg_str_time_stop) {
         time_start = legacy_trading_sec_of_day(arg_str_time_start);
-        if (time_start == LEGACY_TRADING_SEC_PER_DAY) {
+        if (time_start == time_shield::SEC_PER_DAY) {
             error_code = 1;
             return false;
         }
         time_stop = legacy_trading_sec_of_day(arg_str_time_stop);
-        if (time_stop == LEGACY_TRADING_SEC_PER_DAY) {
+        if (time_stop == time_shield::SEC_PER_DAY) {
             error_code = 2;
             return false;
         }
@@ -384,7 +384,7 @@ public:
         block_time              = 0;
         block_bar_time          = 0;
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * LEGACY_TRADING_SEC_PER_MIN;
+        const long period_duration = Period() * time_shield::SEC_PER_MIN;
         last_open_bar_time      = (datetime)((long)current_time - ((long)current_time % period_duration));
         prev_bar_time           = get_candle_time();
         handle = INVALID_HANDLE;
@@ -443,7 +443,7 @@ public:
 
         const datetime gmt_time = TimeGMT();
         const datetime current_time = TimeCurrent();
-        const long period_duration = Period() * LEGACY_TRADING_SEC_PER_MIN;
+        const long period_duration = Period() * time_shield::SEC_PER_MIN;
         const datetime last_close_bar_time = last_open_bar_time + (datetime)period_duration;
 
         if (current_time >= last_close_bar_time) {

--- a/mql/legacy_trading_connector/README.md
+++ b/mql/legacy_trading_connector/README.md
@@ -34,9 +34,9 @@ instead of extending this one.
 Copy the contents of either `MQL4` or `MQL5` into the corresponding terminal
 data folder, preserving the `Include` and `Indicators` directory structure.
 
-The MT5 package includes `<TimeShield.mqh>`. Install the MQL5 headers from the
-`time-shield-cpp` package into the terminal `MQL5/Include` directory before
-compiling the MT5 connector.
+The MT4 and MT5 packages include `<TimeShield.mqh>`. Install the matching MQL
+headers from the `time-shield-cpp` package into the terminal `MQL4/Include` or
+`MQL5/Include` directory before compiling the connector.
 
 Compile `LegacyTradingConnector.mq4` or `LegacyTradingConnector.mq5` in
 MetaEditor. The C++ CI does not compile MQL files.


### PR DESCRIPTION
## What Changed

- Updated `external/time-shield-cpp` to the MQL MetaEditor follow-up from NewYaroslav/time-shield-cpp#115.
- Replaced the local MT4 legacy timing helper logic with calls through `<TimeShield.mqh>`.
- Switched MT4 legacy connector time constants to MQL4-compatible `TSHIELD_` constants.
- Picked up the TimeShield revision that keeps a single MQL5 public root header (`TimeShield.mqh`) instead of shipping both `TimeShield.mqh` and `time_shield.mqh`.
- Fixed MT5 legacy connector compile issues found by MetaEditor: named-pipe read/write WinAPI types and JSON `int` to `uint` step fields.
- Updated legacy connector docs to require matching MQL4 or MQL5 TimeShield headers.

## Dependency

Depends on NewYaroslav/time-shield-cpp#115. PR #114 is already merged.

## Validation

- `git diff --check`
- `cmake --build build-codex --target legacy_trading_bridge_test --parallel`
- `./build-codex/legacy_trading_bridge_test.exe`
- Result: 9/9 tests passed.
- MetaEditor 4 compile, staged package: `LegacyTradingConnector.mq4` — 0 errors, 0 warnings.
- MetaEditor 4 compile, staged package: `LegacyTradingConnector-ru.mq4` — 0 errors, 0 warnings.
- MetaEditor 5 compile, staged package without legacy root `time_shield.mqh`: `LegacyTradingConnector.mq5` — 0 errors, 8 warnings.
- MetaEditor 5 compile, staged package without legacy root `time_shield.mqh`: `LegacyTradingConnector-ru.mq5` — 0 errors, 8 warnings.
- Byte check before commit: no UTF-16/NUL MQL source files remain.

## Notes

The remaining MT5 warnings are pre-existing conversion/import warnings; code generation succeeds.