### PR TITLE
[codex] Remove record equality operators

### DIFF
--- a/include/optionx_cpp/data/trading/SignalRecord.hpp
+++ b/include/optionx_cpp/data/trading/SignalRecord.hpp
@@ -280,52 +280,6 @@ namespace optionx {
             return record;
         }
 
-        bool operator==(const SignalRecord& other) const {
-            return signal_id == other.signal_id &&
-                   bridge_id == other.bridge_id &&
-                   unique_id == other.unique_id &&
-                   unique_hash == other.unique_hash &&
-                   account_id == other.account_id &&
-                   platform_type == other.platform_type &&
-                   account_type == other.account_type &&
-                   currency == other.currency &&
-                   symbol == other.symbol &&
-                   signal_name == other.signal_name &&
-                   user_data == other.user_data &&
-                   comment == other.comment &&
-                   option_type == other.option_type &&
-                   order_type == other.order_type &&
-                   amount == other.amount &&
-                   refund == other.refund &&
-                   min_payout == other.min_payout &&
-                   duration == other.duration &&
-                   expiry_time == other.expiry_time &&
-                   status == other.status &&
-                   reject_code == other.reject_code &&
-                   reject_desc == other.reject_desc &&
-                   outcome == other.outcome &&
-                   trade_state == other.trade_state &&
-                   total_amount == other.total_amount &&
-                   total_profit == other.total_profit &&
-                   create_date == other.create_date &&
-                   accept_date == other.accept_date &&
-                   reject_date == other.reject_date &&
-                   complete_date == other.complete_date &&
-                   mm_type == other.mm_type &&
-                   mm_step == other.mm_step &&
-                   mm_group_id == other.mm_group_id &&
-                   mm_group_hash == other.mm_group_hash &&
-                   mm_group_name == other.mm_group_name &&
-                   mm_params_json == other.mm_params_json &&
-                   decision_params_json == other.decision_params_json &&
-                   metadata_json == other.metadata_json &&
-                   trade_ids == other.trade_ids;
-        }
-
-        bool operator!=(const SignalRecord& other) const {
-            return !(*this == other);
-        }
-
         NLOHMANN_DEFINE_TYPE_INTRUSIVE(
             SignalRecord,
             signal_id,

--- a/include/optionx_cpp/data/trading/TradeRecord.hpp
+++ b/include/optionx_cpp/data/trading/TradeRecord.hpp
@@ -508,61 +508,6 @@ namespace optionx {
             return record;
         }
 
-        bool operator==(const TradeRecord& other) const {
-            return trade_id == other.trade_id &&
-                   signal_id == other.signal_id &&
-                   bridge_id == other.bridge_id &&
-                   unique_id == other.unique_id &&
-                   unique_hash == other.unique_hash &&
-                   account_id == other.account_id &&
-                   option_id == other.option_id &&
-                   option_hash == other.option_hash &&
-                   platform_type == other.platform_type &&
-                   account_type == other.account_type &&
-                   currency == other.currency &&
-                   symbol == other.symbol &&
-                   signal_name == other.signal_name &&
-                   user_data == other.user_data &&
-                   comment == other.comment &&
-                   option_type == other.option_type &&
-                   order_type == other.order_type &&
-                   amount == other.amount &&
-                   refund == other.refund &&
-                   min_payout == other.min_payout &&
-                   payout == other.payout &&
-                   profit == other.profit &&
-                   open_balance == other.open_balance &&
-                   close_balance == other.close_balance &&
-                   trade_state == other.trade_state &&
-                   live_state == other.live_state &&
-                   error_code == other.error_code &&
-                   error_desc == other.error_desc &&
-                   open_price == other.open_price &&
-                   close_price == other.close_price &&
-                   delay == other.delay &&
-                   ping == other.ping &&
-                   place_date == other.place_date &&
-                   send_date == other.send_date &&
-                   open_date == other.open_date &&
-                   close_date == other.close_date &&
-                   duration == other.duration &&
-                   mm_type == other.mm_type &&
-                   mm_step == other.mm_step &&
-                   mm_group_id == other.mm_group_id &&
-                   mm_group_hash == other.mm_group_hash &&
-                   mm_group_name == other.mm_group_name &&
-                   mm_params_json == other.mm_params_json &&
-                   decision_params_json == other.decision_params_json &&
-                   metadata_json == other.metadata_json &&
-                   flags == other.flags &&
-                   spread.raw == other.spread.raw &&
-                   spread.digits == other.spread.digits;
-        }
-
-        bool operator!=(const TradeRecord& other) const {
-            return !(*this == other);
-        }
-
     private:
         static constexpr std::uint32_t kBinaryMagic = 0x5254584fU; // "OXTR" on little-endian hosts.
         static constexpr std::uint16_t kBinaryVersion = 1;

--- a/tests/signal_record_db_test.cpp
+++ b/tests/signal_record_db_test.cpp
@@ -87,6 +87,50 @@ bool contains_uid(const std::vector<SignalRecord>& records, std::int64_t uid) {
     });
 }
 
+void expect_same_signal_record_snapshot(
+        const SignalRecord& actual,
+        const SignalRecord& expected) {
+    EXPECT_EQ(actual.signal_id, expected.signal_id);
+    EXPECT_EQ(actual.bridge_id, expected.bridge_id);
+    EXPECT_EQ(actual.unique_id, expected.unique_id);
+    EXPECT_EQ(actual.unique_hash, expected.unique_hash);
+    EXPECT_EQ(actual.account_id, expected.account_id);
+    EXPECT_EQ(actual.platform_type, expected.platform_type);
+    EXPECT_EQ(actual.account_type, expected.account_type);
+    EXPECT_EQ(actual.currency, expected.currency);
+    EXPECT_EQ(actual.symbol, expected.symbol);
+    EXPECT_EQ(actual.signal_name, expected.signal_name);
+    EXPECT_EQ(actual.user_data, expected.user_data);
+    EXPECT_EQ(actual.comment, expected.comment);
+    EXPECT_EQ(actual.option_type, expected.option_type);
+    EXPECT_EQ(actual.order_type, expected.order_type);
+    EXPECT_EQ(actual.amount, expected.amount);
+    EXPECT_EQ(actual.refund, expected.refund);
+    EXPECT_EQ(actual.min_payout, expected.min_payout);
+    EXPECT_EQ(actual.duration, expected.duration);
+    EXPECT_EQ(actual.expiry_time, expected.expiry_time);
+    EXPECT_EQ(actual.status, expected.status);
+    EXPECT_EQ(actual.reject_code, expected.reject_code);
+    EXPECT_EQ(actual.reject_desc, expected.reject_desc);
+    EXPECT_EQ(actual.outcome, expected.outcome);
+    EXPECT_EQ(actual.trade_state, expected.trade_state);
+    EXPECT_EQ(actual.total_amount, expected.total_amount);
+    EXPECT_EQ(actual.total_profit, expected.total_profit);
+    EXPECT_EQ(actual.create_date, expected.create_date);
+    EXPECT_EQ(actual.accept_date, expected.accept_date);
+    EXPECT_EQ(actual.reject_date, expected.reject_date);
+    EXPECT_EQ(actual.complete_date, expected.complete_date);
+    EXPECT_EQ(actual.mm_type, expected.mm_type);
+    EXPECT_EQ(actual.mm_step, expected.mm_step);
+    EXPECT_EQ(actual.mm_group_id, expected.mm_group_id);
+    EXPECT_EQ(actual.mm_group_hash, expected.mm_group_hash);
+    EXPECT_EQ(actual.mm_group_name, expected.mm_group_name);
+    EXPECT_EQ(actual.mm_params_json, expected.mm_params_json);
+    EXPECT_EQ(actual.decision_params_json, expected.decision_params_json);
+    EXPECT_EQ(actual.metadata_json, expected.metadata_json);
+    EXPECT_EQ(actual.trade_ids, expected.trade_ids);
+}
+
 } // namespace
 
 TEST(SignalRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
@@ -96,7 +140,7 @@ TEST(SignalRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
     const auto bytes = record.to_bytes();
     const auto restored = SignalRecord::from_bytes(bytes.data(), bytes.size());
 
-    EXPECT_EQ(restored, record);
+    expect_same_signal_record_snapshot(restored, record);
     EXPECT_EQ(selected_timestamp_ms(restored), record.create_date);
 }
 

--- a/tests/trade_record_storage_test.cpp
+++ b/tests/trade_record_storage_test.cpp
@@ -145,6 +145,59 @@ optionx::TradeRecord make_record() {
     return record;
 }
 
+void expect_same_trade_record_snapshot(
+        const optionx::TradeRecord& actual,
+        const optionx::TradeRecord& expected) {
+    EXPECT_EQ(actual.trade_id, expected.trade_id);
+    EXPECT_EQ(actual.signal_id, expected.signal_id);
+    EXPECT_EQ(actual.bridge_id, expected.bridge_id);
+    EXPECT_EQ(actual.unique_id, expected.unique_id);
+    EXPECT_EQ(actual.unique_hash, expected.unique_hash);
+    EXPECT_EQ(actual.account_id, expected.account_id);
+    EXPECT_EQ(actual.option_id, expected.option_id);
+    EXPECT_EQ(actual.option_hash, expected.option_hash);
+    EXPECT_EQ(actual.platform_type, expected.platform_type);
+    EXPECT_EQ(actual.account_type, expected.account_type);
+    EXPECT_EQ(actual.currency, expected.currency);
+    EXPECT_EQ(actual.symbol, expected.symbol);
+    EXPECT_EQ(actual.signal_name, expected.signal_name);
+    EXPECT_EQ(actual.user_data, expected.user_data);
+    EXPECT_EQ(actual.comment, expected.comment);
+    EXPECT_EQ(actual.option_type, expected.option_type);
+    EXPECT_EQ(actual.order_type, expected.order_type);
+    EXPECT_EQ(actual.amount, expected.amount);
+    EXPECT_EQ(actual.refund, expected.refund);
+    EXPECT_EQ(actual.min_payout, expected.min_payout);
+    EXPECT_EQ(actual.payout, expected.payout);
+    EXPECT_EQ(actual.profit, expected.profit);
+    EXPECT_EQ(actual.open_balance, expected.open_balance);
+    EXPECT_EQ(actual.close_balance, expected.close_balance);
+    EXPECT_EQ(actual.trade_state, expected.trade_state);
+    EXPECT_EQ(actual.live_state, expected.live_state);
+    EXPECT_EQ(actual.error_code, expected.error_code);
+    EXPECT_EQ(actual.error_desc, expected.error_desc);
+    EXPECT_EQ(actual.open_price, expected.open_price);
+    EXPECT_EQ(actual.close_price, expected.close_price);
+    EXPECT_EQ(actual.delay, expected.delay);
+    EXPECT_EQ(actual.ping, expected.ping);
+    EXPECT_EQ(actual.place_date, expected.place_date);
+    EXPECT_EQ(actual.send_date, expected.send_date);
+    EXPECT_EQ(actual.open_date, expected.open_date);
+    EXPECT_EQ(actual.close_date, expected.close_date);
+    EXPECT_EQ(actual.duration, expected.duration);
+    EXPECT_EQ(actual.mm_type, expected.mm_type);
+    EXPECT_EQ(actual.mm_step, expected.mm_step);
+    EXPECT_EQ(actual.mm_group_id, expected.mm_group_id);
+    EXPECT_EQ(actual.mm_group_hash, expected.mm_group_hash);
+    EXPECT_EQ(actual.mm_group_name, expected.mm_group_name);
+    EXPECT_EQ(actual.mm_params_json, expected.mm_params_json);
+    EXPECT_EQ(actual.decision_params_json, expected.decision_params_json);
+    EXPECT_EQ(actual.metadata_json, expected.metadata_json);
+    EXPECT_EQ(actual.flags, expected.flags);
+    EXPECT_EQ(actual.spread.raw, expected.spread.raw);
+    EXPECT_EQ(actual.spread.digits, expected.spread.digits);
+}
+
 } // namespace
 
 TEST(TradeRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
@@ -152,7 +205,7 @@ TEST(TradeRecordSerializationTest, RoundTripsCurrentBinaryFormat) {
     const auto bytes = record.to_bytes();
     const auto restored = optionx::TradeRecord::from_bytes(bytes.data(), bytes.size());
 
-    EXPECT_EQ(restored, record);
+    expect_same_trade_record_snapshot(restored, record);
 }
 
 TEST(TradeRecordSerializationTest, RejectsCorruptedPayloads) {
@@ -384,7 +437,7 @@ TEST(TradeRecordFactoryTest, EmptyResultPatchDoesNotUpdateRecord) {
     optionx::TradeResult patch;
 
     EXPECT_FALSE(record.merge_result_patch(patch));
-    EXPECT_EQ(record, before);
+    expect_same_trade_record_snapshot(record, before);
 }
 
 TEST(TradeRecordFactoryTest, DoesNotTreatLatestBalanceAsCloseBalance) {
@@ -484,11 +537,11 @@ TEST(TradeRecordStorageTest, StoresInMdbxKeyValueTable) {
 #if __cplusplus >= 201703L
     const auto stored = table.find(record.trade_id);
     ASSERT_TRUE(stored.has_value());
-    EXPECT_EQ(*stored, record);
+    expect_same_trade_record_snapshot(*stored, record);
 #else
     const auto stored = table.find_compat(record.trade_id);
     ASSERT_TRUE(stored.first);
-    EXPECT_EQ(stored.second, record);
+    expect_same_trade_record_snapshot(stored.second, record);
 #endif
 }
 


### PR DESCRIPTION
﻿## What Changed

- Removed public `operator==` / `operator!=` from `TradeRecord` and `SignalRecord`.
- Replaced test usage with explicit local snapshot comparison helpers.
- Kept full-field round-trip/storage checks without exposing DTO equality as a public business-logic API.

## Why

Record equality was only used by tests, but a public `operator==` could be mistaken for storage identity or business identity. Trade/signal identity remains explicit through IDs and existing domain helpers such as broker identity matching.

## Validation

- `git diff --check`
- `cmake --build build-codex --target trade_record_storage_test --parallel`
- `cmake --build build-codex --target signal_record_db_test --parallel`
- `./build-codex/trade_record_storage_test.exe` — 17/17 passed
- `./build-codex/signal_record_db_test.exe` — 14/14 passed
