### PR TITLE
[codex] Add bar price source metadata

### DIFF
--- a/include/optionx_cpp/data/bars.hpp
+++ b/include/optionx_cpp/data/bars.hpp
@@ -5,6 +5,7 @@
 /// \file bars.hpp
 /// \brief
 
+#include "bars/enums.hpp"
 #include "bars/Bar.hpp"
 #include "bars/flags.hpp"
 #include "bars/BarData.hpp"

--- a/include/optionx_cpp/data/bars/BarData.hpp
+++ b/include/optionx_cpp/data/bars/BarData.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 namespace optionx {
 
@@ -17,14 +18,30 @@ namespace optionx {
 		std::string symbol; 	///< Symbol
 		std::string provider;	///< Provider
 		uint16_t timeframe; 	///< Timeframe
-        uint16_t flags;     	///< Bar data flags (bitmask of BarUpdateFlags)
+		uint16_t flags;     	///< Bar data flags (bitmask of BarUpdateFlags)
         uint16_t price_digits;  ///< Number of decimal places for price
         uint16_t volume_digits; ///< Number of decimal places for volume
+        BarPriceSource price_source = BarPriceSource::MID; ///< Price stream used to build the OHLC values.
 
 
         /// \brief Constructor to initialize all fields
-        BarData(Bar b, std::string s, std::string p, uint16_t tf, uint16_t f, uint16_t d, uint16_t vd)
-            : bar(std::move(b)), symbol(std::move(s)), provider(std::move(p)), timeframe(tf), flags(f), price_digits(d), volume_digits(vd) {}
+        BarData(
+            Bar b,
+            std::string s,
+            std::string p,
+            uint16_t tf,
+            uint16_t f,
+            uint16_t d,
+            uint16_t vd,
+            BarPriceSource ps = BarPriceSource::MID)
+            : bar(std::move(b)),
+              symbol(std::move(s)),
+              provider(std::move(p)),
+              timeframe(tf),
+              flags(f),
+              price_digits(d),
+              volume_digits(vd),
+              price_source(ps) {}
     }; // BarData
 
 }; // namespace optionx

--- a/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
+++ b/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
@@ -5,6 +5,7 @@
 /// \file BarHistoryRequest.hpp
 /// \brief Contains the CandleHistoryRequest class for requesting historical candlestick data.
 
+#include <cstdint>
 #include <string>
 
 namespace optionx {
@@ -17,6 +18,7 @@ namespace optionx {
         int64_t timeframe = 0; ///< Timeframe of the requested data in seconds.
         int64_t from_ts = 0;   ///< Start timestamp (Unix time) for the requested data range.
         int64_t to_ts = 0;     ///< End timestamp (Unix time) for the requested data range.
+        BarPriceSource price_source = BarPriceSource::MID; ///< Requested price stream for OHLC values.
 
         /// \brief Default constructor.
         BarHistoryRequest() = default;
@@ -26,12 +28,18 @@ namespace optionx {
         /// \param timeframe Timeframe in seconds for each candlestick.
         /// \param from_ts Start timestamp for data retrieval.
         /// \param to_ts End timestamp for data retrieval.
+        /// \param price_source Requested price stream for OHLC values.
         BarHistoryRequest(
             const std::string& symbol,
             int64_t timeframe,
             int64_t from_ts,
-            int64_t to_ts
-        ) : symbol(symbol), timeframe(timeframe), from_ts(from_ts), to_ts(to_ts) {}
+            int64_t to_ts,
+            BarPriceSource price_source = BarPriceSource::MID
+        ) : symbol(symbol),
+            timeframe(timeframe),
+            from_ts(from_ts),
+            to_ts(to_ts),
+            price_source(price_source) {}
     };
 
 }; // namespace optionx

--- a/include/optionx_cpp/data/bars/BarSequence.hpp
+++ b/include/optionx_cpp/data/bars/BarSequence.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <utility>
 
 namespace optionx {
 
@@ -21,13 +22,29 @@ namespace optionx {
 		uint16_t flags;         ///< Bar data flags (bitmask of BarUpdateFlags)
         uint16_t price_digits;  ///< Number of decimal places for price
         uint16_t volume_digits; ///< Number of decimal places for volume
+        BarPriceSource price_source = BarPriceSource::MID; ///< Price stream used to build the OHLC values.
 
         /// \brief Default constructor initializes metadata fields to zero
         BarSequence() : flags(0), price_digits(0), volume_digits(0) {}
 
         /// \brief Constructor to initialize all fields
-        BarSequence(std::vector<Bar> bs, std::string s, std::string p, uint16_t tf, uint16_t f, uint16_t d, uint16_t vd)
-            : bars(std::move(bs)), symbol(std::move(s)), provider(std::move(p)), timeframe(tf), flags(f), price_digits(d), volume_digits(vd) {}
+        BarSequence(
+            std::vector<Bar> bs,
+            std::string s,
+            std::string p,
+            uint16_t tf,
+            uint16_t f,
+            uint16_t d,
+            uint16_t vd,
+            BarPriceSource ps = BarPriceSource::MID)
+            : bars(std::move(bs)),
+              symbol(std::move(s)),
+              provider(std::move(p)),
+              timeframe(tf),
+              flags(f),
+              price_digits(d),
+              volume_digits(vd),
+              price_source(ps) {}
     }; // BarSequence
 
 } // namespace optionx

--- a/include/optionx_cpp/data/bars/enums.hpp
+++ b/include/optionx_cpp/data/bars/enums.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef _OPTIONX_BAR_ENUMS_HPP_INCLUDED
+#define _OPTIONX_BAR_ENUMS_HPP_INCLUDED
+
+/// \file enums.hpp
+/// \brief Defines bar data enums.
+
+#include <cstdint>
+
+namespace optionx {
+
+    /// \enum BarPriceSource
+    /// \brief Defines which price stream was used to build a single OHLC bar.
+    enum class BarPriceSource : std::uint8_t {
+        UNKNOWN = 0, ///< Price source is not specified.
+        BID,         ///< Bar was built from bid prices.
+        ASK,         ///< Bar was built from ask prices.
+        MID,         ///< Bar was built from the bid/ask midpoint.
+        LAST         ///< Bar was built from last trade prices.
+    };
+
+} // namespace optionx
+
+#endif // _OPTIONX_BAR_ENUMS_HPP_INCLUDED

--- a/tests/bar_price_source_contract_test.cpp
+++ b/tests/bar_price_source_contract_test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include "optionx_cpp/data.hpp"
+
+#include <vector>
+
+TEST(BarPriceSourceContract, HistoryRequestDefaultsToMidPrice) {
+    optionx::BarHistoryRequest request("EUR/USD", 60, 1000, 2000);
+
+    EXPECT_EQ(request.symbol, "EUR/USD");
+    EXPECT_EQ(request.timeframe, 60);
+    EXPECT_EQ(request.from_ts, 1000);
+    EXPECT_EQ(request.to_ts, 2000);
+    EXPECT_EQ(request.price_source, optionx::BarPriceSource::MID);
+}
+
+TEST(BarPriceSourceContract, HistoryRequestCanSelectBidOrAsk) {
+    const optionx::BarHistoryRequest bid_request(
+        "EUR/USD",
+        60,
+        1000,
+        2000,
+        optionx::BarPriceSource::BID);
+    const optionx::BarHistoryRequest ask_request(
+        "EUR/USD",
+        60,
+        1000,
+        2000,
+        optionx::BarPriceSource::ASK);
+
+    EXPECT_EQ(bid_request.price_source, optionx::BarPriceSource::BID);
+    EXPECT_EQ(ask_request.price_source, optionx::BarPriceSource::ASK);
+}
+
+TEST(BarPriceSourceContract, BarDataAndSequenceCarryPriceSource) {
+    optionx::Bar bar(1.0, 1.2, 0.9, 1.1, 0.0, 123000);
+
+    const optionx::BarData default_data(bar, "EUR/USD", "test", 60, 0, 5, 0);
+    const optionx::BarData bid_data(
+        bar,
+        "EUR/USD",
+        "test",
+        60,
+        0,
+        5,
+        0,
+        optionx::BarPriceSource::BID);
+    const optionx::BarSequence last_sequence(
+        std::vector<optionx::Bar>{bar},
+        "BTCUSDT",
+        "test",
+        60,
+        0,
+        2,
+        0,
+        optionx::BarPriceSource::LAST);
+
+    EXPECT_EQ(default_data.price_source, optionx::BarPriceSource::MID);
+    EXPECT_EQ(bid_data.price_source, optionx::BarPriceSource::BID);
+    EXPECT_EQ(last_sequence.price_source, optionx::BarPriceSource::LAST);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
﻿## What Changed

- Added `optionx::BarPriceSource` for BID/ASK/MID/LAST bar price semantics.
- Carried the price source through `BarHistoryRequest`, `BarData`, and `BarSequence` with `MID` as the default.
- Added a focused DTO contract test covering default and explicit price-source values.

## Why

The existing `Bar` DTO already represents a single OHLCV price line. This adds the missing metadata needed for providers such as Intrade `/fxhis`, where raw bid/ask data can be adapted into bid, ask, or mid bars without introducing a second public bar model for the common BO workflow.

## Validation

- `cmake -S . -B build-codex -DOPTIONX_BUILD_TESTS=ON -DOPTIONX_BUILD_DEPS=ON`
- `cmake --build build-codex --target bar_price_source_contract_test --parallel`
- `./build-codex/bar_price_source_contract_test.exe`
- `cmake --build build-codex --target utils_core_test --parallel`
- `./build-codex/utils_core_test.exe`
