### PR TITLE
[codex] Rename market data DTO wrappers

### DIFF
--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
@@ -35,7 +35,7 @@ namespace optionx::components {
         TradeState determine_trade_state(
                 const std::shared_ptr<TradeResult>& result,
                 const std::shared_ptr<TradeRequest>& request,
-                const TickData& tick) const;
+                const SingleTick& tick) const;
 
         /// \brief Checks if the given trade state allows closing.
         /// \param state The current trade state.
@@ -103,7 +103,7 @@ namespace optionx::components {
     inline TradeState TradeStateManager::determine_trade_state(
             const std::shared_ptr<TradeResult>& result,
             const std::shared_ptr<TradeRequest>& request,
-            const TickData& tick) const {
+            const SingleTick& tick) const {
         if (!result->open_price) {
             return TradeState::STANDOFF;
         }

--- a/include/optionx_cpp/data/bars.hpp
+++ b/include/optionx_cpp/data/bars.hpp
@@ -8,7 +8,7 @@
 #include "bars/enums.hpp"
 #include "bars/Bar.hpp"
 #include "bars/flags.hpp"
-#include "bars/BarData.hpp"
+#include "bars/SingleBar.hpp"
 #include "bars/BarSequence.hpp"
 #include "bars/BarHistoryRequest.hpp"
 

--- a/include/optionx_cpp/data/bars/SingleBar.hpp
+++ b/include/optionx_cpp/data/bars/SingleBar.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#ifndef _OPTIONX_SINGLE_BAR_SEQUENCE_HPP_INCLUDED
-#define _OPTIONX_SINGLE_BAR_SEQUENCE_HPP_INCLUDED
+#ifndef _OPTIONX_SINGLE_BAR_HPP_INCLUDED
+#define _OPTIONX_SINGLE_BAR_HPP_INCLUDED
 
-/// \file BarData.hpp
+/// \file SingleBar.hpp
 /// \brief
 
 #include <cstdint>
@@ -11,9 +11,9 @@
 
 namespace optionx {
 
-	/// \struct BarData
+	/// \struct SingleBar
     /// \brief Represents a market bar with additional metadata
-    struct BarData {
+    struct SingleBar {
         Bar bar;        		///< Bar data of the specified type
 		std::string symbol; 	///< Symbol
 		std::string provider;	///< Provider
@@ -25,7 +25,7 @@ namespace optionx {
 
 
         /// \brief Constructor to initialize all fields
-        BarData(
+        SingleBar(
             Bar b,
             std::string s,
             std::string p,
@@ -42,8 +42,8 @@ namespace optionx {
               price_digits(d),
               volume_digits(vd),
               price_source(ps) {}
-    }; // BarData
+    }; // SingleBar
 
 }; // namespace optionx
 
-#endif // _OPTIONX_SINGLE_BAR_SEQUENCE_HPP_INCLUDED
+#endif // _OPTIONX_SINGLE_BAR_HPP_INCLUDED

--- a/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
+++ b/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
@@ -16,12 +16,12 @@ namespace optionx::events {
     public:
         /// \brief Constructor initializing the tick data.
         /// \param ticks A vector of tick information.
-        explicit PriceUpdateEvent(std::vector<TickData> ticks)
+        explicit PriceUpdateEvent(std::vector<SingleTick> ticks)
             : m_ticks(std::move(ticks)) {}
 
         /// \brief Gets the tick data associated with this event.
         /// \return A constant reference to the vector of tick information.
-        const std::vector<TickData>& get_ticks() const {
+        const std::vector<SingleTick>& get_ticks() const {
             return m_ticks;
         }
 
@@ -38,18 +38,18 @@ namespace optionx::events {
 
         /// \brief Finds a tick by its symbol name.
         /// \param symbol The name of the symbol to find.
-        /// \return An optional containing the found TickData.
-        TickData get_tick_by_symbol(const std::string& symbol) const {
+        /// \return An optional containing the found SingleTick.
+        SingleTick get_tick_by_symbol(const std::string& symbol) const {
             for (const auto& tick : m_ticks) {
                 if (tick.symbol == symbol) {
                     return tick;
                 }
             }
-            return TickData();
+            return SingleTick();
         }
 
     private:
-        std::vector<TickData> m_ticks; ///< Tick information associated with this event.
+        std::vector<SingleTick> m_ticks; ///< Tick information associated with this event.
     };
 
 } // namespace optionx::events

--- a/include/optionx_cpp/data/ticks.hpp
+++ b/include/optionx_cpp/data/ticks.hpp
@@ -7,7 +7,7 @@
 
 #include "ticks/flags.hpp"
 #include "ticks/Tick.hpp"
-#include "ticks/TickData.hpp"
-#include "ticks/TickSequenceData.hpp"
+#include "ticks/SingleTick.hpp"
+#include "ticks/TickSequence.hpp"
 
 #endif // _OPTIONX_TICKS_HPP_INCLUDED

--- a/include/optionx_cpp/data/ticks/SingleTick.hpp
+++ b/include/optionx_cpp/data/ticks/SingleTick.hpp
@@ -1,18 +1,19 @@
 #pragma once
-#ifndef _OPTIONX_TICK_DATA_HPP_INCLUDED
-#define _OPTIONX_TICK_DATA_HPP_INCLUDED
+#ifndef _OPTIONX_SINGLE_TICK_HPP_INCLUDED
+#define _OPTIONX_SINGLE_TICK_HPP_INCLUDED
 
-/// \file TickData.hpp
-/// \brief Defines the TickData structure for storing individual tick data with metadata.
+/// \file SingleTick.hpp
+/// \brief Defines the SingleTick structure for storing individual tick data with metadata.
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 namespace optionx {
 
-    /// \struct TickData
+    /// \struct SingleTick
     /// \brief Represents a single market tick with associated metadata.
-    struct TickData {
+    struct SingleTick {
         Tick tick;              ///< Tick data of the specified type.
         std::string symbol;     ///< Symbol associated with the tick.
         std::string provider;   ///< Data provider associated with the tick.
@@ -21,7 +22,7 @@ namespace optionx {
         uint32_t flags;         ///< Tick data flags (bitmask of UpdateFlags).
 
         /// \brief Default constructor initializing all fields to default values.
-        TickData() : price_digits(0), volume_digits(0), flags(0) {}
+        SingleTick() : price_digits(0), volume_digits(0), flags(0) {}
 
         /// \brief Constructor to initialize all fields.
         /// \param t Tick data.
@@ -30,7 +31,7 @@ namespace optionx {
         /// \param d Number of decimal places for price.
         /// \param vd Number of decimal places for volume.
         /// \param f Tick data flags.
-        TickData(Tick t, std::string s, std::string p, uint32_t d, uint32_t vd, uint32_t f)
+        SingleTick(Tick t, std::string s, std::string p, uint32_t d, uint32_t vd, uint32_t f)
             : tick(std::move(t)), symbol(std::move(s)), provider(std::move(p)), price_digits(d), volume_digits(vd), flags(f) {}
 
         /// \brief Calculates the average price based on bid and ask.
@@ -59,5 +60,4 @@ namespace optionx {
 
 } // namespace optionx
 
-#endif // _OPTIONX_TICK_DATA_HPP_INCLUDED
-
+#endif // _OPTIONX_SINGLE_TICK_HPP_INCLUDED

--- a/include/optionx_cpp/data/ticks/TickSequence.hpp
+++ b/include/optionx_cpp/data/ticks/TickSequence.hpp
@@ -1,18 +1,19 @@
 #pragma once
-#ifndef _OPTIONX_TICK_SEQUENCE_DATA_HPP_INCLUDED
-#define _OPTIONX_TICK_SEQUENCE_DATA_HPP_INCLUDED
+#ifndef _OPTIONX_TICK_SEQUENCE_HPP_INCLUDED
+#define _OPTIONX_TICK_SEQUENCE_HPP_INCLUDED
 
-/// \file TickSequenceData.hpp
-/// \brief Defines the TickSequenceData structure for storing a sequence of tick data with metadata.
+/// \file TickSequence.hpp
+/// \brief Defines the TickSequence structure for storing a sequence of tick data with metadata.
 
 #include <vector>
 #include <string>
+#include <utility>
 
 namespace optionx {
 
-    /// \struct TickSequenceData
+    /// \struct TickSequence
     /// \brief Represents a sequence of tick data with metadata.
-    struct TickSequenceData {
+    struct TickSequence {
         std::vector<Tick> ticks;    ///< Sequence of tick data of the specified type.
         std::string symbol;         ///< Symbol associated with the tick sequence.
         std::string provider;       ///< Data provider associated with the tick sequence.
@@ -21,7 +22,7 @@ namespace optionx {
         uint32_t flags;             ///< Tick data flags (bitmask of UpdateFlags).
 
         /// \brief Default constructor initializing all fields to default values.
-        TickSequenceData() : price_digits(0), volume_digits(0), flags(0) {}
+        TickSequence() : price_digits(0), volume_digits(0), flags(0) {}
 
         /// \brief Constructor to initialize all fields.
         /// \param ts Sequence of tick data.
@@ -30,10 +31,10 @@ namespace optionx {
         /// \param f Tick data flags.
         /// \param d Number of decimal places for price.
         /// \param vd Number of decimal places for volume.
-        TickSequenceData(std::vector<Tick> ts, std::string s, std::string p, uint32_t d, uint32_t vd, uint32_t f)
+        TickSequence(std::vector<Tick> ts, std::string s, std::string p, uint32_t d, uint32_t vd, uint32_t f)
             : ticks(std::move(ts)), symbol(std::move(s)), provider(std::move(p)), price_digits(d), volume_digits(vd), flags(f) {}
     };
 
 } // namespace optionx
 
-#endif // _OPTIONX_TICK_SEQUENCE_DATA_HPP_INCLUDED
+#endif // _OPTIONX_TICK_SEQUENCE_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
@@ -85,7 +85,7 @@ namespace optionx::platforms::intrade_bar {
 
     /// \brief Tick snapshot returned by the polling price endpoint.
     struct PriceSnapshot {
-        std::vector<TickData> ticks;
+        std::vector<SingleTick> ticks;
     };
 
     /// \brief Trade open response payload.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -85,7 +85,7 @@ namespace optionx::platforms::intrade_bar {
 
     private:
         kurlyk::WebSocketClient m_websocket_client; ///< WebSocket client for BTCUSDT.
-        std::vector<TickData>   m_tick_data;        ///< Container for tick data.
+        std::vector<SingleTick>   m_tick_data;        ///< Container for tick data.
         bool                    m_is_error = false; ///< Flag indicating if an error has occurred.
 
         /// \brief Handles incoming WebSocket messages.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
@@ -45,7 +45,7 @@ namespace optionx::platforms::intrade_bar {
     private:
         RequestManager&    m_request_manager; ///< Reference to the request manager.
         utils::TaskManager m_task_manager;    ///< Task manager for handling asynchronous tasks.
-        std::unordered_map<std::string, TickData> m_ticks; ///< Stores the latest tick data for each symbol.
+        std::unordered_map<std::string, SingleTick> m_ticks; ///< Stores the latest tick data for each symbol.
         bool m_has_price_update = false; ///< Flag indicating whether a price update is in progress.
 
         /// \brief Initiates the process of retrieving price updates.
@@ -129,7 +129,7 @@ namespace optionx::platforms::intrade_bar {
         LOGIT_DEBUG("Intrade Bar price: requesting price snapshot.");
         m_request_manager.request_price([this, task](
                 bool success,
-                std::vector<TickData> ticks) {
+                std::vector<SingleTick> ticks) {
             m_has_price_update = false;
             if (task->is_shutdown()) {
                 m_ticks.clear();

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -220,7 +220,7 @@ namespace optionx::platforms::intrade_bar {
         void request_price(
             std::function<void(
                 bool success,
-                std::vector<TickData> ticks)> price_callback);
+                std::vector<SingleTick> ticks)> price_callback);
 
         /// \brief Typed variant of request_price.
         void request_price_result(
@@ -920,7 +920,7 @@ namespace optionx::platforms::intrade_bar {
     inline void RequestManager::request_price(
             std::function<void(
                 bool success,
-                std::vector<TickData> ticks)> price_callback) {
+                std::vector<SingleTick> ticks)> price_callback) {
         // Отправка GET-запроса
         auto future = get_http_client().get(
             "/price_now",
@@ -938,12 +938,12 @@ namespace optionx::platforms::intrade_bar {
 
             using json = nlohmann::json;
             int64_t received_ms = OPTIONX_TIMESTAMP_MS;
-            std::vector<TickData> ticks;
+            std::vector<SingleTick> ticks;
             try {
                 json j = json::parse(response->content); // Парсинг JSON
                 for (auto& el : j.items()) {
                     const std::string symbol_name = el.key();
-                    TickData tick;
+                    SingleTick tick;
                     tick.provider = to_str(PlatformType::INTRADE_BAR);
                     tick.symbol = normalize_symbol_name(symbol_name);
                     tick.volume_digits = 0;
@@ -1794,7 +1794,7 @@ namespace optionx::platforms::intrade_bar {
         request_price(
             [price_callback = std::move(price_callback)](
                     bool success,
-                    std::vector<TickData> ticks) {
+                    std::vector<SingleTick> ticks) {
                 if (!price_callback) return;
                 if (!success) {
                     price_callback(PriceSnapshotResult::fail("Failed to retrieve price snapshot."));

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -1304,11 +1304,11 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
-    /// \brief Parses a BTCUSDT tick message from the WebSocket and updates the provided TickData structure.
+    /// \brief Parses a BTCUSDT tick message from the WebSocket and updates the provided SingleTick structure.
     /// \param message The JSON-formatted string containing the tick data.
-    /// \param tick_data Reference to the TickData structure to be updated.
+    /// \param tick_data Reference to the SingleTick structure to be updated.
     /// \return true if parsing is successful and the symbol matches BTCUSDT; false otherwise.
-    inline bool parse_btcusdt_tick(const std::string& message, TickData& tick_data) {
+    inline bool parse_btcusdt_tick(const std::string& message, SingleTick& tick_data) {
         auto j = nlohmann::json::parse(message);
 
         if (j.contains("data")) {

--- a/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
+++ b/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
@@ -15,8 +15,8 @@ namespace optionx::platforms {
         using trade_result_check_callback_t = std::function<void(std::unique_ptr<TradeResult>)>;
         using trade_history_callback_t = std::function<void(TradeHistoryResult)>;
         using trade_id_provider_t = std::function<std::uint32_t()>;
-        using bars_callback_t  = std::function<void(const std::vector<BarData>&)>;
-        using ticks_callback_t = std::function<void(const std::vector<TickData>&)>;
+        using bars_callback_t  = std::function<void(const std::vector<SingleBar>&)>;
+        using ticks_callback_t = std::function<void(const std::vector<SingleTick>&)>;
 
         BaseTradingPlatform(std::shared_ptr<BaseAccountInfoData> account_info)
             : m_account_info(std::move(account_info)),

--- a/tests/bar_price_source_contract_test.cpp
+++ b/tests/bar_price_source_contract_test.cpp
@@ -35,8 +35,8 @@ TEST(BarPriceSourceContract, HistoryRequestCanSelectBidOrAsk) {
 TEST(BarPriceSourceContract, BarDataAndSequenceCarryPriceSource) {
     optionx::Bar bar(1.0, 1.2, 0.9, 1.1, 0.0, 123000);
 
-    const optionx::BarData default_data(bar, "EUR/USD", "test", 60, 0, 5, 0);
-    const optionx::BarData bid_data(
+    const optionx::SingleBar default_data(bar, "EUR/USD", "test", 60, 0, 5, 0);
+    const optionx::SingleBar bid_data(
         bar,
         "EUR/USD",
         "test",

--- a/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
+++ b/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
@@ -284,7 +284,7 @@ public:
     void on_event(const optionx::utils::Event* const) override {
     }
 
-    std::vector<optionx::TickData> ticks() const {
+    std::vector<optionx::SingleTick> ticks() const {
         std::lock_guard<std::mutex> lock(m_mutex);
         return m_ticks;
     }
@@ -304,7 +304,7 @@ public:
 
 private:
     mutable std::mutex m_mutex;
-    std::vector<optionx::TickData> m_ticks;
+    std::vector<optionx::SingleTick> m_ticks;
     std::size_t m_update_count = 0;
 };
 
@@ -505,7 +505,7 @@ public:
             timeout_ms);
     }
 
-    std::vector<optionx::TickData> latest_ticks() const {
+    std::vector<optionx::SingleTick> latest_ticks() const {
         return m_price_capture.ticks();
     }
 

--- a/tests/intrade_bar_api/intrade_bar_auth_smoke_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_auth_smoke_test.cpp
@@ -114,7 +114,7 @@ TEST(IntradeBarApiSmoke, AccountInfoAndQuotesAvailableAfterAuth) {
 
     const auto ticks = runtime.latest_ticks();
     EXPECT_FALSE(ticks.empty());
-    EXPECT_TRUE(std::any_of(ticks.begin(), ticks.end(), [&](const optionx::TickData& tick) {
+    EXPECT_TRUE(std::any_of(ticks.begin(), ticks.end(), [&](const optionx::SingleTick& tick) {
         return tick.symbol == quote_symbol;
     })) << "Expected quote symbol in live price snapshot: " << quote_symbol;
 

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -1068,14 +1068,14 @@ TEST_F(TradeManagerTestFixture, ValidTradeTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    TickData tick;
+    SingleTick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
     tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
     tick.symbol       = "EURUSD";
     tick.price_digits = 5;
     tick.flags        = optionx::TickStatusFlags::REALTIME | optionx::TickStatusFlags::INITIALIZED;
-    std::vector<TickData> ticks = { tick };
+    std::vector<SingleTick> ticks = { tick };
 
     bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
 
@@ -1163,14 +1163,14 @@ TEST_F(TradeManagerTestFixture, InvalidTradeTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    TickData tick;
+    SingleTick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
     tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
     tick.symbol       = "EURUSD";
     tick.price_digits = 5;
     tick.flags        = optionx::TickStatusFlags::REALTIME | optionx::TickStatusFlags::INITIALIZED;
-    std::vector<TickData> ticks = { tick };
+    std::vector<SingleTick> ticks = { tick };
 
     bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
 
@@ -1260,14 +1260,14 @@ TEST_F(TradeManagerTestFixture, ShutdownTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    TickData tick;
+    SingleTick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
     tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
     tick.symbol       = "EURUSD";
     tick.price_digits = 5;
     tick.flags        = optionx::TickStatusFlags::REALTIME | optionx::TickStatusFlags::INITIALIZED;
-    std::vector<TickData> ticks = { tick };
+    std::vector<SingleTick> ticks = { tick };
 
     bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
 


### PR DESCRIPTION
﻿## What Changed

- Renamed `BarData` to `SingleBar`.
- Renamed `TickData` to `SingleTick`.
- Renamed `TickSequenceData` to `TickSequence`.
- Updated platform, event, parser, smoke support, and trade manager references to the new names.

## Why

The market-data DTO names now match the shorter DataFeedHub-style model we want to keep compatible with: a single item wrapper (`SingleBar`, `SingleTick`) and a sequence wrapper (`BarSequence`, `TickSequence`). No compatibility aliases were kept because the public API is still being shaped.

## Validation

- `cmake -S . -B build-codex -DOPTIONX_BUILD_TESTS=ON -DOPTIONX_BUILD_DEPS=ON`
- `cmake --build build-codex --target bar_price_source_contract_test --parallel`
- `./build-codex/bar_price_source_contract_test.exe`
- `cmake --build build-codex --target trade_manager_test --parallel`
- `./build-codex/trade_manager_test.exe`
- `cmake --build build-codex --target intrade_bar_api_response_test --parallel`
- `./build-codex/intrade_bar_api_response_test.exe`
- `cmake --build build-codex --target header_only_odr_test --parallel`
- `./build-codex/header_only_odr_test.exe`
