### PR TITLE
[codex] Add Intrade Bar historical bar requests

### DIFF
--- a/include/optionx_cpp/data/bars.hpp
+++ b/include/optionx_cpp/data/bars.hpp
@@ -11,5 +11,6 @@
 #include "bars/SingleBar.hpp"
 #include "bars/BarSequence.hpp"
 #include "bars/BarHistoryRequest.hpp"
+#include "bars/BarHistoryResult.hpp"
 
 #endif // _OPTIONX_BARS_HPP_INCLUDED

--- a/include/optionx_cpp/data/bars/BarHistoryResult.hpp
+++ b/include/optionx_cpp/data/bars/BarHistoryResult.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#ifndef _OPTIONX_BAR_HISTORY_RESULT_HPP_INCLUDED
+#define _OPTIONX_BAR_HISTORY_RESULT_HPP_INCLUDED
+
+/// \file BarHistoryResult.hpp
+/// \brief Defines the result of a broker bar-history request.
+
+namespace optionx {
+
+    /// \struct BarHistoryResult
+    /// \brief Public result DTO for broker historical bar requests.
+    struct BarHistoryResult {
+        static constexpr long NO_HTTP_STATUS = 0;      ///< No HTTP status was captured.
+        static constexpr long NO_RESPONSE_STATUS = -1; ///< The request did not produce a response.
+
+        bool success = false;              ///< Whether the history request succeeded.
+        long status_code = NO_HTTP_STATUS; ///< HTTP status code, when available.
+        std::string error_desc;            ///< Human-readable failure reason.
+        BarSequence sequence;              ///< Historical bar sequence returned by the broker.
+
+        /// \brief Creates a successful bar-history result.
+        /// \param bar_sequence Historical bars returned by the broker.
+        /// \param status HTTP status code, if available.
+        /// \return Successful result.
+        static BarHistoryResult ok(
+                BarSequence bar_sequence,
+                long status = NO_HTTP_STATUS) {
+            BarHistoryResult result;
+            result.success = true;
+            result.status_code = status;
+            result.sequence = std::move(bar_sequence);
+            return result;
+        }
+
+        /// \brief Creates a failed bar-history result.
+        /// \param message Human-readable failure reason.
+        /// \param status HTTP status code, if available.
+        /// \return Failed result.
+        static BarHistoryResult fail(
+                std::string message,
+                long status = NO_RESPONSE_STATUS) {
+            BarHistoryResult result;
+            result.success = false;
+            result.status_code = status;
+            result.error_desc = std::move(message);
+            return result;
+        }
+
+        /// \brief Checks whether status_code contains a real HTTP status.
+        /// \return True for positive HTTP status codes.
+        bool has_http_status() const noexcept {
+            return status_code > NO_HTTP_STATUS;
+        }
+
+        /// \brief Allows concise success checks.
+        explicit operator bool() const noexcept {
+            return success;
+        }
+    };
+
+} // namespace optionx
+
+#endif // _OPTIONX_BAR_HISTORY_RESULT_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -107,21 +107,24 @@ namespace optionx::platforms {
 
         /// \brief Requests historical Intrade Bar candle data.
         /// \param request Symbol, timeframe, range, and preferred price source.
-        /// \param callback Callback receiving a parsed bar sequence. Failures are
-        ///        adapted to an empty sequence for the legacy base callback shape.
+        /// \param callback Callback receiving parsed bars or a failure reason.
         /// \return True if the history request was accepted for processing; false otherwise.
         bool fetch_candle_data(
                 const BarHistoryRequest& request,
-                std::function<void(const BarSequence&)> callback) override {
+                bar_history_callback_t callback) override {
             if (!callback) return false;
             m_request_manager.request_bar_history_result(
                 request,
                 [callback = std::move(callback)](intrade_bar::BarHistoryApiResult result) {
                     if (result) {
-                        callback(result.value.sequence);
+                        callback(BarHistoryResult::ok(
+                            std::move(result.value),
+                            result.status_code));
                         return;
                     }
-                    callback(BarSequence{});
+                    callback(BarHistoryResult::fail(
+                        std::move(result.error_message),
+                        result.status_code));
                 });
             return true;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -105,6 +105,27 @@ namespace optionx::platforms {
                 std::move(callback));
         }
 
+        /// \brief Requests historical Intrade Bar candle data.
+        /// \param request Symbol, timeframe, range, and preferred price source.
+        /// \param callback Callback receiving a parsed bar sequence. Failures are
+        ///        adapted to an empty sequence for the legacy base callback shape.
+        /// \return True if the history request was accepted for processing; false otherwise.
+        bool fetch_candle_data(
+                const BarHistoryRequest& request,
+                std::function<void(const BarSequence&)> callback) override {
+            if (!callback) return false;
+            m_request_manager.request_bar_history_result(
+                request,
+                [callback = std::move(callback)](intrade_bar::BarHistoryApiResult result) {
+                    if (result) {
+                        callback(result.value.sequence);
+                        return;
+                    }
+                    callback(BarSequence{});
+                });
+            return true;
+        }
+
         /// \brief Returns the platform-level trade result callback.
         /// \return Mutable callback reference from the trade execution component.
         trade_result_callback_t& on_trade_result() override {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
@@ -88,6 +88,11 @@ namespace optionx::platforms::intrade_bar {
         std::vector<SingleTick> ticks;
     };
 
+    /// \brief Historical bar sequence returned by a broker data endpoint.
+    struct BarHistory {
+        BarSequence sequence;
+    };
+
     /// \brief Trade open response payload.
     struct TradeOpenInfo {
         int64_t option_id = 0;
@@ -152,6 +157,7 @@ namespace optionx::platforms::intrade_bar {
     using SettingsSwitchResult = ApiResult<SettingsSwitch>;
     using ActiveTradesSnapshotResult = ApiResult<ActiveTradesSnapshot>;
     using PriceSnapshotResult = ApiResult<PriceSnapshot>;
+    using BarHistoryApiResult = ApiResult<BarHistory>;
     using TradeOpenResult = ApiResult<TradeOpenInfo>;
     using TradeCheckResult = ApiResult<TradeCheckInfo>;
     using TradeHistoryApiResult = ApiResult<TradeHistory>;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/ApiResponses.hpp
@@ -88,11 +88,6 @@ namespace optionx::platforms::intrade_bar {
         std::vector<SingleTick> ticks;
     };
 
-    /// \brief Historical bar sequence returned by a broker data endpoint.
-    struct BarHistory {
-        BarSequence sequence;
-    };
-
     /// \brief Trade open response payload.
     struct TradeOpenInfo {
         int64_t option_id = 0;
@@ -157,7 +152,7 @@ namespace optionx::platforms::intrade_bar {
     using SettingsSwitchResult = ApiResult<SettingsSwitch>;
     using ActiveTradesSnapshotResult = ApiResult<ActiveTradesSnapshot>;
     using PriceSnapshotResult = ApiResult<PriceSnapshot>;
-    using BarHistoryApiResult = ApiResult<BarHistory>;
+    using BarHistoryApiResult = ApiResult<BarSequence>;
     using TradeOpenResult = ApiResult<TradeOpenInfo>;
     using TradeCheckResult = ApiResult<TradeCheckInfo>;
     using TradeHistoryApiResult = ApiResult<TradeHistory>;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BarHistoryUtils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BarHistoryUtils.hpp
@@ -19,7 +19,44 @@ namespace optionx::platforms::intrade_bar {
     inline constexpr std::int64_t FX_HISTORY_MAX_BARS_PER_REQUEST = 1000;
 
     /// \brief Maximum klines requested from Binance at once.
+    /// \details Binance documents 1000 as the maximum kline limit.
     inline constexpr std::int64_t BINANCE_KLINES_MAX_BARS_PER_REQUEST = 1000;
+
+    /// \brief Known lower bound for historical bars of one symbol.
+    struct BarHistoryStartLimit {
+        const char* symbol = "";          ///< Normalized symbol.
+        std::int64_t min_from_ts = 0;     ///< Earliest known timestamp in seconds.
+    };
+
+    /// \brief Empirical FX history lower bounds from the old Intrade history dataset.
+    inline constexpr BarHistoryStartLimit FX_HISTORY_START_LIMITS[] = {
+        {"EURUSD", 1007337600}, // 03.12.2001
+        {"USDJPY", 1007337600}, // 03.12.2001
+        {"GBPUSD", 1007337600}, // 03.12.2001
+        {"USDCHF", 1007337600}, // 03.12.2001
+        {"USDCAD", 1007424000}, // 04.12.2001
+        {"EURJPY", 1006992000}, // 29.11.2001
+        {"AUDUSD", 1039824000}, // 14.12.2002
+        {"NZDUSD", 1007424000}, // 04.12.2001
+        {"EURGBP", 1012521600}, // 01.02.2002
+        {"EURCHF", 1007596800}, // 06.12.2001
+        {"AUDJPY", 1006905600}, // 28.11.2001
+        {"GBPJPY", 1006905600}, // 28.11.2001
+        {"CHFJPY", 1007337600}, // 03.12.2001
+        {"EURCAD", 1007078400}, // 30.11.2001
+        {"AUDCAD", 1059523200}, // 30.07.2003
+        {"CADJPY", 1006992000}, // 29.11.2001
+        {"NZDJPY", 1006992000}, // 29.11.2001
+        {"AUDNZD", 1006992000}, // 29.11.2001
+        {"GBPAUD", 1006992000}, // 29.11.2001
+        {"EURAUD", 1006992000}, // 29.11.2001
+        {"GBPCHF", 1007078400}, // 30.11.2001
+        {"EURNZD", 1206921600}, // 31.03.2008
+        {"AUDCHF", 1006992000}, // 29.11.2001
+        {"GBPNZD", 1007078400}, // 30.11.2001
+        {"GBPCAD", 1006992000}, // 29.11.2001
+        {"XAUUSD", 1254096000}  // 28.09.2009
+    };
 
     /// \brief Inclusive time range for one backend request.
     struct BarHistoryChunk {
@@ -51,9 +88,12 @@ namespace optionx::platforms::intrade_bar {
     inline std::int64_t minimum_bar_history_from_ts(const std::string& symbol) {
         const auto normalized = normalize_symbol_name(symbol);
 
-        // Binance BTCUSDT history begins in August 2017. FX limits differ by
-        // symbol and should be added here only after broker-side verification.
+        // Binance BTCUSDT history begins in August 2017.
         if (normalized == "BTCUSDT") return 1502942400;
+
+        for (const auto& item : FX_HISTORY_START_LIMITS) {
+            if (normalized == item.symbol) return item.min_from_ts;
+        }
 
         return 0;
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BarHistoryUtils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BarHistoryUtils.hpp
@@ -1,0 +1,122 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_INTRADEBAR_BAR_HISTORY_UTILS_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_INTRADEBAR_BAR_HISTORY_UTILS_HPP_INCLUDED
+
+/// \file BarHistoryUtils.hpp
+/// \brief Helpers for Intrade Bar historical bar request slicing.
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "SymbolUtils.hpp"
+
+namespace optionx::platforms::intrade_bar {
+
+    /// \brief Maximum bars requested from the Intrade FX history endpoint at once.
+    inline constexpr std::int64_t FX_HISTORY_MAX_BARS_PER_REQUEST = 1000;
+
+    /// \brief Maximum klines requested from Binance at once.
+    inline constexpr std::int64_t BINANCE_KLINES_MAX_BARS_PER_REQUEST = 1000;
+
+    /// \brief Inclusive time range for one backend request.
+    struct BarHistoryChunk {
+        std::int64_t from_ts = 0; ///< Chunk start timestamp in seconds.
+        std::int64_t to_ts = 0;   ///< Chunk end timestamp in seconds.
+    };
+
+    /// \brief Checks whether historical bars for a symbol must be requested from Binance.
+    /// \param symbol Public or normalized symbol.
+    /// \return True when the symbol maps to BTCUSDT.
+    inline bool uses_binance_bar_history(const std::string& symbol) {
+        return is_btc_symbol(symbol);
+    }
+
+    /// \brief Converts a normalized FX symbol to the slash form expected by /fxhis.
+    /// \param symbol Public or normalized symbol.
+    /// \return Broker query symbol such as "NZD/USD".
+    inline std::string fx_history_query_symbol(const std::string& symbol) {
+        const auto normalized = normalize_symbol_name(symbol);
+        if (normalized.size() == 6) {
+            return normalized.substr(0, 3) + "/" + normalized.substr(3, 3);
+        }
+        return normalized;
+    }
+
+    /// \brief Returns an empirically known earliest history timestamp.
+    /// \param symbol Public or normalized symbol.
+    /// \return Minimum supported timestamp in seconds, or 0 when no local limit is known.
+    inline std::int64_t minimum_bar_history_from_ts(const std::string& symbol) {
+        const auto normalized = normalize_symbol_name(symbol);
+
+        // Binance BTCUSDT history begins in August 2017. FX limits differ by
+        // symbol and should be added here only after broker-side verification.
+        if (normalized == "BTCUSDT") return 1502942400;
+
+        return 0;
+    }
+
+    /// \brief Converts a timeframe in seconds to the Binance kline interval.
+    /// \param timeframe_sec Requested timeframe in seconds.
+    /// \return Binance interval string, or an empty string when unsupported.
+    inline std::string binance_interval_from_timeframe(std::int64_t timeframe_sec) {
+        switch (timeframe_sec) {
+        case 60: return "1m";
+        case 180: return "3m";
+        case 300: return "5m";
+        case 900: return "15m";
+        case 1800: return "30m";
+        case 3600: return "1h";
+        case 7200: return "2h";
+        case 14400: return "4h";
+        case 21600: return "6h";
+        case 28800: return "8h";
+        case 43200: return "12h";
+        case 86400: return "1d";
+        case 259200: return "3d";
+        case 604800: return "1w";
+        default:
+            return {};
+        }
+    }
+
+    /// \brief Splits an inclusive history range into backend-sized chunks.
+    /// \param from_ts Inclusive start timestamp in seconds.
+    /// \param to_ts Inclusive end timestamp in seconds.
+    /// \param timeframe_sec Bar timeframe in seconds.
+    /// \param max_bars_per_request Backend limit for one request.
+    /// \return Ordered chunks without duplicated bar timestamps.
+    inline std::vector<BarHistoryChunk> build_bar_history_chunks(
+            std::int64_t from_ts,
+            std::int64_t to_ts,
+            std::int64_t timeframe_sec,
+            std::int64_t max_bars_per_request) {
+        std::vector<BarHistoryChunk> chunks;
+        if (from_ts <= 0 ||
+            to_ts < from_ts ||
+            timeframe_sec <= 0 ||
+            max_bars_per_request <= 0) {
+            return chunks;
+        }
+
+        const auto chunk_span =
+            timeframe_sec * std::max<std::int64_t>(0, max_bars_per_request - 1);
+        for (auto current = from_ts; current <= to_ts;) {
+            const auto remaining = to_ts - current;
+            const auto current_to = current + std::min(remaining, chunk_span);
+            chunks.push_back({current, current_to});
+
+            if (current_to > (std::numeric_limits<std::int64_t>::max)() - timeframe_sec) {
+                break;
+            }
+            current = current_to + timeframe_sec;
+        }
+
+        return chunks;
+    }
+
+} // namespace optionx::platforms::intrade_bar
+
+#endif // _OPTIONX_PLATFORMS_INTRADEBAR_BAR_HISTORY_UTILS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/HttpClientComponent.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/HttpClientComponent.hpp
@@ -17,8 +17,16 @@ namespace optionx::platforms::intrade_bar {
         ACCOUNT_INFO,           ///< The limit for account information requests.
         ACCOUNT_SETTINGS,       ///< The limit for account type or currency change requests.
         TICK_DATA,              ///< The limit for tick data requests.
+        FX_BAR_HISTORY,         ///< The limit for Intrade FX bar-history requests.
+        BTC_BAR_HISTORY,        ///< The limit for Binance BTCUSDT bar-history requests.
         COUNT                   ///< The total number of rate limit types.
     };
+
+    /// \brief Conservative throttle for the Intrade /fxhis history endpoint.
+    inline constexpr uint32_t FX_BAR_HISTORY_REQUESTS_PER_SECOND = 1;
+
+    /// \brief Conservative throttle for Binance kline history requests.
+    inline constexpr uint32_t BTC_BAR_HISTORY_REQUESTS_PER_SECOND = 1;
 
     /// \class HttpClientComponent
     /// \brief Handles HTTP requests and manages rate limits for the Intrade Bar platform.
@@ -37,6 +45,12 @@ namespace optionx::platforms::intrade_bar {
             set_rate_limit_rpm(RateLimitType::ACCOUNT_INFO, 6);
             set_rate_limit_rpm(RateLimitType::ACCOUNT_SETTINGS, 12);
             set_rate_limit_rps(RateLimitType::TICK_DATA, 1);
+            set_rate_limit_rps(
+                RateLimitType::FX_BAR_HISTORY,
+                FX_BAR_HISTORY_REQUESTS_PER_SECOND);
+            set_rate_limit_rps(
+                RateLimitType::BTC_BAR_HISTORY,
+                BTC_BAR_HISTORY_REQUESTS_PER_SECOND);
 			get_http_client().assign_rate_limit_id(get_rate_limit(RateLimitType::GENERAL));
             platform.register_component(this);
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -5,7 +5,11 @@
 /// \file RequestManager.hpp
 /// \brief Handles HTTP requests for user authentication, trade execution, balance updates, and market data retrieval.
 
+#include <algorithm>
+#include <iterator>
+
 #include "ApiResponses.hpp"
+#include "BarHistoryUtils.hpp"
 
 namespace optionx::platforms::intrade_bar {
 
@@ -24,7 +28,9 @@ namespace optionx::platforms::intrade_bar {
         explicit RequestManager(
                 BaseTradingPlatform& platform,
                 HttpClientComponent& client)
-                : BaseComponent(platform.event_bus()), m_client(client) {
+                : BaseComponent(platform.event_bus()),
+                  m_client(client),
+                  m_binance_client("https://api.binance.com") {
             subscribe<events::AuthDataEvent>();
 
             m_api_headers = {
@@ -226,6 +232,13 @@ namespace optionx::platforms::intrade_bar {
         void request_price_result(
             std::function<void(PriceSnapshotResult)> price_callback);
 
+        /// \brief Requests historical bars from the broker market-data backend.
+        /// \param request Symbol, timeframe, range, and preferred price source.
+        /// \param callback Callback receiving a typed bar history result.
+        void request_bar_history_result(
+            const BarHistoryRequest& request,
+            std::function<void(BarHistoryApiResult)> callback);
+
         /// \brief Requests closed trade history export.
         /// \param request History range and timestamp field.
         /// \param account_type Current broker account type selected during authentication.
@@ -283,6 +296,7 @@ namespace optionx::platforms::intrade_bar {
 
     private:
         HttpClientComponent& m_client;      ///< Reference to the HTTP client component.
+        kurlyk::HttpClient m_binance_client; ///< Separate backend for BTCUSDT history.
         kurlyk::Headers   m_api_headers; ///< Default API headers.
         std::string       m_user_id;     ///< User ID for authentication.
         std::string       m_user_hash;   ///< User authentication hash.
@@ -338,6 +352,11 @@ namespace optionx::platforms::intrade_bar {
                 client.set_proxy_server(msg->proxy_server);
                 client.set_proxy_auth(msg->proxy_auth);
                 client.set_proxy_type(msg->proxy_type);
+                m_binance_client.set_user_agent(msg->user_agent);
+                m_binance_client.set_accept_language(msg->accept_language);
+                m_binance_client.set_proxy_server(msg->proxy_server);
+                m_binance_client.set_proxy_auth(msg->proxy_auth);
+                m_binance_client.set_proxy_type(msg->proxy_type);
                 m_trade_history_source = msg->trade_history_source;
                 LOGIT_INFO(
                     "Intrade Bar HTTP client configured. host=",
@@ -348,6 +367,9 @@ namespace optionx::platforms::intrade_bar {
                 client.set_retry_attempts(10, time_shield::MS_PER_SEC);
                 client.set_timeout(30);
                 client.set_connect_timeout(15);
+                m_binance_client.set_retry_attempts(10, time_shield::MS_PER_SEC);
+                m_binance_client.set_timeout(30);
+                m_binance_client.set_connect_timeout(15);
             }
         }
 
@@ -1802,6 +1824,202 @@ namespace optionx::platforms::intrade_bar {
                 }
                 price_callback(PriceSnapshotResult::ok(PriceSnapshot{std::move(ticks)}));
             });
+    }
+
+    inline void RequestManager::request_bar_history_result(
+            const BarHistoryRequest& request,
+            std::function<void(BarHistoryApiResult)> callback) {
+        if (!callback) return;
+
+        if (request.symbol.empty()) {
+            callback(BarHistoryApiResult::fail("Bar history symbol is required."));
+            return;
+        }
+        if (request.timeframe <= 0 ||
+            request.timeframe > static_cast<std::int64_t>((std::numeric_limits<std::uint16_t>::max)())) {
+            callback(BarHistoryApiResult::fail("Bar history timeframe is invalid."));
+            return;
+        }
+        if (request.from_ts <= 0 || request.to_ts < request.from_ts) {
+            callback(BarHistoryApiResult::fail("Bar history request range is invalid."));
+            return;
+        }
+
+        BarHistoryRequest effective_request = request;
+        effective_request.symbol = normalize_symbol_name(request.symbol);
+
+        const bool use_binance = uses_binance_bar_history(effective_request.symbol);
+        const auto min_from_ts = minimum_bar_history_from_ts(effective_request.symbol);
+        if (min_from_ts > 0 && effective_request.from_ts < min_from_ts) {
+            effective_request.from_ts = min_from_ts;
+        }
+
+        const auto make_empty_sequence = [](const BarHistoryRequest& req, BarPriceSource source) {
+            BarSequence sequence;
+            sequence.symbol = normalize_symbol_name(req.symbol);
+            sequence.provider = to_str(PlatformType::INTRADE_BAR);
+            sequence.timeframe = static_cast<std::uint16_t>(req.timeframe);
+            sequence.flags =
+                static_cast<std::uint16_t>(dfh::BarStatusFlags::HISTORICAL) |
+                static_cast<std::uint16_t>(dfh::BarStatusFlags::FINALIZED);
+            sequence.price_digits = price_digits_for_symbol(sequence.symbol);
+            sequence.volume_digits = 0;
+            sequence.price_source = source;
+            return sequence;
+        };
+
+        if (effective_request.from_ts > effective_request.to_ts) {
+            const auto source = use_binance ? BarPriceSource::LAST : effective_request.price_source;
+            callback(BarHistoryApiResult::ok(
+                BarHistory{make_empty_sequence(effective_request, source)}));
+            return;
+        }
+
+        std::string binance_interval;
+        std::int64_t max_bars_per_request = FX_HISTORY_MAX_BARS_PER_REQUEST;
+        if (use_binance) {
+            if (effective_request.price_source == BarPriceSource::BID ||
+                effective_request.price_source == BarPriceSource::ASK ||
+                effective_request.price_source == BarPriceSource::UNKNOWN) {
+                callback(BarHistoryApiResult::fail(
+                    "BTCUSDT bar history is available only as LAST trade-price bars."));
+                return;
+            }
+
+            binance_interval = binance_interval_from_timeframe(effective_request.timeframe);
+            if (binance_interval.empty()) {
+                callback(BarHistoryApiResult::fail(
+                    "Unsupported Binance kline timeframe for BTCUSDT history."));
+                return;
+            }
+            max_bars_per_request = BINANCE_KLINES_MAX_BARS_PER_REQUEST;
+        } else {
+            if (effective_request.price_source == BarPriceSource::UNKNOWN ||
+                effective_request.price_source == BarPriceSource::LAST) {
+                callback(BarHistoryApiResult::fail(
+                    "Intrade FX bar history supports only BID, ASK, or MID price sources."));
+                return;
+            }
+            if (effective_request.timeframe % time_shield::SEC_PER_MIN != 0) {
+                callback(BarHistoryApiResult::fail(
+                    "Intrade FX bar history supports minute-based timeframes only."));
+                return;
+            }
+        }
+
+        auto chunks = build_bar_history_chunks(
+            effective_request.from_ts,
+            effective_request.to_ts,
+            effective_request.timeframe,
+            max_bars_per_request);
+
+        struct BarHistoryState {
+            BarHistoryRequest request;
+            std::vector<BarHistoryChunk> chunks;
+            std::string binance_interval;
+            BarSequence sequence;
+            std::size_t next_index = 0;
+            long last_status = BarHistoryApiResult::NO_HTTP_STATUS;
+            bool use_binance = false;
+            std::function<void(BarHistoryApiResult)> callback;
+        };
+
+        auto state = std::make_shared<BarHistoryState>();
+        state->request = effective_request;
+        state->chunks = std::move(chunks);
+        state->binance_interval = std::move(binance_interval);
+        state->use_binance = use_binance;
+        state->sequence = make_empty_sequence(
+            effective_request,
+            use_binance ? BarPriceSource::LAST : effective_request.price_source);
+        state->callback = std::move(callback);
+
+        auto finish_success = [state]() {
+            auto& bars = state->sequence.bars;
+            std::sort(bars.begin(), bars.end(), [](const Bar& lhs, const Bar& rhs) {
+                return lhs.time_ms < rhs.time_ms;
+            });
+            bars.erase(
+                std::unique(bars.begin(), bars.end(), [](const Bar& lhs, const Bar& rhs) {
+                    return lhs.time_ms == rhs.time_ms;
+                }),
+                bars.end());
+
+            state->callback(BarHistoryApiResult::ok(
+                BarHistory{std::move(state->sequence)},
+                state->last_status));
+        };
+
+        auto request_next = std::make_shared<std::function<void()>>();
+        *request_next = [this, state, request_next, finish_success]() {
+            if (state->next_index >= state->chunks.size()) {
+                finish_success();
+                return;
+            }
+
+            const auto chunk = state->chunks[state->next_index++];
+
+            std::future<kurlyk::HttpResponsePtr> future;
+            if (state->use_binance) {
+                kurlyk::QueryParams query = {
+                    {"symbol", state->request.symbol},
+                    {"interval", state->binance_interval},
+                    {"startTime", std::to_string(time_shield::sec_to_ms(chunk.from_ts))},
+                    {"endTime", std::to_string(time_shield::sec_to_ms(chunk.to_ts))},
+                    {"limit", std::to_string(BINANCE_KLINES_MAX_BARS_PER_REQUEST)}
+                };
+                future = m_binance_client.get(
+                    "/api/v3/klines",
+                    query,
+                    {{"Accept", "application/json"}},
+                    get_rate_limit(RateLimitType::TICK_DATA));
+            } else {
+                kurlyk::QueryParams query = {
+                    {"symbol", fx_history_query_symbol(state->request.symbol)},
+                    {"resolution", std::to_string(state->request.timeframe / time_shield::SEC_PER_MIN)},
+                    {"from", std::to_string(chunk.from_ts)},
+                    {"to", std::to_string(chunk.to_ts)}
+                };
+                future = get_http_client().get(
+                    "/fxhis/",
+                    query,
+                    {{"Accept", "application/json"}, {"Cookie", m_cookies}},
+                    get_rate_limit(RateLimitType::TICK_DATA));
+            }
+
+            auto response_callback = [state, request_next](
+                    kurlyk::HttpResponsePtr response) {
+                if (!validate_response(response)) {
+                    state->callback(BarHistoryApiResult::fail(
+                        "Bar history HTTP response failed validation.",
+                        response ? response->status_code : BarHistoryApiResult::NO_RESPONSE_STATUS));
+                    return;
+                }
+
+                state->last_status = response->status_code;
+                try {
+                    auto chunk_sequence = state->use_binance
+                        ? parse_binance_klines_bar_history(response->content, state->request)
+                        : parse_fxhis_bar_history(response->content, state->request);
+                    auto& target = state->sequence.bars;
+                    target.insert(
+                        target.end(),
+                        std::make_move_iterator(chunk_sequence.bars.begin()),
+                        std::make_move_iterator(chunk_sequence.bars.end()));
+                } catch (const std::exception& ex) {
+                    state->callback(BarHistoryApiResult::fail(
+                        std::string("Failed to parse bar history: ") + ex.what(),
+                        response->status_code));
+                    return;
+                }
+
+                (*request_next)();
+            };
+
+            add_http_request_task(std::move(future), std::move(response_callback));
+        };
+
+        (*request_next)();
     }
 
     inline void RequestManager::request_trade_check_result(

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -1871,7 +1871,7 @@ namespace optionx::platforms::intrade_bar {
         if (effective_request.from_ts > effective_request.to_ts) {
             const auto source = use_binance ? BarPriceSource::LAST : effective_request.price_source;
             callback(BarHistoryApiResult::ok(
-                BarHistory{make_empty_sequence(effective_request, source)}));
+                make_empty_sequence(effective_request, source)));
             return;
         }
 
@@ -1946,7 +1946,7 @@ namespace optionx::platforms::intrade_bar {
                 bars.end());
 
             state->callback(BarHistoryApiResult::ok(
-                BarHistory{std::move(state->sequence)},
+                std::move(state->sequence),
                 state->last_status));
         };
 
@@ -1972,7 +1972,7 @@ namespace optionx::platforms::intrade_bar {
                     "/api/v3/klines",
                     query,
                     {{"Accept", "application/json"}},
-                    get_rate_limit(RateLimitType::TICK_DATA));
+                    get_rate_limit(RateLimitType::BTC_BAR_HISTORY));
             } else {
                 kurlyk::QueryParams query = {
                     {"symbol", fx_history_query_symbol(state->request.symbol)},
@@ -1984,7 +1984,7 @@ namespace optionx::platforms::intrade_bar {
                     "/fxhis/",
                     query,
                     {{"Accept", "application/json"}, {"Cookie", m_cookies}},
-                    get_rate_limit(RateLimitType::TICK_DATA));
+                    get_rate_limit(RateLimitType::FX_BAR_HISTORY));
             }
 
             auto response_callback = [state, request_next](

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -20,6 +20,7 @@
 
 #include "utils/response_parse_utils.hpp"
 #include "ApiResponses.hpp"
+#include "http_utils.hpp"
 
 namespace optionx::platforms::intrade_bar {
 
@@ -1302,6 +1303,163 @@ namespace optionx::platforms::intrade_bar {
             result_callback(false, status_code,
                 0, 0, 0, "Exception while parsing trade response: " + std::string(ex.what()));
         }
+    }
+
+    namespace detail {
+
+        inline double read_json_double(
+                const nlohmann::json& value,
+                const char* field_name) {
+            if (value.is_number()) return value.get<double>();
+            if (value.is_string()) return std::stod(value.get<std::string>());
+            throw std::runtime_error(
+                std::string("Expected numeric value for ") + field_name + ".");
+        }
+
+        inline std::int64_t read_json_int64(
+                const nlohmann::json& value,
+                const char* field_name) {
+            if (value.is_number_integer()) return value.get<std::int64_t>();
+            if (value.is_number()) return static_cast<std::int64_t>(value.get<double>());
+            if (value.is_string()) return std::stoll(value.get<std::string>());
+            throw std::runtime_error(
+                std::string("Expected integer value for ") + field_name + ".");
+        }
+
+        inline double select_fx_history_price(
+                double bid,
+                double ask,
+                BarPriceSource source) {
+            switch (source) {
+            case BarPriceSource::BID:
+                return bid;
+            case BarPriceSource::ASK:
+                return ask;
+            case BarPriceSource::MID:
+                return (bid + ask) / 2.0;
+            case BarPriceSource::UNKNOWN:
+            case BarPriceSource::LAST:
+            default:
+                throw std::runtime_error("Unsupported Intrade FX bar price source.");
+            }
+        }
+
+        inline BarSequence make_empty_bar_sequence(
+                const BarHistoryRequest& request,
+                BarPriceSource actual_source) {
+            BarSequence sequence;
+            sequence.symbol = normalize_symbol_name(request.symbol);
+            sequence.provider = to_str(PlatformType::INTRADE_BAR);
+            sequence.timeframe = static_cast<std::uint16_t>(request.timeframe);
+            sequence.flags =
+                static_cast<std::uint16_t>(dfh::BarStatusFlags::HISTORICAL) |
+                static_cast<std::uint16_t>(dfh::BarStatusFlags::FINALIZED);
+            sequence.price_digits = price_digits_for_symbol(sequence.symbol);
+            sequence.volume_digits = 0;
+            sequence.price_source = actual_source;
+            return sequence;
+        }
+
+    } // namespace detail
+
+    /// \brief Parses the Intrade `/fxhis` response into a normalized bar sequence.
+    /// \param content Raw JSON response body.
+    /// \param request Original bar history request.
+    /// \return Parsed bar sequence using the requested BID/ASK/MID price stream.
+    /// \throws std::runtime_error When the payload is malformed or broker rejected the request.
+    inline BarSequence parse_fxhis_bar_history(
+            const std::string& content,
+            const BarHistoryRequest& request) {
+        if (request.price_source == BarPriceSource::UNKNOWN ||
+            request.price_source == BarPriceSource::LAST) {
+            throw std::runtime_error("Intrade FX history supports only BID, ASK, or MID bars.");
+        }
+
+        const auto j = nlohmann::json::parse(content);
+        if (j.contains("response") && j["response"].is_object()) {
+            const auto& response = j["response"];
+            const bool executed = response.value("executed", false);
+            const std::string error = response.value("error", std::string());
+            if (!executed || !error.empty()) {
+                throw std::runtime_error(
+                    error.empty()
+                        ? "Intrade FX history request was rejected."
+                        : "Intrade FX history request was rejected: " + error);
+            }
+        }
+
+        if (!j.contains("candles") || !j["candles"].is_array()) {
+            throw std::runtime_error("Intrade FX history response does not contain a candles array.");
+        }
+
+        auto sequence = detail::make_empty_bar_sequence(request, request.price_source);
+        const auto& candles = j["candles"];
+        sequence.bars.reserve(candles.size());
+
+        for (const auto& item : candles) {
+            if (!item.is_array() || item.size() < 10) {
+                throw std::runtime_error("Malformed Intrade FX history candle.");
+            }
+
+            const auto ts = detail::read_json_int64(item.at(0), "time");
+            const auto bid_open = detail::read_json_double(item.at(1), "bid_open");
+            const auto bid_close = detail::read_json_double(item.at(2), "bid_close");
+            const auto bid_high = detail::read_json_double(item.at(3), "bid_high");
+            const auto bid_low = detail::read_json_double(item.at(4), "bid_low");
+            const auto ask_open = detail::read_json_double(item.at(5), "ask_open");
+            const auto ask_close = detail::read_json_double(item.at(6), "ask_close");
+            const auto ask_high = detail::read_json_double(item.at(7), "ask_high");
+            const auto ask_low = detail::read_json_double(item.at(8), "ask_low");
+            const auto volume = detail::read_json_double(item.at(9), "volume");
+
+            sequence.bars.emplace_back(
+                detail::select_fx_history_price(bid_open, ask_open, request.price_source),
+                detail::select_fx_history_price(bid_high, ask_high, request.price_source),
+                detail::select_fx_history_price(bid_low, ask_low, request.price_source),
+                detail::select_fx_history_price(bid_close, ask_close, request.price_source),
+                volume,
+                static_cast<std::uint64_t>(time_shield::sec_to_ms(ts)));
+        }
+
+        return sequence;
+    }
+
+    /// \brief Parses Binance klines into BTCUSDT historical bars.
+    /// \param content Raw Binance JSON array.
+    /// \param request Original bar history request.
+    /// \return Parsed bar sequence using LAST trade prices.
+    /// \throws std::runtime_error When the payload is malformed.
+    inline BarSequence parse_binance_klines_bar_history(
+            const std::string& content,
+            const BarHistoryRequest& request) {
+        if (request.price_source == BarPriceSource::BID ||
+            request.price_source == BarPriceSource::ASK) {
+            throw std::runtime_error("Binance kline history does not provide bid/ask bars.");
+        }
+
+        const auto j = nlohmann::json::parse(content);
+        if (!j.is_array()) {
+            throw std::runtime_error("Binance kline response is not an array.");
+        }
+
+        auto sequence = detail::make_empty_bar_sequence(request, BarPriceSource::LAST);
+        sequence.bars.reserve(j.size());
+
+        for (const auto& item : j) {
+            if (!item.is_array() || item.size() < 6) {
+                throw std::runtime_error("Malformed Binance kline entry.");
+            }
+
+            sequence.bars.emplace_back(
+                detail::read_json_double(item.at(1), "open"),
+                detail::read_json_double(item.at(2), "high"),
+                detail::read_json_double(item.at(3), "low"),
+                detail::read_json_double(item.at(4), "close"),
+                detail::read_json_double(item.at(5), "volume"),
+                static_cast<std::uint64_t>(detail::read_json_int64(item.at(0), "open_time")));
+        }
+
+        return sequence;
     }
 
     /// \brief Parses a BTCUSDT tick message from the WebSocket and updates the provided SingleTick structure.

--- a/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
+++ b/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
@@ -14,6 +14,7 @@ namespace optionx::platforms {
         using trade_result_callback_t = std::function<void(std::unique_ptr<TradeRequest>, std::unique_ptr<TradeResult>)>;
         using trade_result_check_callback_t = std::function<void(std::unique_ptr<TradeResult>)>;
         using trade_history_callback_t = std::function<void(TradeHistoryResult)>;
+        using bar_history_callback_t = std::function<void(BarHistoryResult)>;
         using trade_id_provider_t = std::function<std::uint32_t()>;
         using bars_callback_t  = std::function<void(const std::vector<SingleBar>&)>;
         using ticks_callback_t = std::function<void(const std::vector<SingleTick>&)>;
@@ -99,10 +100,10 @@ namespace optionx::platforms {
 
         /// \brief Requests historical candle data for a specified time range.
         /// \param request Historical candle data request parameters.
-        /// \param callback Callback function to receive the candle data.
+        /// \param callback Callback function to receive bars or a failure reason.
         virtual bool fetch_candle_data(
             const BarHistoryRequest& request,
-            std::function<void(const BarSequence&)> callback) { return false; };
+            bar_history_callback_t callback) { return false; };
 
         /// \brief Requests the list of available trading symbols.
         /// \param callback Callback function to receive the symbol list.

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -892,6 +892,35 @@ TEST(IntradeBarApiResponses, ParsesBinanceKlinesAsLastPriceBars) {
     EXPECT_DOUBLE_EQ(sequence.bars[0].volume, 0.25);
 }
 
+TEST(IntradeBarApiResponses, UsesKnownBarHistoryStartLimits) {
+    EXPECT_EQ(minimum_bar_history_from_ts("EUR/USD"), 1007337600);
+    EXPECT_EQ(minimum_bar_history_from_ts("NZDUSD"), 1007424000);
+    EXPECT_EQ(minimum_bar_history_from_ts("AUDCAD"), 1059523200);
+    EXPECT_EQ(minimum_bar_history_from_ts("BTCUSDT"), 1502942400);
+    EXPECT_EQ(minimum_bar_history_from_ts("UNKNOWN"), 0);
+}
+
+TEST(IntradeBarApiResponses, PlatformBarHistoryResultPreservesFailureReason) {
+    IntradeBarPlatform platform;
+    BarHistoryResult result;
+    int callback_count = 0;
+
+    EXPECT_TRUE(platform.fetch_candle_data(
+        BarHistoryRequest("", time_shield::SEC_PER_MIN, 1000, 2000),
+        [&result, &callback_count](BarHistoryResult history_result) {
+            result = std::move(history_result);
+            ++callback_count;
+        }));
+
+    platform.shutdown();
+
+    ASSERT_EQ(callback_count, 1);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status_code, BarHistoryResult::NO_RESPONSE_STATUS);
+    EXPECT_NE(result.error_desc.find("symbol"), std::string::npos);
+    EXPECT_TRUE(result.sequence.bars.empty());
+}
+
 TEST(IntradeBarApiResponses, SplitsFxHisBarHistoryIntoSequentialRequests) {
     const std::int64_t first_ts = 1782980700;
     const std::int64_t second_ts =
@@ -915,11 +944,11 @@ TEST(IntradeBarApiResponses, SplitsFxHisBarHistoryIntoSequentialRequests) {
     ASSERT_EQ(call.callback_count, 1);
     ASSERT_TRUE(call.result);
     EXPECT_EQ(server.fxhis_requests.load(), 2);
-    ASSERT_EQ(call.result.value.sequence.bars.size(), 2u);
-    EXPECT_EQ(call.result.value.sequence.symbol, "NZDUSD");
-    EXPECT_EQ(call.result.value.sequence.price_source, BarPriceSource::MID);
-    EXPECT_EQ(call.result.value.sequence.bars[0].time_ms, time_shield::sec_to_ms(first_ts));
-    EXPECT_EQ(call.result.value.sequence.bars[1].time_ms, time_shield::sec_to_ms(second_ts));
+    ASSERT_EQ(call.result.value.bars.size(), 2u);
+    EXPECT_EQ(call.result.value.symbol, "NZDUSD");
+    EXPECT_EQ(call.result.value.price_source, BarPriceSource::MID);
+    EXPECT_EQ(call.result.value.bars[0].time_ms, time_shield::sec_to_ms(first_ts));
+    EXPECT_EQ(call.result.value.bars[1].time_ms, time_shield::sec_to_ms(second_ts));
 }
 
 TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsHtmlFailureStatus) {

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1,11 +1,16 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <server_http.hpp>
 
@@ -165,6 +170,97 @@ struct CombinedHistoryTestResult {
     bool callback_received = false;
 };
 
+struct BarHistoryTestResult {
+    BarHistoryApiResult result;
+    int callback_count = 0;
+    bool callback_received = false;
+};
+
+struct LocalBarHistoryServer {
+    explicit LocalBarHistoryServer(std::vector<std::string> response_bodies)
+        : bodies(std::move(response_bodies)) {}
+
+    ~LocalBarHistoryServer() {
+        stop();
+    }
+
+    bool start() {
+        server.config.address = "127.0.0.1";
+        server.config.port = 0;
+
+        server.resource["^/health$"]["GET"] = [](
+                std::shared_ptr<TradeHistoryHttpServer::Response> response,
+                std::shared_ptr<TradeHistoryHttpServer::Request>) {
+            response->write(SimpleWeb::StatusCode::success_ok, "ok");
+        };
+
+        server.resource["^/fxhis/?$"]["GET"] = [this](
+                std::shared_ptr<TradeHistoryHttpServer::Response> response,
+                std::shared_ptr<TradeHistoryHttpServer::Request> request) {
+            const auto index = fxhis_requests.fetch_add(1);
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                queries.push_back(request->query_string);
+            }
+
+            const auto body_index =
+                static_cast<std::size_t>(std::min<int>(
+                    index,
+                    static_cast<int>(bodies.size()) - 1));
+            response->write(SimpleWeb::StatusCode::success_ok, bodies[body_index]);
+        };
+
+        thread = std::thread([this]() {
+            server.start();
+        });
+
+        if (!wait_until_ready()) {
+            stop();
+            return false;
+        }
+        return true;
+    }
+
+    void stop() {
+        server.stop();
+        if (thread.joinable()) thread.join();
+    }
+
+    std::string host() const {
+        return "http://127.0.0.1:" + std::to_string(server.bound_port());
+    }
+
+    bool wait_until_ready() const {
+        for (int i = 0; i < 100; ++i) {
+            if (server.bound_port() == 0) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                continue;
+            }
+
+            try {
+                kurlyk::HttpClient client(host());
+                client.set_timeout(1);
+                client.set_connect_timeout(1);
+                auto future = client.get("/health", {}, {});
+                if (future.wait_for(std::chrono::seconds(1)) == std::future_status::ready) {
+                    auto response = future.get();
+                    if (response && response->status_code == 200) return true;
+                }
+            } catch (...) {
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+        return false;
+    }
+
+    BoundPortHttpServer server;
+    std::thread thread;
+    std::vector<std::string> bodies;
+    std::atomic<int> fxhis_requests{0};
+    mutable std::mutex mutex;
+    std::vector<std::string> queries;
+};
+
 std::string valid_trade_history_csv() {
     return
         "id;Type;Asset;Direction;Open;Close;Open quote;Close quote;Amount;Result\n"
@@ -184,6 +280,29 @@ std::string empty_trade_history_html() {
             </div>
         </div>
     )HTML";
+}
+
+std::string fxhis_response(std::int64_t timestamp, double bid_open = 0.56880) {
+    const double bid_close = bid_open - 0.00005;
+    const double bid_high = bid_open + 0.00010;
+    const double bid_low = bid_open - 0.00011;
+    const double ask_open = bid_open + 0.00003;
+    const double ask_close = bid_close + 0.00001;
+    const double ask_high = bid_high + 0.00003;
+    const double ask_low = bid_low + 0.00003;
+
+    std::ostringstream out;
+    out << R"({"response":{"error":"","executed":true},"instrument_id":"NZD\/USD","period_id":"m1","candles":[[)"
+        << timestamp << ','
+        << bid_open << ','
+        << bid_close << ','
+        << bid_high << ','
+        << bid_low << ','
+        << ask_open << ','
+        << ask_close << ','
+        << ask_high << ','
+        << ask_low << ",104]]}";
+    return out.str();
 }
 
 CombinedHistoryTestResult request_trade_history(
@@ -212,6 +331,49 @@ CombinedHistoryTestResult request_trade_history(
         account_type,
         [&call, &callback_count](TradeHistoryApiResult history_result) {
             call.result = std::move(history_result);
+            ++callback_count;
+        });
+
+    for (int i = 0; i < 500; ++i) {
+        http_client.process();
+        if (callback_count.load() != 0) {
+            call.callback_received = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    for (int i = 0; i < 20; ++i) {
+        http_client.process();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    call.callback_count = callback_count.load();
+    platform.shutdown();
+    return call;
+}
+
+BarHistoryTestResult request_bar_history(
+        LocalBarHistoryServer& server,
+        BarHistoryRequest request) {
+    TestPlatform platform;
+    HttpClientComponent http_client(platform);
+    RequestManager request_manager(platform, http_client);
+
+    auto auth_data = std::make_shared<AuthData>();
+    auth_data->host = server.host();
+
+    events::AuthDataEvent auth_event(auth_data);
+    request_manager.on_event(&auth_event);
+    http_client.get_http_client().set_retry_attempts(0, 0);
+
+    BarHistoryTestResult call;
+    std::atomic<int> callback_count{0};
+
+    request_manager.request_bar_history_result(
+        request,
+        [&call, &callback_count](BarHistoryApiResult result) {
+            call.result = std::move(result);
             ++callback_count;
         });
 
@@ -657,6 +819,107 @@ TEST(IntradeBarApiResponses, CombinedTradeHistoryStatusPrefersFailedSource) {
     EXPECT_EQ(select_combined_trade_history_status(false, -1, false, -2), -1);
     EXPECT_EQ(select_combined_trade_history_status(false, 500, false, 451), 500);
     EXPECT_EQ(select_combined_trade_history_status(true, 200, true, 200), 200);
+}
+
+TEST(IntradeBarApiResponses, ParsesFxHisBidAskAndMidBars) {
+    BarHistoryRequest request("NZDUSD", 60, 1782980700, 1782980700);
+    request.price_source = BarPriceSource::MID;
+
+    const auto mid_sequence = parse_fxhis_bar_history(
+        fxhis_response(1782980700),
+        request);
+
+    ASSERT_EQ(mid_sequence.bars.size(), 1u);
+    EXPECT_EQ(mid_sequence.symbol, "NZDUSD");
+    EXPECT_EQ(mid_sequence.provider, to_str(PlatformType::INTRADE_BAR));
+    EXPECT_EQ(mid_sequence.price_source, BarPriceSource::MID);
+    EXPECT_EQ(mid_sequence.bars[0].time_ms, 1782980700000ull);
+    EXPECT_DOUBLE_EQ(mid_sequence.bars[0].open, (0.56880 + 0.56883) / 2.0);
+    EXPECT_DOUBLE_EQ(mid_sequence.bars[0].high, (0.56890 + 0.56893) / 2.0);
+    EXPECT_DOUBLE_EQ(mid_sequence.bars[0].low, (0.56869 + 0.56872) / 2.0);
+    EXPECT_DOUBLE_EQ(mid_sequence.bars[0].close, (0.56875 + 0.56876) / 2.0);
+    EXPECT_DOUBLE_EQ(mid_sequence.bars[0].volume, 104.0);
+
+    request.price_source = BarPriceSource::BID;
+    const auto bid_sequence = parse_fxhis_bar_history(
+        fxhis_response(1782980700),
+        request);
+    ASSERT_EQ(bid_sequence.bars.size(), 1u);
+    EXPECT_EQ(bid_sequence.price_source, BarPriceSource::BID);
+    EXPECT_DOUBLE_EQ(bid_sequence.bars[0].open, 0.56880);
+    EXPECT_DOUBLE_EQ(bid_sequence.bars[0].high, 0.56890);
+    EXPECT_DOUBLE_EQ(bid_sequence.bars[0].low, 0.56869);
+    EXPECT_DOUBLE_EQ(bid_sequence.bars[0].close, 0.56875);
+
+    request.price_source = BarPriceSource::ASK;
+    const auto ask_sequence = parse_fxhis_bar_history(
+        fxhis_response(1782980700),
+        request);
+    ASSERT_EQ(ask_sequence.bars.size(), 1u);
+    EXPECT_EQ(ask_sequence.price_source, BarPriceSource::ASK);
+    EXPECT_DOUBLE_EQ(ask_sequence.bars[0].open, 0.56883);
+    EXPECT_DOUBLE_EQ(ask_sequence.bars[0].high, 0.56893);
+    EXPECT_DOUBLE_EQ(ask_sequence.bars[0].low, 0.56872);
+    EXPECT_DOUBLE_EQ(ask_sequence.bars[0].close, 0.56876);
+}
+
+TEST(IntradeBarApiResponses, RejectsFxHisLastPriceSource) {
+    BarHistoryRequest request("NZDUSD", 60, 1782980700, 1782980700);
+    request.price_source = BarPriceSource::LAST;
+
+    EXPECT_THROW(
+        parse_fxhis_bar_history(fxhis_response(1782980700), request),
+        std::runtime_error);
+}
+
+TEST(IntradeBarApiResponses, ParsesBinanceKlinesAsLastPriceBars) {
+    const std::string payload =
+        R"([[1783016040000,"61521.34","61530.00","61500.00","61510.00","0.25",1783016099999]])";
+
+    BarHistoryRequest request("BTCUSDT", 60, 1783016040, 1783016040);
+    request.price_source = BarPriceSource::MID;
+
+    const auto sequence = parse_binance_klines_bar_history(payload, request);
+
+    ASSERT_EQ(sequence.bars.size(), 1u);
+    EXPECT_EQ(sequence.symbol, "BTCUSDT");
+    EXPECT_EQ(sequence.price_source, BarPriceSource::LAST);
+    EXPECT_EQ(sequence.bars[0].time_ms, 1783016040000ull);
+    EXPECT_DOUBLE_EQ(sequence.bars[0].open, 61521.34);
+    EXPECT_DOUBLE_EQ(sequence.bars[0].high, 61530.00);
+    EXPECT_DOUBLE_EQ(sequence.bars[0].low, 61500.00);
+    EXPECT_DOUBLE_EQ(sequence.bars[0].close, 61510.00);
+    EXPECT_DOUBLE_EQ(sequence.bars[0].volume, 0.25);
+}
+
+TEST(IntradeBarApiResponses, SplitsFxHisBarHistoryIntoSequentialRequests) {
+    const std::int64_t first_ts = 1782980700;
+    const std::int64_t second_ts =
+        first_ts + FX_HISTORY_MAX_BARS_PER_REQUEST * time_shield::SEC_PER_MIN;
+
+    LocalBarHistoryServer server({
+        fxhis_response(first_ts, 0.56880),
+        fxhis_response(second_ts, 0.57000)
+    });
+    ASSERT_TRUE(server.start());
+
+    const BarHistoryRequest request(
+        "NZD/USD",
+        time_shield::SEC_PER_MIN,
+        first_ts,
+        second_ts);
+
+    const auto call = request_bar_history(server, request);
+
+    ASSERT_TRUE(call.callback_received);
+    ASSERT_EQ(call.callback_count, 1);
+    ASSERT_TRUE(call.result);
+    EXPECT_EQ(server.fxhis_requests.load(), 2);
+    ASSERT_EQ(call.result.value.sequence.bars.size(), 2u);
+    EXPECT_EQ(call.result.value.sequence.symbol, "NZDUSD");
+    EXPECT_EQ(call.result.value.sequence.price_source, BarPriceSource::MID);
+    EXPECT_EQ(call.result.value.sequence.bars[0].time_ms, time_shield::sec_to_ms(first_ts));
+    EXPECT_EQ(call.result.value.sequence.bars[1].time_ms, time_shield::sec_to_ms(second_ts));
 }
 
 TEST(IntradeBarApiResponses, CombinedTradeHistoryRequestReportsHtmlFailureStatus) {


### PR DESCRIPTION
## What Changed

- Added a typed Intrade Bar bar-history request flow through `RequestManager::request_bar_history_result()`.
- Added public `BarHistoryResult` so `BaseTradingPlatform::fetch_candle_data()` can report transport/parser failures instead of collapsing them into an empty `BarSequence`.
- Added FX `/fxhis` parsing for BID, ASK, and MID OHLC bars.
- Added BTCUSDT historical bar support through Binance `/api/v3/klines`, returning actual `LAST` trade-price bars.
- Added backend-specific range slicing so large history windows are requested sequentially without duplicated bar timestamps.
- Added separate conservative rate-limit buckets for Intrade FX history and Binance BTCUSDT history requests.
- Added known per-symbol FX history lower bounds from the old Intrade historical dataset, plus the BTCUSDT Binance lower bound.
- Added regression tests for FX field mapping, unsupported FX `LAST`, Binance kline parsing, public failure reporting, known history lower bounds, and multi-request FX range splitting.

## Notes

`BarHistoryUtils.hpp` centralizes backend limits and earliest known history timestamps. FX dates come from the old `intrade-bar-historical-data` dataset and are used as lower-bound clamps; several representative live probes still returned data at those boundaries.

Binance documents `/api/v3/klines` with `limit` max `1000` and request weight `2`, but this PR keeps a conservative one-request-per-second history throttle until the broader market-data architecture is split into dedicated data-feed components.

## Validation

- `git diff --check`
- `cmake --build build-codex --target intrade_bar_api_response_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe` - 47/47 passed
- `cmake --build build-codex --target header_only_odr_test -j 4`
- `./build-codex/header_only_odr_test.exe` - 4/4 passed
