### PR TITLE
[codex] Add market data subscription contract

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Run legacy_trading_bridge_test
         run: ./build-linux/legacy_trading_bridge_test --gtest_brief=1
 
+      - name: Build market_data_subscription_contract_test
+        run: cmake --build build-linux --target market_data_subscription_contract_test -j
+
+      - name: Run market_data_subscription_contract_test
+        run: ./build-linux/market_data_subscription_contract_test --gtest_brief=1
+
       - name: Configure submodule consumer
         run: cmake -S tests/cmake/submodule_consumer -B build-submodule-consumer
 

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -15,6 +15,7 @@
 ```cpp
 #include <optionx_cpp/optionx.hpp>
 #include <optionx_cpp/data.hpp>
+#include <optionx_cpp/market_data.hpp>
 #include <optionx_cpp/platforms.hpp>
 #include <optionx_cpp/platforms/IntradeBarPlatform.hpp>
 ```
@@ -32,9 +33,9 @@
 
 - Не используй `../` в `#include`.
 - Не используй `"optionx_cpp/..."` внутри `include/optionx_cpp`.
-- Public aggregate headers (`optionx.hpp`, `data.hpp`, `platforms.hpp`,
-  `storages.hpp`, `components.hpp`, `utils.hpp`, `bridges.hpp`) задают публичные
-  точки подключения.
+- Public aggregate headers (`optionx.hpp`, `data.hpp`, `market_data.hpp`,
+  `platforms.hpp`, `storages.hpp`, `components.hpp`, `utils.hpp`,
+  `bridges.hpp`) задают публичные точки подключения.
 - Domain aggregates, например `data/trading.hpp`, задают include context для
   связанных leaf headers.
 - Leaf DTO headers не должны вручную восстанавливать весь порядок зависимостей
@@ -85,6 +86,39 @@ Managers (`AuthManager`, `RequestManager`, `TradeManager`, `BalanceManager`,
 etc.) являются implementation detail конкретной платформы. Новый user-facing
 метод сначала должен появиться на facade/base contract, а затем делегироваться
 в manager.
+
+## Market Data Contract
+
+Market-data APIs are split into DTO/data types and a provider role:
+
+- `data/bars/*`, `data/ticks/*`, `data/symbol/*` contain payload DTOs such as
+  `SingleBar`, `BarSequence`, `SingleTick`, `TickSequence` and
+  `BarHistoryRequest`.
+- `market_data.hpp` exposes the provider role and subscription contract:
+  `BaseMarketDataProvider`, `TickSubscriptionRequest`,
+  `BarSubscriptionRequest`, `MarketDataSubscriptionHandle` and
+  `MarketDataSubscriptionResult`.
+
+Contract rules:
+
+- `BarTimeframe` is a signed 32-bit value in seconds. Values less than or equal
+  to zero are invalid in requests.
+- Live tick and live bar subscriptions use separate request types because the
+  payloads and validation rules differ.
+- `MarketDataSubscriptionResult::status` is the source of truth. There is no
+  separate mutable `success` field; use `result.success()` or `if (result)`.
+- Subscription handles are provider-bound. `provider_id` is a runtime identity
+  of a concrete provider object, and `unsubscribe()` must reject handles from
+  another provider with `WRONG_PROVIDER`.
+- A provider object is intentionally non-copyable and non-movable, because
+  copying it would duplicate runtime identity and make existing handles
+  ambiguous.
+- A broker implementation may maintain price polling or websocket connections
+  even when no public subscription exists, because trading logic can also need
+  current prices. Public subscriptions are the routing contract for external
+  consumers, not necessarily the only source lifecycle.
+- Historical bars use `BarHistoryResult` so callers can distinguish an empty
+  successful range from transport, validation or parser failures.
 
 ## Typed Broker Result Pattern
 

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -8,6 +8,7 @@
 | Нужно сделать | Используй | Не начинай с |
 |---|---|---|
 | Подключить торговую платформу в приложении | `platforms::IntradeBarPlatform` или `BaseTradingPlatform` API | Platform-specific managers |
+| Получать market data | `market_data::BaseMarketDataProvider` API | Прямой доступ к price managers |
 | Добавить новый broker flow | Новый `BaseTradingPlatform` descendant + managers | Большой manager со всей логикой сразу |
 | Отправить сделку | `BaseTradingPlatform::place_trade(std::unique_ptr<TradeRequest>)` | Прямое создание `TradeTransactionEvent` из application code |
 | Подписаться на результат сделки | `on_trade_result()` callback или event flow | Polling internal queue |
@@ -56,6 +57,41 @@
 - Callbacks `on_trade_result`, `on_candle_data`, `on_tick_data` в base
   возвращают static null callback; concrete class/component должен дать рабочую
   callback-ссылку, если feature поддерживается.
+
+## `market_data::BaseMarketDataProvider`
+
+Файл: `include/optionx_cpp/market_data/BaseMarketDataProvider.hpp`.
+
+Роль: public role для endpoints, которые умеют отдавать live ticks, live bars
+или historical bars. Торговая платформа может одновременно наследоваться от
+`BaseTradingPlatform` и `BaseMarketDataProvider`, но market-data contract
+остается отдельным: его можно реализовать и у источника котировок без торговых
+операций.
+
+Основные методы:
+
+| Метод | Для чего | Ограничения |
+|---|---|---|
+| `on_tick_data()` | Callback для live tick batches | По умолчанию возвращает null callback |
+| `on_bar_data()` | Callback для live bar batches | По умолчанию возвращает null callback |
+| `subscribe_ticks(request, callback)` | Запросить live tick stream | Request type отдельный от bars |
+| `subscribe_bars(request, callback)` | Запросить live bar stream | `timeframe` в секундах и должен быть > 0 |
+| `unsubscribe(handle, callback)` | Остановить live stream | Handle должен принадлежать этому provider instance |
+| `fetch_bar_history(request, callback)` | Запросить исторические бары | Возвращает `BarHistoryResult`, а не пустой массив при ошибке |
+
+Subscription rules:
+
+- `ProviderInstanceId` and `SubscriptionId` are runtime IDs, not storage IDs.
+- `MarketDataSubscriptionHandle` is valid only for the provider instance that
+  created it. This prevents unsubscribing from a different provider object by
+  accident.
+- `MarketDataSubscriptionResult::status` is the source of truth. Use
+  `result.success()` or `if (result)`.
+- `BaseMarketDataProvider` is non-copyable and non-movable so provider identity
+  cannot be duplicated after handles were issued.
+- Public subscriptions describe consumer routing. Internal platform polling or
+  websocket feeds may still run for trade lifecycle needs even when there are
+  no public subscribers.
 
 ## Concrete Platforms
 

--- a/guides/project-overview.md
+++ b/guides/project-overview.md
@@ -30,6 +30,7 @@ broker API и bridges. Основной сценарий: пользовател
 | `optionx_cpp/utils.hpp` | Pub-sub, tasks, crypto, strings, time, ids | Для инфраструктурного кода и новых components |
 | `optionx_cpp/data.hpp` | DTO, events, enums, account/symbol/tick/bar/trading data | Для API boundary и сообщений |
 | `optionx_cpp/components.hpp` | `BaseComponent`, HTTP и trade execution base classes | Для нового manager/component |
+| `optionx_cpp/market_data.hpp` | Market-data provider role, subscription DTOs and statuses | Для live tick/bar subscriptions и history API contracts |
 | `optionx_cpp/platforms.hpp` | Base platform и Intrade Bar platform | Для клиентского кода платформ |
 | `optionx_cpp/storages.hpp` | `ServiceSessionDB` | Для session storage |
 | `optionx_cpp/bridges.hpp` | `BaseBridge` | Для внешних bridge integrations |
@@ -44,7 +45,7 @@ broker API и bridges. Основной сценарий: пользовател
 | Platform facade | `optionx::platforms`, `include/optionx_cpp/platforms` | Публичный API платформы: connect, auth, trades, account info |
 | Components/managers | `optionx::components`, platform subnamespaces | Lifecycle-компоненты, которые получают events и выполняют работу |
 | Trading data | `optionx`, `include/optionx_cpp/data/trading` | `TradeRequest`, `TradeResult`, enums, signals |
-| Market data | `include/optionx_cpp/data/bars`, `ticks`, `symbol` | Свечи, тики, symbols, history requests |
+| Market data | `optionx::market_data`, `include/optionx_cpp/market_data`, `data/bars`, `data/ticks`, `data/symbol` | Live subscriptions, history requests/results, ticks, bars and symbols |
 | Events | `optionx::events`, `include/optionx_cpp/data/events` | Pub-sub контракты между components |
 | Infrastructure | `optionx::utils` | EventBus, tasks, crypto, ids, HTTP helpers |
 | Storage | `optionx::storage` | AES + mdbx session storage |
@@ -67,7 +68,12 @@ broker API и bridges. Основной сценарий: пользовател
    `TradeStateManager`.
 6. `fetch_trade_result()` и `fetch_trade_history()` у конкретной платформы
    делегируются в platform managers и возвращают DTO через callbacks.
-7. `shutdown()` останавливает tasks, вызывает shutdown у components, затем
+7. Market-data entry points (`fetch_bar_history`, `subscribe_ticks`,
+   `subscribe_bars`, `unsubscribe`) are exposed by `BaseMarketDataProvider`
+   implementations. Concrete platforms may use HTTP polling, websockets, or
+   both internally; public subscription results are reported through typed
+   callbacks.
+8. `shutdown()` останавливает tasks, вызывает shutdown у components, затем
    draining event bus.
 
 ## Реальные Платформы
@@ -89,7 +95,7 @@ DTO и events обычно открытые классы/структуры с p
 
 - `data/trading/TradeRequest.hpp`
 - `data/trading/TradeResult.hpp`
-- `data/bars/Bar.hpp`, `BarData.hpp`, `BarSequence.hpp`
+- `data/bars/Bar.hpp`, `SingleBar.hpp`, `BarSequence.hpp`
 - `data/ticks/Tick.hpp`, `TickData.hpp`
 - `data/account/BaseAccountInfoData.hpp`
 - `data/events/TradeRequestEvent.hpp`

--- a/include/optionx_cpp/data/bars.hpp
+++ b/include/optionx_cpp/data/bars.hpp
@@ -5,6 +5,7 @@
 /// \file bars.hpp
 /// \brief
 
+#include "bars/types.hpp"
 #include "bars/enums.hpp"
 #include "bars/Bar.hpp"
 #include "bars/flags.hpp"

--- a/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
+++ b/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
@@ -15,7 +15,7 @@ namespace optionx {
     class BarHistoryRequest {
     public:
         std::string symbol;    ///< The symbol for which the historical data is requested.
-        int64_t timeframe = 0; ///< Timeframe of the requested data in seconds.
+        BarTimeframe timeframe = 0; ///< Timeframe of the requested data in seconds.
         int64_t from_ts = 0;   ///< Start timestamp (Unix time) for the requested data range.
         int64_t to_ts = 0;     ///< End timestamp (Unix time) for the requested data range.
         BarPriceSource price_source = BarPriceSource::MID; ///< Requested price stream for OHLC values.
@@ -31,7 +31,7 @@ namespace optionx {
         /// \param price_source Requested price stream for OHLC values.
         BarHistoryRequest(
             const std::string& symbol,
-            int64_t timeframe,
+            BarTimeframe timeframe,
             int64_t from_ts,
             int64_t to_ts,
             BarPriceSource price_source = BarPriceSource::MID

--- a/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
+++ b/include/optionx_cpp/data/bars/BarHistoryRequest.hpp
@@ -3,7 +3,7 @@
 #define _OPTIONX_BAR_HISTORY_REQUEST_HPP_INCLUDED
 
 /// \file BarHistoryRequest.hpp
-/// \brief Contains the CandleHistoryRequest class for requesting historical candlestick data.
+/// \brief Contains the BarHistoryRequest class for requesting historical bar data.
 
 #include <cstdint>
 #include <string>
@@ -11,11 +11,11 @@
 namespace optionx {
 
     /// \class BarHistoryRequest
-    /// \brief Represents a request for historical candlestick data over a specified time range.
+    /// \brief Represents a request for historical bar data over a specified time range.
     class BarHistoryRequest {
     public:
         std::string symbol;    ///< The symbol for which the historical data is requested.
-        BarTimeframe timeframe = 0; ///< Timeframe of the requested data in seconds.
+        BarTimeframe timeframe = 0; ///< Requested bar timeframe in seconds; values <= 0 are invalid.
         int64_t from_ts = 0;   ///< Start timestamp (Unix time) for the requested data range.
         int64_t to_ts = 0;     ///< End timestamp (Unix time) for the requested data range.
         BarPriceSource price_source = BarPriceSource::MID; ///< Requested price stream for OHLC values.
@@ -25,7 +25,7 @@ namespace optionx {
 
         /// \brief Constructs a BarHistoryRequest with all parameters.
         /// \param symbol The symbol for the data.
-        /// \param timeframe Timeframe in seconds for each candlestick.
+        /// \param timeframe Timeframe in seconds for each bar.
         /// \param from_ts Start timestamp for data retrieval.
         /// \param to_ts End timestamp for data retrieval.
         /// \param price_source Requested price stream for OHLC values.

--- a/include/optionx_cpp/data/bars/BarSequence.hpp
+++ b/include/optionx_cpp/data/bars/BarSequence.hpp
@@ -18,21 +18,21 @@ namespace optionx {
 		std::vector<Bar> bars;	///< Sequence of bar data of the specified type
         std::string symbol; 	///< Symbol
 		std::string provider;	///< Provider
-		uint16_t timeframe; 	///< Timeframe
+        BarTimeframe timeframe; ///< Bar timeframe in seconds.
 		uint16_t flags;         ///< Bar data flags (bitmask of BarUpdateFlags)
         uint16_t price_digits;  ///< Number of decimal places for price
         uint16_t volume_digits; ///< Number of decimal places for volume
         BarPriceSource price_source = BarPriceSource::MID; ///< Price stream used to build the OHLC values.
 
         /// \brief Default constructor initializes metadata fields to zero
-        BarSequence() : flags(0), price_digits(0), volume_digits(0) {}
+        BarSequence() : timeframe(0), flags(0), price_digits(0), volume_digits(0) {}
 
         /// \brief Constructor to initialize all fields
         BarSequence(
             std::vector<Bar> bs,
             std::string s,
             std::string p,
-            uint16_t tf,
+            BarTimeframe tf,
             uint16_t f,
             uint16_t d,
             uint16_t vd,

--- a/include/optionx_cpp/data/bars/BarSequence.hpp
+++ b/include/optionx_cpp/data/bars/BarSequence.hpp
@@ -3,7 +3,7 @@
 #define _OPTIONX_BAR_SEQUENCE_HPP_INCLUDED
 
 /// \file BarSequence.hpp
-/// \brief
+/// \brief Defines a normalized sequence of market bars with provider metadata.
 
 #include <cstdint>
 #include <vector>
@@ -13,21 +13,21 @@
 namespace optionx {
 
     /// \struct BarSequence
-    /// \brief Represents a sequence of market bars with additional metadata
+    /// \brief Represents an ordered sequence of OHLC market bars.
     struct BarSequence {
-		std::vector<Bar> bars;	///< Sequence of bar data of the specified type
-        std::string symbol; 	///< Symbol
-		std::string provider;	///< Provider
-        BarTimeframe timeframe; ///< Bar timeframe in seconds.
-		uint16_t flags;         ///< Bar data flags (bitmask of BarUpdateFlags)
-        uint16_t price_digits;  ///< Number of decimal places for price
-        uint16_t volume_digits; ///< Number of decimal places for volume
+		std::vector<Bar> bars;	///< Ordered bar payloads.
+        std::string symbol; 	///< Provider symbol.
+		std::string provider;	///< Provider name or source identifier.
+        BarTimeframe timeframe; ///< Bar timeframe in seconds; values <= 0 are invalid.
+		uint16_t flags;         ///< Bar data flags (bitmask of BarUpdateFlags).
+        uint16_t price_digits;  ///< Number of decimal places for price.
+        uint16_t volume_digits; ///< Number of decimal places for volume.
         BarPriceSource price_source = BarPriceSource::MID; ///< Price stream used to build the OHLC values.
 
-        /// \brief Default constructor initializes metadata fields to zero
+        /// \brief Default constructor initializes metadata fields to zero.
         BarSequence() : timeframe(0), flags(0), price_digits(0), volume_digits(0) {}
 
-        /// \brief Constructor to initialize all fields
+        /// \brief Constructs a bar sequence with all metadata fields.
         BarSequence(
             std::vector<Bar> bs,
             std::string s,

--- a/include/optionx_cpp/data/bars/SingleBar.hpp
+++ b/include/optionx_cpp/data/bars/SingleBar.hpp
@@ -17,7 +17,7 @@ namespace optionx {
         Bar bar;        		///< Bar data of the specified type
 		std::string symbol; 	///< Symbol
 		std::string provider;	///< Provider
-		uint16_t timeframe; 	///< Timeframe
+        BarTimeframe timeframe; ///< Bar timeframe in seconds.
 		uint16_t flags;     	///< Bar data flags (bitmask of BarUpdateFlags)
         uint16_t price_digits;  ///< Number of decimal places for price
         uint16_t volume_digits; ///< Number of decimal places for volume
@@ -29,7 +29,7 @@ namespace optionx {
             Bar b,
             std::string s,
             std::string p,
-            uint16_t tf,
+            BarTimeframe tf,
             uint16_t f,
             uint16_t d,
             uint16_t vd,

--- a/include/optionx_cpp/data/bars/SingleBar.hpp
+++ b/include/optionx_cpp/data/bars/SingleBar.hpp
@@ -3,7 +3,7 @@
 #define _OPTIONX_SINGLE_BAR_HPP_INCLUDED
 
 /// \file SingleBar.hpp
-/// \brief
+/// \brief Defines a normalized market bar with provider metadata.
 
 #include <cstdint>
 #include <string>
@@ -11,20 +11,20 @@
 
 namespace optionx {
 
-	/// \struct SingleBar
-    /// \brief Represents a market bar with additional metadata
+    /// \struct SingleBar
+    /// \brief Represents one OHLC market bar and the metadata needed to route it.
     struct SingleBar {
-        Bar bar;        		///< Bar data of the specified type
-		std::string symbol; 	///< Symbol
-		std::string provider;	///< Provider
-        BarTimeframe timeframe; ///< Bar timeframe in seconds.
-		uint16_t flags;     	///< Bar data flags (bitmask of BarUpdateFlags)
-        uint16_t price_digits;  ///< Number of decimal places for price
-        uint16_t volume_digits; ///< Number of decimal places for volume
+        Bar bar;        		///< OHLC bar payload.
+		std::string symbol; 	///< Provider symbol.
+		std::string provider;	///< Provider name or source identifier.
+        BarTimeframe timeframe; ///< Bar timeframe in seconds; values <= 0 are invalid.
+		uint16_t flags;     	///< Bar data flags (bitmask of BarUpdateFlags).
+        uint16_t price_digits;  ///< Number of decimal places for price.
+        uint16_t volume_digits; ///< Number of decimal places for volume.
         BarPriceSource price_source = BarPriceSource::MID; ///< Price stream used to build the OHLC values.
 
 
-        /// \brief Constructor to initialize all fields
+        /// \brief Constructs a single bar with all metadata fields.
         SingleBar(
             Bar b,
             std::string s,

--- a/include/optionx_cpp/data/bars/enums.hpp
+++ b/include/optionx_cpp/data/bars/enums.hpp
@@ -9,6 +9,9 @@
 
 namespace optionx {
 
+    /// \brief Bar timeframe in seconds.
+    using BarTimeframe = std::uint32_t;
+
     /// \enum BarPriceSource
     /// \brief Defines which price stream was used to build a single OHLC bar.
     enum class BarPriceSource : std::uint8_t {

--- a/include/optionx_cpp/data/bars/enums.hpp
+++ b/include/optionx_cpp/data/bars/enums.hpp
@@ -9,9 +9,6 @@
 
 namespace optionx {
 
-    /// \brief Bar timeframe in seconds.
-    using BarTimeframe = std::uint32_t;
-
     /// \enum BarPriceSource
     /// \brief Defines which price stream was used to build a single OHLC bar.
     enum class BarPriceSource : std::uint8_t {

--- a/include/optionx_cpp/data/bars/types.hpp
+++ b/include/optionx_cpp/data/bars/types.hpp
@@ -9,7 +9,9 @@
 
 namespace optionx {
 
-    using BarTimeframe = std::int32_t; ///< Bar timeframe in seconds; values <= 0 are invalid.
+    /// \brief Bar timeframe in seconds.
+    /// \details Request DTOs treat values less than or equal to zero as invalid.
+    using BarTimeframe = std::int32_t;
 
 } // namespace optionx
 

--- a/include/optionx_cpp/data/bars/types.hpp
+++ b/include/optionx_cpp/data/bars/types.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#ifndef _OPTIONX_BAR_TYPES_HPP_INCLUDED
+#define _OPTIONX_BAR_TYPES_HPP_INCLUDED
+
+/// \file types.hpp
+/// \brief Defines shared bar data types.
+
+#include <cstdint>
+
+namespace optionx {
+
+    using BarTimeframe = std::int32_t; ///< Bar timeframe in seconds; values <= 0 are invalid.
+
+} // namespace optionx
+
+#endif // _OPTIONX_BAR_TYPES_HPP_INCLUDED

--- a/include/optionx_cpp/market_data.hpp
+++ b/include/optionx_cpp/market_data.hpp
@@ -4,7 +4,10 @@
 
 /// \file market_data.hpp
 /// \brief Includes public market-data provider contracts.
+/// \note Headers under market_data subdirectories are internal components and
+/// intended to be included through this umbrella header.
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <string>

--- a/include/optionx_cpp/market_data.hpp
+++ b/include/optionx_cpp/market_data.hpp
@@ -5,10 +5,15 @@
 /// \file market_data.hpp
 /// \brief Includes public market-data provider contracts.
 
+#include <cstdint>
 #include <functional>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "data.hpp"
+#include "market_data/enums.hpp"
+#include "market_data/MarketDataSubscription.hpp"
 #include "market_data/BaseMarketDataProvider.hpp"
 
 #endif // _OPTIONX_MARKET_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -14,6 +14,7 @@ namespace optionx::market_data {
         using bars_callback_t = std::function<void(const std::vector<SingleBar>&)>;
         using ticks_callback_t = std::function<void(const std::vector<SingleTick>&)>;
         using bar_history_callback_t = std::function<void(BarHistoryResult)>;
+        using subscription_callback_t = std::function<void(MarketDataSubscriptionResult)>;
 
         /// \brief Virtual destructor for polymorphic provider implementations.
         virtual ~BaseMarketDataProvider() = default;
@@ -32,6 +33,86 @@ namespace optionx::market_data {
             return null_callback;
         }
 
+        /// \brief Requests a live tick stream subscription.
+        /// \param request Subscription parameters; stream_type is normalized to TICKS.
+        /// \param callback Callback receiving subscription acceptance or failure.
+        /// \return True if the provider accepted the operation for processing; false otherwise.
+        virtual bool subscribe_ticks(
+                MarketDataSubscriptionRequest request,
+                subscription_callback_t callback) {
+            request.stream_type = MarketDataStreamType::TICKS;
+            if (!request.valid()) {
+                dispatch_subscription_result(
+                    std::move(callback),
+                    MarketDataSubscriptionResult::failed(
+                        std::move(request),
+                        MarketDataSubscriptionStatus::INVALID_REQUEST,
+                        "Invalid tick subscription request."));
+                return false;
+            }
+
+            dispatch_subscription_result(
+                std::move(callback),
+                MarketDataSubscriptionResult::failed(
+                    std::move(request),
+                    MarketDataSubscriptionStatus::UNSUPPORTED,
+                    "Tick subscriptions are not supported by this provider."));
+            return false;
+        }
+
+        /// \brief Requests a live bar stream subscription.
+        /// \param request Subscription parameters; stream_type is normalized to BARS.
+        /// \param callback Callback receiving subscription acceptance or failure.
+        /// \return True if the provider accepted the operation for processing; false otherwise.
+        virtual bool subscribe_bars(
+                MarketDataSubscriptionRequest request,
+                subscription_callback_t callback) {
+            request.stream_type = MarketDataStreamType::BARS;
+            if (!request.valid()) {
+                dispatch_subscription_result(
+                    std::move(callback),
+                    MarketDataSubscriptionResult::failed(
+                        std::move(request),
+                        MarketDataSubscriptionStatus::INVALID_REQUEST,
+                        "Invalid bar subscription request."));
+                return false;
+            }
+
+            dispatch_subscription_result(
+                std::move(callback),
+                MarketDataSubscriptionResult::failed(
+                    std::move(request),
+                    MarketDataSubscriptionStatus::UNSUPPORTED,
+                    "Bar subscriptions are not supported by this provider."));
+            return false;
+        }
+
+        /// \brief Stops a live market-data subscription.
+        /// \param subscription Subscription handle returned by a successful subscribe call.
+        /// \param callback Callback receiving unsubscribe status.
+        /// \return True if the provider accepted the operation for processing; false otherwise.
+        virtual bool unsubscribe(
+                MarketDataSubscriptionHandle subscription,
+                subscription_callback_t callback) {
+            if (!subscription.valid()) {
+                dispatch_subscription_result(
+                    std::move(callback),
+                    MarketDataSubscriptionResult::failed(
+                        std::move(subscription),
+                        MarketDataSubscriptionStatus::INVALID_REQUEST,
+                        "Invalid market-data subscription handle."));
+                return false;
+            }
+
+            dispatch_subscription_result(
+                std::move(callback),
+                MarketDataSubscriptionResult::failed(
+                    std::move(subscription),
+                    MarketDataSubscriptionStatus::UNSUPPORTED,
+                    "Market-data subscriptions are not supported by this provider."));
+            return false;
+        }
+
         /// \brief Requests historical bar data for a specified time range.
         /// \param request Historical bar-data request parameters.
         /// \param callback Callback function to receive bars or a failure reason.
@@ -42,6 +123,16 @@ namespace optionx::market_data {
             (void)request;
             (void)callback;
             return false;
+        }
+
+    protected:
+        /// \brief Delivers a subscription operation result when a callback was supplied.
+        static void dispatch_subscription_result(
+                subscription_callback_t callback,
+                MarketDataSubscriptionResult result) {
+            if (callback) {
+                callback(std::move(result));
+            }
         }
     };
 

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -16,8 +16,16 @@ namespace optionx::market_data {
         using bar_history_callback_t = std::function<void(BarHistoryResult)>;
         using subscription_callback_t = std::function<void(MarketDataSubscriptionResult)>;
 
+        /// \brief Constructs a market-data provider and assigns a runtime instance ID.
+        BaseMarketDataProvider() : m_provider_id(next_provider_instance_id()) {}
+
         /// \brief Virtual destructor for polymorphic provider implementations.
         virtual ~BaseMarketDataProvider() = default;
+
+        /// \brief Returns the runtime provider instance ID used to bind subscription handles.
+        ProviderInstanceId provider_id() const noexcept {
+            return m_provider_id;
+        }
 
         /// \brief Returns a reference to the live bar-data callback.
         /// \return Mutable callback reference, or a null callback if live bars are unsupported.
@@ -34,13 +42,12 @@ namespace optionx::market_data {
         }
 
         /// \brief Requests a live tick stream subscription.
-        /// \param request Subscription parameters; stream_type is normalized to TICKS.
+        /// \param request Tick subscription parameters.
         /// \param callback Callback receiving subscription acceptance or failure.
         /// \return True if the provider accepted the operation for processing; false otherwise.
         virtual bool subscribe_ticks(
-                MarketDataSubscriptionRequest request,
+                TickSubscriptionRequest request,
                 subscription_callback_t callback) {
-            request.stream_type = MarketDataStreamType::TICKS;
             if (!request.valid()) {
                 dispatch_subscription_result(
                     std::move(callback),
@@ -61,13 +68,12 @@ namespace optionx::market_data {
         }
 
         /// \brief Requests a live bar stream subscription.
-        /// \param request Subscription parameters; stream_type is normalized to BARS.
+        /// \param request Bar subscription parameters.
         /// \param callback Callback receiving subscription acceptance or failure.
         /// \return True if the provider accepted the operation for processing; false otherwise.
         virtual bool subscribe_bars(
-                MarketDataSubscriptionRequest request,
+                BarSubscriptionRequest request,
                 subscription_callback_t callback) {
-            request.stream_type = MarketDataStreamType::BARS;
             if (!request.valid()) {
                 dispatch_subscription_result(
                     std::move(callback),
@@ -103,6 +109,15 @@ namespace optionx::market_data {
                         "Invalid market-data subscription handle."));
                 return false;
             }
+            if (subscription.provider_id != provider_id()) {
+                dispatch_subscription_result(
+                    std::move(callback),
+                    MarketDataSubscriptionResult::failed(
+                        std::move(subscription),
+                        MarketDataSubscriptionStatus::WRONG_PROVIDER,
+                        "Market-data subscription handle belongs to another provider."));
+                return false;
+            }
 
             dispatch_subscription_result(
                 std::move(callback),
@@ -133,6 +148,16 @@ namespace optionx::market_data {
             if (callback) {
                 callback(std::move(result));
             }
+        }
+
+    private:
+        ProviderInstanceId m_provider_id = kInvalidProviderInstanceId; ///< Runtime provider instance ID.
+
+        /// \brief Returns the next non-zero provider instance ID.
+        static ProviderInstanceId next_provider_instance_id() {
+            static std::atomic<ProviderInstanceId> counter{1};
+            const auto id = counter.fetch_add(1, std::memory_order_relaxed);
+            return id == kInvalidProviderInstanceId ? counter.fetch_add(1, std::memory_order_relaxed) : id;
         }
     };
 

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -11,17 +11,28 @@ namespace optionx::market_data {
     /// \brief Role interface for endpoints that provide live or historical market data.
     class BaseMarketDataProvider {
     public:
+        /// \brief Callback that receives live bar batches from a provider.
         using bars_callback_t = std::function<void(const std::vector<SingleBar>&)>;
+
+        /// \brief Callback that receives live tick batches from a provider.
         using ticks_callback_t = std::function<void(const std::vector<SingleTick>&)>;
+
+        /// \brief Callback that receives historical bars or a typed failure.
         using bar_history_callback_t = std::function<void(BarHistoryResult)>;
+
+        /// \brief Callback that receives subscribe/unsubscribe operation results.
         using subscription_callback_t = std::function<void(MarketDataSubscriptionResult)>;
 
         /// \brief Constructs a market-data provider and assigns a runtime instance ID.
         BaseMarketDataProvider() : m_provider_id(next_provider_instance_id()) {}
 
+        /// \brief Copying is disabled because subscription handles are bound to provider identity.
         BaseMarketDataProvider(const BaseMarketDataProvider&) = delete;
+        /// \brief Copy assignment is disabled because it would duplicate provider identity.
         BaseMarketDataProvider& operator=(const BaseMarketDataProvider&) = delete;
+        /// \brief Moving is disabled because existing handles must not change owner identity.
         BaseMarketDataProvider(BaseMarketDataProvider&&) = delete;
+        /// \brief Move assignment is disabled because existing handles must not change owner identity.
         BaseMarketDataProvider& operator=(BaseMarketDataProvider&&) = delete;
 
         /// \brief Virtual destructor for polymorphic provider implementations.
@@ -147,6 +158,8 @@ namespace optionx::market_data {
 
     protected:
         /// \brief Delivers a subscription operation result when a callback was supplied.
+        /// \param callback Optional callback supplied by the caller.
+        /// \param result Typed operation result to deliver.
         static void dispatch_subscription_result(
                 subscription_callback_t callback,
                 MarketDataSubscriptionResult result) {

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -19,6 +19,11 @@ namespace optionx::market_data {
         /// \brief Constructs a market-data provider and assigns a runtime instance ID.
         BaseMarketDataProvider() : m_provider_id(next_provider_instance_id()) {}
 
+        BaseMarketDataProvider(const BaseMarketDataProvider&) = delete;
+        BaseMarketDataProvider& operator=(const BaseMarketDataProvider&) = delete;
+        BaseMarketDataProvider(BaseMarketDataProvider&&) = delete;
+        BaseMarketDataProvider& operator=(BaseMarketDataProvider&&) = delete;
+
         /// \brief Virtual destructor for polymorphic provider implementations.
         virtual ~BaseMarketDataProvider() = default;
 

--- a/include/optionx_cpp/market_data/MarketDataSubscription.hpp
+++ b/include/optionx_cpp/market_data/MarketDataSubscription.hpp
@@ -8,9 +8,13 @@
 namespace optionx::market_data {
 
     /// \brief Runtime identifier of a market-data provider instance.
+    /// \details The value is process-local and is used only to reject handles
+    ///          passed to the wrong provider object.
     using ProviderInstanceId = std::uint64_t;
 
     /// \brief Runtime identifier assigned by a market-data provider.
+    /// \details A subscription ID is meaningful only together with its
+    ///          ProviderInstanceId.
     using SubscriptionId = std::uint64_t;
 
     /// \brief Invalid market-data provider instance identifier.
@@ -29,6 +33,8 @@ namespace optionx::market_data {
         TickSubscriptionRequest() = default;
 
         /// \brief Constructs a tick-stream request.
+        /// \param symbol Broker/provider symbol.
+        /// \param transport Preferred transport for live data.
         TickSubscriptionRequest(
                 std::string symbol,
                 MarketDataTransport transport = MarketDataTransport::AUTO)
@@ -36,6 +42,7 @@ namespace optionx::market_data {
                   transport(transport) {}
 
         /// \brief Returns true when the request describes a valid live tick stream.
+        /// \return True when symbol is not empty.
         bool valid() const {
             return !symbol.empty();
         }
@@ -45,7 +52,7 @@ namespace optionx::market_data {
     /// \brief Request for a live bar market-data stream.
     struct BarSubscriptionRequest {
         std::string symbol; ///< Broker/provider symbol.
-        BarTimeframe timeframe = 0; ///< Bar timeframe in seconds.
+        BarTimeframe timeframe = 0; ///< Bar timeframe in seconds; values <= 0 are invalid.
         BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bars.
         MarketDataTransport transport = MarketDataTransport::AUTO; ///< Preferred transport.
 
@@ -53,6 +60,10 @@ namespace optionx::market_data {
         BarSubscriptionRequest() = default;
 
         /// \brief Constructs a bar-stream request.
+        /// \param symbol Broker/provider symbol.
+        /// \param timeframe Bar timeframe in seconds.
+        /// \param price_source Price stream used to build OHLC values.
+        /// \param transport Preferred transport for live data.
         BarSubscriptionRequest(
                 std::string symbol,
                 BarTimeframe timeframe,
@@ -64,6 +75,7 @@ namespace optionx::market_data {
                   transport(transport) {}
 
         /// \brief Returns true when the request describes a valid live bar stream.
+        /// \return True when symbol is not empty and timeframe is positive.
         bool valid() const {
             return !symbol.empty() && timeframe > 0;
         }
@@ -81,12 +93,16 @@ namespace optionx::market_data {
         MarketDataTransport transport = MarketDataTransport::AUTO; ///< Transport chosen or requested.
 
         /// \brief Returns true if the handle can identify a provider subscription.
+        /// \return True when both provider and subscription IDs are non-zero.
         bool valid() const {
             return provider_id != kInvalidProviderInstanceId &&
                    id != kInvalidSubscriptionId;
         }
 
         /// \brief Builds a tick handle from a request and provider-assigned IDs.
+        /// \param provider_id Runtime provider instance that owns the handle.
+        /// \param id Provider-assigned subscription ID.
+        /// \param request Original tick subscription request.
         static MarketDataSubscriptionHandle from_tick_request(
                 ProviderInstanceId provider_id,
                 SubscriptionId id,
@@ -102,6 +118,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Builds a bar handle from a request and provider-assigned IDs.
+        /// \param provider_id Runtime provider instance that owns the handle.
+        /// \param id Provider-assigned subscription ID.
+        /// \param request Original bar subscription request.
         static MarketDataSubscriptionHandle from_bar_request(
                 ProviderInstanceId provider_id,
                 SubscriptionId id,
@@ -126,6 +145,8 @@ namespace optionx::market_data {
         MarketDataSubscriptionHandle subscription; ///< Related subscription handle.
 
         /// \brief Returns true when the operation succeeded.
+        /// \details The status field is the source of truth; there is no
+        ///          separate mutable success flag.
         bool success() const noexcept {
             return status == MarketDataSubscriptionStatus::SUBSCRIBED ||
                    status == MarketDataSubscriptionStatus::UNSUBSCRIBED;
@@ -137,6 +158,7 @@ namespace optionx::market_data {
         }
 
         /// \brief Creates a successful subscribe result.
+        /// \param handle Accepted subscription handle.
         static MarketDataSubscriptionResult subscribed(MarketDataSubscriptionHandle handle) {
             if (!handle.valid()) {
                 return failed(
@@ -152,6 +174,7 @@ namespace optionx::market_data {
         }
 
         /// \brief Creates a successful unsubscribe result.
+        /// \param handle Stopped subscription handle.
         static MarketDataSubscriptionResult unsubscribed(MarketDataSubscriptionHandle handle) {
             if (!handle.valid()) {
                 return failed(
@@ -167,6 +190,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Creates a failure result for a tick request.
+        /// \param request Rejected request.
+        /// \param status Failure status; accidental success statuses are normalized.
+        /// \param message Diagnostic message for the caller.
         static MarketDataSubscriptionResult failed(
                 TickSubscriptionRequest request,
                 MarketDataSubscriptionStatus status,
@@ -182,6 +208,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Creates a failure result for a bar request.
+        /// \param request Rejected request.
+        /// \param status Failure status; accidental success statuses are normalized.
+        /// \param message Diagnostic message for the caller.
         static MarketDataSubscriptionResult failed(
                 BarSubscriptionRequest request,
                 MarketDataSubscriptionStatus status,
@@ -197,6 +226,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Creates a failure result for an existing handle.
+        /// \param handle Subscription handle related to the failure.
+        /// \param status Failure status; accidental success statuses are normalized.
+        /// \param message Diagnostic message for the caller.
         static MarketDataSubscriptionResult failed(
                 MarketDataSubscriptionHandle handle,
                 MarketDataSubscriptionStatus status,
@@ -209,6 +241,7 @@ namespace optionx::market_data {
         }
 
         /// \brief Converts accidental success statuses to a failure status.
+        /// \return FAILED when status is a success value; otherwise returns status.
         static MarketDataSubscriptionStatus failure_status_or_failed(
                 MarketDataSubscriptionStatus status) noexcept {
             if (status == MarketDataSubscriptionStatus::SUBSCRIBED ||

--- a/include/optionx_cpp/market_data/MarketDataSubscription.hpp
+++ b/include/optionx_cpp/market_data/MarketDataSubscription.hpp
@@ -7,79 +7,110 @@
 
 namespace optionx::market_data {
 
-    /// \brief Persistent runtime identifier assigned by a market-data provider.
-    using MarketDataSubscriptionId = std::uint64_t;
+    /// \brief Runtime identifier of a market-data provider instance.
+    using ProviderInstanceId = std::uint64_t;
+
+    /// \brief Runtime identifier assigned by a market-data provider.
+    using SubscriptionId = std::uint64_t;
+
+    /// \brief Invalid market-data provider instance identifier.
+    inline constexpr ProviderInstanceId kInvalidProviderInstanceId = 0;
 
     /// \brief Invalid market-data subscription identifier.
-    inline constexpr MarketDataSubscriptionId kInvalidMarketDataSubscriptionId = 0;
+    inline constexpr SubscriptionId kInvalidSubscriptionId = 0;
 
-    /// \struct MarketDataSubscriptionRequest
-    /// \brief Request for a live tick or bar market-data stream.
-    struct MarketDataSubscriptionRequest {
+    /// \struct TickSubscriptionRequest
+    /// \brief Request for a live tick market-data stream.
+    struct TickSubscriptionRequest {
         std::string symbol; ///< Broker/provider symbol.
-        MarketDataStreamType stream_type = MarketDataStreamType::UNKNOWN; ///< Requested stream type.
-        std::int64_t timeframe = 0; ///< Bar timeframe in seconds; ignored for tick streams.
-        BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bar streams.
         MarketDataTransport transport = MarketDataTransport::AUTO; ///< Preferred transport.
 
-        /// \brief Creates a tick-stream request.
-        static MarketDataSubscriptionRequest ticks(
-                std::string symbol,
-                MarketDataTransport transport = MarketDataTransport::AUTO) {
-            MarketDataSubscriptionRequest request;
-            request.symbol = std::move(symbol);
-            request.stream_type = MarketDataStreamType::TICKS;
-            request.transport = transport;
-            return request;
-        }
+        /// \brief Default constructor.
+        TickSubscriptionRequest() = default;
 
-        /// \brief Creates a bar-stream request.
-        static MarketDataSubscriptionRequest bars(
+        /// \brief Constructs a tick-stream request.
+        TickSubscriptionRequest(
                 std::string symbol,
-                std::int64_t timeframe,
-                BarPriceSource price_source = BarPriceSource::MID,
-                MarketDataTransport transport = MarketDataTransport::AUTO) {
-            MarketDataSubscriptionRequest request;
-            request.symbol = std::move(symbol);
-            request.stream_type = MarketDataStreamType::BARS;
-            request.timeframe = timeframe;
-            request.price_source = price_source;
-            request.transport = transport;
-            return request;
-        }
+                MarketDataTransport transport = MarketDataTransport::AUTO)
+                : symbol(std::move(symbol)),
+                  transport(transport) {}
 
-        /// \brief Returns true when the request describes a valid live stream.
+        /// \brief Returns true when the request describes a valid live tick stream.
         bool valid() const {
-            if (symbol.empty()) return false;
-            if (stream_type == MarketDataStreamType::TICKS) return true;
-            if (stream_type == MarketDataStreamType::BARS) return timeframe > 0;
-            return false;
+            return !symbol.empty();
+        }
+    };
+
+    /// \struct BarSubscriptionRequest
+    /// \brief Request for a live bar market-data stream.
+    struct BarSubscriptionRequest {
+        std::string symbol; ///< Broker/provider symbol.
+        BarTimeframe timeframe = 0; ///< Bar timeframe in seconds.
+        BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bars.
+        MarketDataTransport transport = MarketDataTransport::AUTO; ///< Preferred transport.
+
+        /// \brief Default constructor.
+        BarSubscriptionRequest() = default;
+
+        /// \brief Constructs a bar-stream request.
+        BarSubscriptionRequest(
+                std::string symbol,
+                BarTimeframe timeframe,
+                BarPriceSource price_source = BarPriceSource::MID,
+                MarketDataTransport transport = MarketDataTransport::AUTO)
+                : symbol(std::move(symbol)),
+                  timeframe(timeframe),
+                  price_source(price_source),
+                  transport(transport) {}
+
+        /// \brief Returns true when the request describes a valid live bar stream.
+        bool valid() const {
+            return !symbol.empty() && timeframe > 0;
         }
     };
 
     /// \struct MarketDataSubscriptionHandle
     /// \brief Opaque handle returned for an accepted live market-data subscription.
     struct MarketDataSubscriptionHandle {
-        MarketDataSubscriptionId id = kInvalidMarketDataSubscriptionId; ///< Provider-assigned ID.
+        ProviderInstanceId provider_id = kInvalidProviderInstanceId; ///< Provider instance that owns the handle.
+        SubscriptionId id = kInvalidSubscriptionId; ///< Provider-assigned subscription ID.
         std::string symbol; ///< Subscribed symbol.
         MarketDataStreamType stream_type = MarketDataStreamType::UNKNOWN; ///< Stream type.
-        std::int64_t timeframe = 0; ///< Bar timeframe in seconds, or 0 for ticks.
+        BarTimeframe timeframe = 0; ///< Bar timeframe in seconds, or 0 for ticks.
         BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bar streams.
         MarketDataTransport transport = MarketDataTransport::AUTO; ///< Transport chosen or requested.
 
         /// \brief Returns true if the handle can identify a provider subscription.
         bool valid() const {
-            return id != kInvalidMarketDataSubscriptionId;
+            return provider_id != kInvalidProviderInstanceId &&
+                   id != kInvalidSubscriptionId;
         }
 
-        /// \brief Builds a handle from a request and provider-assigned ID.
-        static MarketDataSubscriptionHandle from_request(
-                MarketDataSubscriptionId id,
-                const MarketDataSubscriptionRequest& request) {
+        /// \brief Builds a tick handle from a request and provider-assigned IDs.
+        static MarketDataSubscriptionHandle from_tick_request(
+                ProviderInstanceId provider_id,
+                SubscriptionId id,
+                const TickSubscriptionRequest& request) {
             MarketDataSubscriptionHandle handle;
+            handle.provider_id = provider_id;
             handle.id = id;
             handle.symbol = request.symbol;
-            handle.stream_type = request.stream_type;
+            handle.stream_type = MarketDataStreamType::TICKS;
+            handle.timeframe = 0;
+            handle.transport = request.transport;
+            return handle;
+        }
+
+        /// \brief Builds a bar handle from a request and provider-assigned IDs.
+        static MarketDataSubscriptionHandle from_bar_request(
+                ProviderInstanceId provider_id,
+                SubscriptionId id,
+                const BarSubscriptionRequest& request) {
+            MarketDataSubscriptionHandle handle;
+            handle.provider_id = provider_id;
+            handle.id = id;
+            handle.symbol = request.symbol;
+            handle.stream_type = MarketDataStreamType::BARS;
             handle.timeframe = request.timeframe;
             handle.price_source = request.price_source;
             handle.transport = request.transport;
@@ -90,20 +121,31 @@ namespace optionx::market_data {
     /// \struct MarketDataSubscriptionResult
     /// \brief Typed result for market-data subscribe and unsubscribe operations.
     struct MarketDataSubscriptionResult {
-        bool success = false; ///< True if the operation succeeded.
         MarketDataSubscriptionStatus status = MarketDataSubscriptionStatus::UNKNOWN; ///< Operation status.
         std::string error_message; ///< Failure details, if any.
         MarketDataSubscriptionHandle subscription; ///< Related subscription handle.
 
+        /// \brief Returns true when the operation succeeded.
+        bool success() const noexcept {
+            return status == MarketDataSubscriptionStatus::SUBSCRIBED ||
+                   status == MarketDataSubscriptionStatus::UNSUBSCRIBED;
+        }
+
         /// \brief Allows result objects to be used in boolean contexts.
-        explicit operator bool() const {
-            return success;
+        explicit operator bool() const noexcept {
+            return success();
         }
 
         /// \brief Creates a successful subscribe result.
         static MarketDataSubscriptionResult subscribed(MarketDataSubscriptionHandle handle) {
+            if (!handle.valid()) {
+                return failed(
+                    std::move(handle),
+                    MarketDataSubscriptionStatus::INVALID_REQUEST,
+                    "Cannot subscribe with an invalid market-data subscription handle.");
+            }
+
             MarketDataSubscriptionResult result;
-            result.success = true;
             result.status = MarketDataSubscriptionStatus::SUBSCRIBED;
             result.subscription = std::move(handle);
             return result;
@@ -111,24 +153,45 @@ namespace optionx::market_data {
 
         /// \brief Creates a successful unsubscribe result.
         static MarketDataSubscriptionResult unsubscribed(MarketDataSubscriptionHandle handle) {
+            if (!handle.valid()) {
+                return failed(
+                    std::move(handle),
+                    MarketDataSubscriptionStatus::INVALID_REQUEST,
+                    "Cannot unsubscribe with an invalid market-data subscription handle.");
+            }
+
             MarketDataSubscriptionResult result;
-            result.success = true;
             result.status = MarketDataSubscriptionStatus::UNSUBSCRIBED;
             result.subscription = std::move(handle);
             return result;
         }
 
-        /// \brief Creates a failure result for a request.
+        /// \brief Creates a failure result for a tick request.
         static MarketDataSubscriptionResult failed(
-                MarketDataSubscriptionRequest request,
+                TickSubscriptionRequest request,
                 MarketDataSubscriptionStatus status,
                 std::string message) {
             MarketDataSubscriptionResult result;
-            result.success = false;
-            result.status = status;
+            result.status = failure_status_or_failed(status);
             result.error_message = std::move(message);
-            result.subscription = MarketDataSubscriptionHandle::from_request(
-                kInvalidMarketDataSubscriptionId,
+            result.subscription = MarketDataSubscriptionHandle::from_tick_request(
+                kInvalidProviderInstanceId,
+                kInvalidSubscriptionId,
+                request);
+            return result;
+        }
+
+        /// \brief Creates a failure result for a bar request.
+        static MarketDataSubscriptionResult failed(
+                BarSubscriptionRequest request,
+                MarketDataSubscriptionStatus status,
+                std::string message) {
+            MarketDataSubscriptionResult result;
+            result.status = failure_status_or_failed(status);
+            result.error_message = std::move(message);
+            result.subscription = MarketDataSubscriptionHandle::from_bar_request(
+                kInvalidProviderInstanceId,
+                kInvalidSubscriptionId,
                 request);
             return result;
         }
@@ -139,11 +202,20 @@ namespace optionx::market_data {
                 MarketDataSubscriptionStatus status,
                 std::string message) {
             MarketDataSubscriptionResult result;
-            result.success = false;
-            result.status = status;
+            result.status = failure_status_or_failed(status);
             result.error_message = std::move(message);
             result.subscription = std::move(handle);
             return result;
+        }
+
+        /// \brief Converts accidental success statuses to a failure status.
+        static MarketDataSubscriptionStatus failure_status_or_failed(
+                MarketDataSubscriptionStatus status) noexcept {
+            if (status == MarketDataSubscriptionStatus::SUBSCRIBED ||
+                status == MarketDataSubscriptionStatus::UNSUBSCRIBED) {
+                return MarketDataSubscriptionStatus::FAILED;
+            }
+            return status;
         }
     };
 

--- a/include/optionx_cpp/market_data/MarketDataSubscription.hpp
+++ b/include/optionx_cpp/market_data/MarketDataSubscription.hpp
@@ -1,0 +1,152 @@
+#pragma once
+#ifndef _OPTIONX_MARKET_DATA_SUBSCRIPTION_HPP_INCLUDED
+#define _OPTIONX_MARKET_DATA_SUBSCRIPTION_HPP_INCLUDED
+
+/// \file MarketDataSubscription.hpp
+/// \brief Defines market-data subscription request, handle, and result DTOs.
+
+namespace optionx::market_data {
+
+    /// \brief Persistent runtime identifier assigned by a market-data provider.
+    using MarketDataSubscriptionId = std::uint64_t;
+
+    /// \brief Invalid market-data subscription identifier.
+    inline constexpr MarketDataSubscriptionId kInvalidMarketDataSubscriptionId = 0;
+
+    /// \struct MarketDataSubscriptionRequest
+    /// \brief Request for a live tick or bar market-data stream.
+    struct MarketDataSubscriptionRequest {
+        std::string symbol; ///< Broker/provider symbol.
+        MarketDataStreamType stream_type = MarketDataStreamType::UNKNOWN; ///< Requested stream type.
+        std::int64_t timeframe = 0; ///< Bar timeframe in seconds; ignored for tick streams.
+        BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bar streams.
+        MarketDataTransport transport = MarketDataTransport::AUTO; ///< Preferred transport.
+
+        /// \brief Creates a tick-stream request.
+        static MarketDataSubscriptionRequest ticks(
+                std::string symbol,
+                MarketDataTransport transport = MarketDataTransport::AUTO) {
+            MarketDataSubscriptionRequest request;
+            request.symbol = std::move(symbol);
+            request.stream_type = MarketDataStreamType::TICKS;
+            request.transport = transport;
+            return request;
+        }
+
+        /// \brief Creates a bar-stream request.
+        static MarketDataSubscriptionRequest bars(
+                std::string symbol,
+                std::int64_t timeframe,
+                BarPriceSource price_source = BarPriceSource::MID,
+                MarketDataTransport transport = MarketDataTransport::AUTO) {
+            MarketDataSubscriptionRequest request;
+            request.symbol = std::move(symbol);
+            request.stream_type = MarketDataStreamType::BARS;
+            request.timeframe = timeframe;
+            request.price_source = price_source;
+            request.transport = transport;
+            return request;
+        }
+
+        /// \brief Returns true when the request describes a valid live stream.
+        bool valid() const {
+            if (symbol.empty()) return false;
+            if (stream_type == MarketDataStreamType::TICKS) return true;
+            if (stream_type == MarketDataStreamType::BARS) return timeframe > 0;
+            return false;
+        }
+    };
+
+    /// \struct MarketDataSubscriptionHandle
+    /// \brief Opaque handle returned for an accepted live market-data subscription.
+    struct MarketDataSubscriptionHandle {
+        MarketDataSubscriptionId id = kInvalidMarketDataSubscriptionId; ///< Provider-assigned ID.
+        std::string symbol; ///< Subscribed symbol.
+        MarketDataStreamType stream_type = MarketDataStreamType::UNKNOWN; ///< Stream type.
+        std::int64_t timeframe = 0; ///< Bar timeframe in seconds, or 0 for ticks.
+        BarPriceSource price_source = BarPriceSource::MID; ///< Price source for bar streams.
+        MarketDataTransport transport = MarketDataTransport::AUTO; ///< Transport chosen or requested.
+
+        /// \brief Returns true if the handle can identify a provider subscription.
+        bool valid() const {
+            return id != kInvalidMarketDataSubscriptionId;
+        }
+
+        /// \brief Builds a handle from a request and provider-assigned ID.
+        static MarketDataSubscriptionHandle from_request(
+                MarketDataSubscriptionId id,
+                const MarketDataSubscriptionRequest& request) {
+            MarketDataSubscriptionHandle handle;
+            handle.id = id;
+            handle.symbol = request.symbol;
+            handle.stream_type = request.stream_type;
+            handle.timeframe = request.timeframe;
+            handle.price_source = request.price_source;
+            handle.transport = request.transport;
+            return handle;
+        }
+    };
+
+    /// \struct MarketDataSubscriptionResult
+    /// \brief Typed result for market-data subscribe and unsubscribe operations.
+    struct MarketDataSubscriptionResult {
+        bool success = false; ///< True if the operation succeeded.
+        MarketDataSubscriptionStatus status = MarketDataSubscriptionStatus::UNKNOWN; ///< Operation status.
+        std::string error_message; ///< Failure details, if any.
+        MarketDataSubscriptionHandle subscription; ///< Related subscription handle.
+
+        /// \brief Allows result objects to be used in boolean contexts.
+        explicit operator bool() const {
+            return success;
+        }
+
+        /// \brief Creates a successful subscribe result.
+        static MarketDataSubscriptionResult subscribed(MarketDataSubscriptionHandle handle) {
+            MarketDataSubscriptionResult result;
+            result.success = true;
+            result.status = MarketDataSubscriptionStatus::SUBSCRIBED;
+            result.subscription = std::move(handle);
+            return result;
+        }
+
+        /// \brief Creates a successful unsubscribe result.
+        static MarketDataSubscriptionResult unsubscribed(MarketDataSubscriptionHandle handle) {
+            MarketDataSubscriptionResult result;
+            result.success = true;
+            result.status = MarketDataSubscriptionStatus::UNSUBSCRIBED;
+            result.subscription = std::move(handle);
+            return result;
+        }
+
+        /// \brief Creates a failure result for a request.
+        static MarketDataSubscriptionResult failed(
+                MarketDataSubscriptionRequest request,
+                MarketDataSubscriptionStatus status,
+                std::string message) {
+            MarketDataSubscriptionResult result;
+            result.success = false;
+            result.status = status;
+            result.error_message = std::move(message);
+            result.subscription = MarketDataSubscriptionHandle::from_request(
+                kInvalidMarketDataSubscriptionId,
+                request);
+            return result;
+        }
+
+        /// \brief Creates a failure result for an existing handle.
+        static MarketDataSubscriptionResult failed(
+                MarketDataSubscriptionHandle handle,
+                MarketDataSubscriptionStatus status,
+                std::string message) {
+            MarketDataSubscriptionResult result;
+            result.success = false;
+            result.status = status;
+            result.error_message = std::move(message);
+            result.subscription = std::move(handle);
+            return result;
+        }
+    };
+
+} // namespace optionx::market_data
+
+#endif // _OPTIONX_MARKET_DATA_SUBSCRIPTION_HPP_INCLUDED

--- a/include/optionx_cpp/market_data/enums.hpp
+++ b/include/optionx_cpp/market_data/enums.hpp
@@ -32,6 +32,7 @@ namespace optionx::market_data {
         UNSUBSCRIBED,    ///< Subscription was stopped.
         UNSUPPORTED,     ///< Provider does not support the requested subscription.
         INVALID_REQUEST, ///< Request or handle is invalid.
+        WRONG_PROVIDER,  ///< Subscription handle belongs to another provider instance.
         FAILED           ///< Provider attempted the operation but it failed.
     };
 
@@ -64,6 +65,7 @@ namespace optionx::market_data {
             "UNSUBSCRIBED",
             "UNSUPPORTED",
             "INVALID_REQUEST",
+            "WRONG_PROVIDER",
             "FAILED"
         };
         return utils::enum_string_or_unknown(names, static_cast<std::size_t>(value));

--- a/include/optionx_cpp/market_data/enums.hpp
+++ b/include/optionx_cpp/market_data/enums.hpp
@@ -1,0 +1,74 @@
+#pragma once
+#ifndef _OPTIONX_MARKET_DATA_ENUMS_HPP_INCLUDED
+#define _OPTIONX_MARKET_DATA_ENUMS_HPP_INCLUDED
+
+/// \file enums.hpp
+/// \brief Defines market-data subscription enums.
+
+namespace optionx::market_data {
+
+    /// \enum MarketDataStreamType
+    /// \brief Type of live market-data stream requested from a provider.
+    enum class MarketDataStreamType {
+        UNKNOWN = 0, ///< Invalid or unspecified stream type.
+        TICKS,       ///< Tick stream.
+        BARS         ///< Bar stream.
+    };
+
+    /// \enum MarketDataTransport
+    /// \brief Preferred transport for live market-data subscriptions.
+    enum class MarketDataTransport {
+        AUTO = 0,  ///< Let the provider choose the best available transport.
+        WEBSOCKET, ///< Prefer websocket streaming.
+        POLLING,   ///< Prefer periodic snapshot polling.
+        HYBRID     ///< Use streaming with polling fallback where supported.
+    };
+
+    /// \enum MarketDataSubscriptionStatus
+    /// \brief Lifecycle status of a market-data subscription request.
+    enum class MarketDataSubscriptionStatus {
+        UNKNOWN = 0,     ///< No status has been assigned.
+        SUBSCRIBED,      ///< Subscription was accepted.
+        UNSUBSCRIBED,    ///< Subscription was stopped.
+        UNSUPPORTED,     ///< Provider does not support the requested subscription.
+        INVALID_REQUEST, ///< Request or handle is invalid.
+        FAILED           ///< Provider attempted the operation but it failed.
+    };
+
+    /// \brief Converts MarketDataStreamType to its string representation.
+    inline const std::string& to_str(MarketDataStreamType value) noexcept {
+        static const std::vector<std::string> names = {
+            "UNKNOWN",
+            "TICKS",
+            "BARS"
+        };
+        return utils::enum_string_or_unknown(names, static_cast<std::size_t>(value));
+    }
+
+    /// \brief Converts MarketDataTransport to its string representation.
+    inline const std::string& to_str(MarketDataTransport value) noexcept {
+        static const std::vector<std::string> names = {
+            "AUTO",
+            "WEBSOCKET",
+            "POLLING",
+            "HYBRID"
+        };
+        return utils::enum_string_or_unknown(names, static_cast<std::size_t>(value));
+    }
+
+    /// \brief Converts MarketDataSubscriptionStatus to its string representation.
+    inline const std::string& to_str(MarketDataSubscriptionStatus value) noexcept {
+        static const std::vector<std::string> names = {
+            "UNKNOWN",
+            "SUBSCRIBED",
+            "UNSUBSCRIBED",
+            "UNSUPPORTED",
+            "INVALID_REQUEST",
+            "FAILED"
+        };
+        return utils::enum_string_or_unknown(names, static_cast<std::size_t>(value));
+    }
+
+} // namespace optionx::market_data
+
+#endif // _OPTIONX_MARKET_DATA_ENUMS_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -1835,8 +1835,7 @@ namespace optionx::platforms::intrade_bar {
             callback(BarHistoryApiResult::fail("Bar history symbol is required."));
             return;
         }
-        if (request.timeframe <= 0 ||
-            request.timeframe > static_cast<std::int64_t>((std::numeric_limits<std::uint16_t>::max)())) {
+        if (request.timeframe == 0) {
             callback(BarHistoryApiResult::fail("Bar history timeframe is invalid."));
             return;
         }
@@ -1858,7 +1857,7 @@ namespace optionx::platforms::intrade_bar {
             BarSequence sequence;
             sequence.symbol = normalize_symbol_name(req.symbol);
             sequence.provider = to_str(PlatformType::INTRADE_BAR);
-            sequence.timeframe = static_cast<std::uint16_t>(req.timeframe);
+            sequence.timeframe = req.timeframe;
             sequence.flags =
                 static_cast<std::uint16_t>(dfh::BarStatusFlags::HISTORICAL) |
                 static_cast<std::uint16_t>(dfh::BarStatusFlags::FINALIZED);

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/RequestManager.hpp
@@ -1835,7 +1835,7 @@ namespace optionx::platforms::intrade_bar {
             callback(BarHistoryApiResult::fail("Bar history symbol is required."));
             return;
         }
-        if (request.timeframe == 0) {
+        if (request.timeframe <= 0) {
             callback(BarHistoryApiResult::fail("Bar history timeframe is invalid."));
             return;
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_parsers.hpp
@@ -1350,7 +1350,7 @@ namespace optionx::platforms::intrade_bar {
             BarSequence sequence;
             sequence.symbol = normalize_symbol_name(request.symbol);
             sequence.provider = to_str(PlatformType::INTRADE_BAR);
-            sequence.timeframe = static_cast<std::uint16_t>(request.timeframe);
+            sequence.timeframe = request.timeframe;
             sequence.flags =
                 static_cast<std::uint16_t>(dfh::BarStatusFlags::HISTORICAL) |
                 static_cast<std::uint16_t>(dfh::BarStatusFlags::FINALIZED);

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -940,6 +940,26 @@ TEST(IntradeBarApiResponses, PlatformBarHistoryResultPreservesFailureReason) {
     EXPECT_TRUE(result.sequence.bars.empty());
 }
 
+TEST(IntradeBarApiResponses, PlatformBarHistoryRejectsNegativeTimeframe) {
+    IntradeBarPlatform platform;
+    BarHistoryResult result;
+    int callback_count = 0;
+
+    EXPECT_TRUE(platform.fetch_bar_history(
+        BarHistoryRequest("EURUSD", -16, 1000, 2000),
+        [&result, &callback_count](BarHistoryResult history_result) {
+            result = std::move(history_result);
+            ++callback_count;
+        }));
+
+    platform.shutdown();
+
+    ASSERT_EQ(callback_count, 1);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status_code, BarHistoryResult::NO_RESPONSE_STATUS);
+    EXPECT_NE(result.error_desc.find("timeframe"), std::string::npos);
+}
+
 TEST(IntradeBarApiResponses, SplitsFxHisBarHistoryIntoSequentialRequests) {
     const std::int64_t first_ts = 1782980700;
     const std::int64_t second_ts =

--- a/tests/market_data_subscription_contract_test.cpp
+++ b/tests/market_data_subscription_contract_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <type_traits>
+
 #include <optionx_cpp/market_data.hpp>
 
 using namespace optionx;
@@ -25,11 +27,12 @@ TEST(BarSubscriptionRequest, BuildsAndValidatesBarRequests) {
 
     EXPECT_TRUE(request.valid());
     EXPECT_EQ(request.symbol, "BTCUSDT");
-    EXPECT_EQ(request.timeframe, 86400u);
+    EXPECT_EQ(request.timeframe, 86400);
     EXPECT_EQ(request.price_source, BarPriceSource::LAST);
     EXPECT_EQ(request.transport, MarketDataTransport::HYBRID);
 
     EXPECT_FALSE(BarSubscriptionRequest("EUR/USD", 0).valid());
+    EXPECT_FALSE(BarSubscriptionRequest("EUR/USD", -16).valid());
     EXPECT_FALSE(BarSubscriptionRequest("", 60).valid());
 }
 
@@ -43,7 +46,7 @@ TEST(MarketDataSubscriptionHandle, BuildsTickAndBarHandlesAndReportsValidity) {
     EXPECT_EQ(tick_handle.id, 42u);
     EXPECT_EQ(tick_handle.symbol, tick_request.symbol);
     EXPECT_EQ(tick_handle.stream_type, MarketDataStreamType::TICKS);
-    EXPECT_EQ(tick_handle.timeframe, 0u);
+    EXPECT_EQ(tick_handle.timeframe, 0);
     EXPECT_EQ(tick_handle.transport, tick_request.transport);
 
     const BarSubscriptionRequest bar_request("BTCUSDT", 86400, BarPriceSource::LAST);
@@ -55,7 +58,7 @@ TEST(MarketDataSubscriptionHandle, BuildsTickAndBarHandlesAndReportsValidity) {
     EXPECT_EQ(bar_handle.id, 43u);
     EXPECT_EQ(bar_handle.symbol, bar_request.symbol);
     EXPECT_EQ(bar_handle.stream_type, MarketDataStreamType::BARS);
-    EXPECT_EQ(bar_handle.timeframe, 86400u);
+    EXPECT_EQ(bar_handle.timeframe, 86400);
     EXPECT_EQ(bar_handle.price_source, bar_request.price_source);
 
     EXPECT_FALSE(MarketDataSubscriptionHandle{}.valid());
@@ -186,6 +189,18 @@ TEST(BaseMarketDataProvider, RejectsHandleFromAnotherProvider) {
     EXPECT_EQ(to_str(result.status), std::string("WRONG_PROVIDER"));
 }
 
+TEST(BaseMarketDataProvider, IsNotCopyableOrMovable) {
+    static_assert(!std::is_copy_constructible<BaseMarketDataProvider>::value,
+                  "provider identity must not be copy-constructible");
+    static_assert(!std::is_copy_assignable<BaseMarketDataProvider>::value,
+                  "provider identity must not be copy-assignable");
+    static_assert(!std::is_move_constructible<BaseMarketDataProvider>::value,
+                  "provider identity must not be move-constructible");
+    static_assert(!std::is_move_assignable<BaseMarketDataProvider>::value,
+                  "provider identity must not be move-assignable");
+    SUCCEED();
+}
+
 TEST(BarTimeframe, SupportsDailyTimeframeWithoutTruncation) {
     const Bar bar(1.0, 2.0, 0.5, 1.5, 10.0, 1000);
     const SingleBar single_bar(
@@ -197,14 +212,14 @@ TEST(BarTimeframe, SupportsDailyTimeframeWithoutTruncation) {
         5,
         0);
 
-    EXPECT_EQ(single_bar.timeframe, 86400u);
+    EXPECT_EQ(single_bar.timeframe, 86400);
 
     BarSequence sequence;
     sequence.timeframe = 86400;
-    EXPECT_EQ(sequence.timeframe, 86400u);
+    EXPECT_EQ(sequence.timeframe, 86400);
 
     const BarHistoryRequest history_request("EURUSD", 86400, 1000, 2000);
-    EXPECT_EQ(history_request.timeframe, 86400u);
+    EXPECT_EQ(history_request.timeframe, 86400);
 }
 
 int main(int argc, char** argv) {

--- a/tests/market_data_subscription_contract_test.cpp
+++ b/tests/market_data_subscription_contract_test.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/market_data.hpp>
+
+using namespace optionx;
+using namespace optionx::market_data;
+
+TEST(MarketDataSubscriptionRequest, BuildsAndValidatesTickAndBarRequests) {
+    const auto tick_request =
+        MarketDataSubscriptionRequest::ticks("EUR/USD", MarketDataTransport::WEBSOCKET);
+
+    EXPECT_TRUE(tick_request.valid());
+    EXPECT_EQ(tick_request.symbol, "EUR/USD");
+    EXPECT_EQ(tick_request.stream_type, MarketDataStreamType::TICKS);
+    EXPECT_EQ(tick_request.transport, MarketDataTransport::WEBSOCKET);
+    EXPECT_EQ(to_str(tick_request.stream_type), std::string("TICKS"));
+    EXPECT_EQ(to_str(tick_request.transport), std::string("WEBSOCKET"));
+
+    const auto bar_request =
+        MarketDataSubscriptionRequest::bars("BTCUSDT", 60, BarPriceSource::LAST, MarketDataTransport::HYBRID);
+
+    EXPECT_TRUE(bar_request.valid());
+    EXPECT_EQ(bar_request.symbol, "BTCUSDT");
+    EXPECT_EQ(bar_request.stream_type, MarketDataStreamType::BARS);
+    EXPECT_EQ(bar_request.timeframe, 60);
+    EXPECT_EQ(bar_request.price_source, BarPriceSource::LAST);
+    EXPECT_EQ(bar_request.transport, MarketDataTransport::HYBRID);
+
+    auto invalid_bar = MarketDataSubscriptionRequest::bars("EUR/USD", 0);
+    EXPECT_FALSE(invalid_bar.valid());
+
+    auto invalid_tick = MarketDataSubscriptionRequest::ticks("");
+    EXPECT_FALSE(invalid_tick.valid());
+}
+
+TEST(MarketDataSubscriptionHandle, BuildsFromRequestAndReportsValidity) {
+    const auto request =
+        MarketDataSubscriptionRequest::bars("EUR/USD", 300, BarPriceSource::BID);
+
+    const auto handle = MarketDataSubscriptionHandle::from_request(42, request);
+
+    EXPECT_TRUE(handle.valid());
+    EXPECT_EQ(handle.id, 42u);
+    EXPECT_EQ(handle.symbol, request.symbol);
+    EXPECT_EQ(handle.stream_type, request.stream_type);
+    EXPECT_EQ(handle.timeframe, request.timeframe);
+    EXPECT_EQ(handle.price_source, request.price_source);
+
+    EXPECT_FALSE(MarketDataSubscriptionHandle{}.valid());
+}
+
+TEST(BaseMarketDataProvider, DefaultProviderRejectsTickSubscriptionsWithTypedResult) {
+    BaseMarketDataProvider provider;
+    MarketDataSubscriptionResult result;
+    int callback_count = 0;
+
+    const bool accepted = provider.subscribe_ticks(
+        MarketDataSubscriptionRequest::ticks("EUR/USD"),
+        [&result, &callback_count](MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+            ++callback_count;
+        });
+
+    EXPECT_FALSE(accepted);
+    EXPECT_EQ(callback_count, 1);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_EQ(result.subscription.stream_type, MarketDataStreamType::TICKS);
+    EXPECT_EQ(result.subscription.symbol, "EUR/USD");
+    EXPECT_NE(result.error_message.find("Tick subscriptions"), std::string::npos);
+}
+
+TEST(BaseMarketDataProvider, DefaultProviderRejectsInvalidBarSubscriptions) {
+    BaseMarketDataProvider provider;
+    MarketDataSubscriptionResult result;
+    int callback_count = 0;
+
+    const bool accepted = provider.subscribe_bars(
+        MarketDataSubscriptionRequest::bars("EUR/USD", 0),
+        [&result, &callback_count](MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+            ++callback_count;
+        });
+
+    EXPECT_FALSE(accepted);
+    EXPECT_EQ(callback_count, 1);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::INVALID_REQUEST);
+    EXPECT_EQ(result.subscription.stream_type, MarketDataStreamType::BARS);
+    EXPECT_EQ(to_str(result.status), std::string("INVALID_REQUEST"));
+}
+
+TEST(BaseMarketDataProvider, DefaultProviderRejectsUnsupportedUnsubscribe) {
+    BaseMarketDataProvider provider;
+    MarketDataSubscriptionResult result;
+    int callback_count = 0;
+
+    const auto request = MarketDataSubscriptionRequest::ticks("BTCUSDT");
+    const auto handle = MarketDataSubscriptionHandle::from_request(7, request);
+
+    const bool accepted = provider.unsubscribe(
+        handle,
+        [&result, &callback_count](MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+            ++callback_count;
+        });
+
+    EXPECT_FALSE(accepted);
+    EXPECT_EQ(callback_count, 1);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_EQ(result.subscription.id, handle.id);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/market_data_subscription_contract_test.cpp
+++ b/tests/market_data_subscription_contract_test.cpp
@@ -5,48 +5,99 @@
 using namespace optionx;
 using namespace optionx::market_data;
 
-TEST(MarketDataSubscriptionRequest, BuildsAndValidatesTickAndBarRequests) {
-    const auto tick_request =
-        MarketDataSubscriptionRequest::ticks("EUR/USD", MarketDataTransport::WEBSOCKET);
+TEST(TickSubscriptionRequest, BuildsAndValidatesTickRequests) {
+    const TickSubscriptionRequest request("EUR/USD", MarketDataTransport::WEBSOCKET);
 
-    EXPECT_TRUE(tick_request.valid());
-    EXPECT_EQ(tick_request.symbol, "EUR/USD");
-    EXPECT_EQ(tick_request.stream_type, MarketDataStreamType::TICKS);
-    EXPECT_EQ(tick_request.transport, MarketDataTransport::WEBSOCKET);
-    EXPECT_EQ(to_str(tick_request.stream_type), std::string("TICKS"));
-    EXPECT_EQ(to_str(tick_request.transport), std::string("WEBSOCKET"));
+    EXPECT_TRUE(request.valid());
+    EXPECT_EQ(request.symbol, "EUR/USD");
+    EXPECT_EQ(request.transport, MarketDataTransport::WEBSOCKET);
+    EXPECT_EQ(to_str(request.transport), std::string("WEBSOCKET"));
 
-    const auto bar_request =
-        MarketDataSubscriptionRequest::bars("BTCUSDT", 60, BarPriceSource::LAST, MarketDataTransport::HYBRID);
-
-    EXPECT_TRUE(bar_request.valid());
-    EXPECT_EQ(bar_request.symbol, "BTCUSDT");
-    EXPECT_EQ(bar_request.stream_type, MarketDataStreamType::BARS);
-    EXPECT_EQ(bar_request.timeframe, 60);
-    EXPECT_EQ(bar_request.price_source, BarPriceSource::LAST);
-    EXPECT_EQ(bar_request.transport, MarketDataTransport::HYBRID);
-
-    auto invalid_bar = MarketDataSubscriptionRequest::bars("EUR/USD", 0);
-    EXPECT_FALSE(invalid_bar.valid());
-
-    auto invalid_tick = MarketDataSubscriptionRequest::ticks("");
-    EXPECT_FALSE(invalid_tick.valid());
+    EXPECT_FALSE(TickSubscriptionRequest("").valid());
 }
 
-TEST(MarketDataSubscriptionHandle, BuildsFromRequestAndReportsValidity) {
-    const auto request =
-        MarketDataSubscriptionRequest::bars("EUR/USD", 300, BarPriceSource::BID);
+TEST(BarSubscriptionRequest, BuildsAndValidatesBarRequests) {
+    const BarSubscriptionRequest request(
+        "BTCUSDT",
+        86400,
+        BarPriceSource::LAST,
+        MarketDataTransport::HYBRID);
 
-    const auto handle = MarketDataSubscriptionHandle::from_request(42, request);
+    EXPECT_TRUE(request.valid());
+    EXPECT_EQ(request.symbol, "BTCUSDT");
+    EXPECT_EQ(request.timeframe, 86400u);
+    EXPECT_EQ(request.price_source, BarPriceSource::LAST);
+    EXPECT_EQ(request.transport, MarketDataTransport::HYBRID);
 
-    EXPECT_TRUE(handle.valid());
-    EXPECT_EQ(handle.id, 42u);
-    EXPECT_EQ(handle.symbol, request.symbol);
-    EXPECT_EQ(handle.stream_type, request.stream_type);
-    EXPECT_EQ(handle.timeframe, request.timeframe);
-    EXPECT_EQ(handle.price_source, request.price_source);
+    EXPECT_FALSE(BarSubscriptionRequest("EUR/USD", 0).valid());
+    EXPECT_FALSE(BarSubscriptionRequest("", 60).valid());
+}
+
+TEST(MarketDataSubscriptionHandle, BuildsTickAndBarHandlesAndReportsValidity) {
+    const TickSubscriptionRequest tick_request("EUR/USD", MarketDataTransport::POLLING);
+    const auto tick_handle =
+        MarketDataSubscriptionHandle::from_tick_request(11, 42, tick_request);
+
+    EXPECT_TRUE(tick_handle.valid());
+    EXPECT_EQ(tick_handle.provider_id, 11u);
+    EXPECT_EQ(tick_handle.id, 42u);
+    EXPECT_EQ(tick_handle.symbol, tick_request.symbol);
+    EXPECT_EQ(tick_handle.stream_type, MarketDataStreamType::TICKS);
+    EXPECT_EQ(tick_handle.timeframe, 0u);
+    EXPECT_EQ(tick_handle.transport, tick_request.transport);
+
+    const BarSubscriptionRequest bar_request("BTCUSDT", 86400, BarPriceSource::LAST);
+    const auto bar_handle =
+        MarketDataSubscriptionHandle::from_bar_request(11, 43, bar_request);
+
+    EXPECT_TRUE(bar_handle.valid());
+    EXPECT_EQ(bar_handle.provider_id, 11u);
+    EXPECT_EQ(bar_handle.id, 43u);
+    EXPECT_EQ(bar_handle.symbol, bar_request.symbol);
+    EXPECT_EQ(bar_handle.stream_type, MarketDataStreamType::BARS);
+    EXPECT_EQ(bar_handle.timeframe, 86400u);
+    EXPECT_EQ(bar_handle.price_source, bar_request.price_source);
 
     EXPECT_FALSE(MarketDataSubscriptionHandle{}.valid());
+}
+
+TEST(MarketDataSubscriptionResult, DerivesSuccessFromStatus) {
+    const TickSubscriptionRequest request("EUR/USD");
+    const auto handle =
+        MarketDataSubscriptionHandle::from_tick_request(3, 7, request);
+
+    const auto subscribed = MarketDataSubscriptionResult::subscribed(handle);
+    EXPECT_TRUE(subscribed);
+    EXPECT_TRUE(subscribed.success());
+    EXPECT_EQ(subscribed.status, MarketDataSubscriptionStatus::SUBSCRIBED);
+
+    const auto failed = MarketDataSubscriptionResult::failed(
+        handle,
+        MarketDataSubscriptionStatus::FAILED,
+        "network error");
+    EXPECT_FALSE(failed);
+    EXPECT_FALSE(failed.success());
+    EXPECT_EQ(failed.status, MarketDataSubscriptionStatus::FAILED);
+}
+
+TEST(MarketDataSubscriptionResult, CannotSubscribeWithInvalidHandle) {
+    const auto result =
+        MarketDataSubscriptionResult::subscribed(MarketDataSubscriptionHandle{});
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::INVALID_REQUEST);
+    EXPECT_NE(result.error_message.find("invalid"), std::string::npos);
+}
+
+TEST(MarketDataSubscriptionResult, FailureFactoryDoesNotAcceptSuccessStatus) {
+    const TickSubscriptionRequest request("EUR/USD");
+    const auto result = MarketDataSubscriptionResult::failed(
+        request,
+        MarketDataSubscriptionStatus::SUBSCRIBED,
+        "not actually subscribed");
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::FAILED);
 }
 
 TEST(BaseMarketDataProvider, DefaultProviderRejectsTickSubscriptionsWithTypedResult) {
@@ -55,7 +106,7 @@ TEST(BaseMarketDataProvider, DefaultProviderRejectsTickSubscriptionsWithTypedRes
     int callback_count = 0;
 
     const bool accepted = provider.subscribe_ticks(
-        MarketDataSubscriptionRequest::ticks("EUR/USD"),
+        TickSubscriptionRequest("EUR/USD"),
         [&result, &callback_count](MarketDataSubscriptionResult subscription_result) {
             result = std::move(subscription_result);
             ++callback_count;
@@ -76,7 +127,7 @@ TEST(BaseMarketDataProvider, DefaultProviderRejectsInvalidBarSubscriptions) {
     int callback_count = 0;
 
     const bool accepted = provider.subscribe_bars(
-        MarketDataSubscriptionRequest::bars("EUR/USD", 0),
+        BarSubscriptionRequest("EUR/USD", 0),
         [&result, &callback_count](MarketDataSubscriptionResult subscription_result) {
             result = std::move(subscription_result);
             ++callback_count;
@@ -95,8 +146,9 @@ TEST(BaseMarketDataProvider, DefaultProviderRejectsUnsupportedUnsubscribe) {
     MarketDataSubscriptionResult result;
     int callback_count = 0;
 
-    const auto request = MarketDataSubscriptionRequest::ticks("BTCUSDT");
-    const auto handle = MarketDataSubscriptionHandle::from_request(7, request);
+    const TickSubscriptionRequest request("BTCUSDT");
+    const auto handle =
+        MarketDataSubscriptionHandle::from_tick_request(provider.provider_id(), 7, request);
 
     const bool accepted = provider.unsubscribe(
         handle,
@@ -109,7 +161,50 @@ TEST(BaseMarketDataProvider, DefaultProviderRejectsUnsupportedUnsubscribe) {
     EXPECT_EQ(callback_count, 1);
     EXPECT_FALSE(result);
     EXPECT_EQ(result.status, MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_EQ(result.subscription.provider_id, handle.provider_id);
     EXPECT_EQ(result.subscription.id, handle.id);
+}
+
+TEST(BaseMarketDataProvider, RejectsHandleFromAnotherProvider) {
+    BaseMarketDataProvider provider_a;
+    BaseMarketDataProvider provider_b;
+    MarketDataSubscriptionResult result;
+
+    const TickSubscriptionRequest request("BTCUSDT");
+    const auto handle_from_a =
+        MarketDataSubscriptionHandle::from_tick_request(provider_a.provider_id(), 9, request);
+
+    const bool accepted = provider_b.unsubscribe(
+        handle_from_a,
+        [&result](MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+        });
+
+    EXPECT_FALSE(accepted);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, MarketDataSubscriptionStatus::WRONG_PROVIDER);
+    EXPECT_EQ(to_str(result.status), std::string("WRONG_PROVIDER"));
+}
+
+TEST(BarTimeframe, SupportsDailyTimeframeWithoutTruncation) {
+    const Bar bar(1.0, 2.0, 0.5, 1.5, 10.0, 1000);
+    const SingleBar single_bar(
+        bar,
+        "EURUSD",
+        "test",
+        86400,
+        0,
+        5,
+        0);
+
+    EXPECT_EQ(single_bar.timeframe, 86400u);
+
+    BarSequence sequence;
+    sequence.timeframe = 86400;
+    EXPECT_EQ(sequence.timeframe, 86400u);
+
+    const BarHistoryRequest history_request("EURUSD", 86400, 1000, 2000);
+    EXPECT_EQ(history_request.timeframe, 86400u);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## What Changed

- Added market-data subscription enums, typed request DTOs, handle, and typed result DTOs.
- Added `subscribe_ticks`, `subscribe_bars`, and `unsubscribe` to `market_data::BaseMarketDataProvider`.
- Default provider behavior now reports typed invalid/unsupported subscription results through callbacks.
- Split live stream requests into `TickSubscriptionRequest` and `BarSubscriptionRequest`.
- Added runtime provider binding to subscription handles through `ProviderInstanceId`.
- Added `BarTimeframe` in `data/bars/types.hpp` and unified bar DTO/history timeframe fields as signed 32-bit seconds.
- Made `BaseMarketDataProvider` non-copyable/non-movable because provider instance IDs are runtime identity.
- Expanded Doxygen comments for the new market-data and bar DTO contracts.
- Documented the market-data provider/subscription architecture in the project guides.
- Added contract tests for request validation, handles, provider mismatch, result invariants, daily timeframes, default rejection, and unsubscribe semantics.
- Added `market_data_subscription_contract_test` to Ubuntu Smoke.

## Notes

- This PR only defines the public subscription contract.
- Broker-specific stream implementations are intentionally left for the next PR.
- Existing `on_tick_data()` / `on_bar_data()` data callbacks remain the delivery surface for live payloads.
- Headers under `market_data/*` are intended to be included through the `market_data.hpp` umbrella header.

## Validation

- `git diff --check`
- `cmake --build build-codex --target market_data_subscription_contract_test -j 4`
- `./build-codex/market_data_subscription_contract_test.exe --gtest_brief=1` - 12/12 passed
- `cmake --build build-codex --target header_only_odr_test -j 4`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` - 4/4 passed
- `cmake --build build-codex --target intrade_bar_api_response_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` - 49/49 passed
