### PR TITLE
[codex] Add Intrade market data tick subscriptions

### DIFF
--- a/include/optionx_cpp/platforms.hpp
+++ b/include/optionx_cpp/platforms.hpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -22,6 +22,7 @@
 #include "IntradeBarPlatform/ActiveTradesSyncManager.hpp"
 #include "IntradeBarPlatform/PriceManager.hpp"
 #include "IntradeBarPlatform/BtcPriceManager.hpp"
+#include "IntradeBarPlatform/MarketDataSubscriptionManager.hpp"
 #include "IntradeBarPlatform/TradeManager.hpp"
 
 namespace optionx::platforms {
@@ -51,6 +52,7 @@ namespace optionx::platforms {
               m_active_trades_sync_manager(*this, m_request_manager, m_account_info),
               m_price_manager(*this, m_request_manager),
               m_btc_price_manager(*this),
+              m_market_data_subscriptions(*this, m_tick_data_callback, m_bar_data_callback),
               m_trade_manager(*this, m_request_manager, m_account_info) {
         }
 
@@ -126,6 +128,43 @@ namespace optionx::platforms {
             return true;
         }
 
+        /// \brief Returns the live bar data callback.
+        market_data::BaseMarketDataProvider::bars_callback_t& on_bar_data() override {
+            return m_bar_data_callback;
+        }
+
+        /// \brief Returns the live tick data callback.
+        market_data::BaseMarketDataProvider::ticks_callback_t& on_tick_data() override {
+            return m_tick_data_callback;
+        }
+
+        /// \brief Requests an Intrade Bar live tick stream subscription.
+        bool subscribe_ticks(
+                market_data::MarketDataSubscriptionRequest request,
+                market_data::BaseMarketDataProvider::subscription_callback_t callback) override {
+            return m_market_data_subscriptions.subscribe_ticks(
+                std::move(request),
+                std::move(callback));
+        }
+
+        /// \brief Requests an Intrade Bar live bar stream subscription.
+        bool subscribe_bars(
+                market_data::MarketDataSubscriptionRequest request,
+                market_data::BaseMarketDataProvider::subscription_callback_t callback) override {
+            return m_market_data_subscriptions.subscribe_bars(
+                std::move(request),
+                std::move(callback));
+        }
+
+        /// \brief Stops an Intrade Bar live market-data subscription.
+        bool unsubscribe(
+                market_data::MarketDataSubscriptionHandle subscription,
+                market_data::BaseMarketDataProvider::subscription_callback_t callback) override {
+            return m_market_data_subscriptions.unsubscribe(
+                std::move(subscription),
+                std::move(callback));
+        }
+
         /// \brief Returns the platform-level trade result callback.
         /// \return Mutable callback reference from the trade execution component.
         trade_result_callback_t& on_trade_result() override {
@@ -153,6 +192,9 @@ namespace optionx::platforms {
         intrade_bar::ActiveTradesSyncManager m_active_trades_sync_manager; ///< Syncs broker active trade snapshots.
         intrade_bar::PriceManager         m_price_manager;    ///< Retrieves and updates price data.
         intrade_bar::BtcPriceManager      m_btc_price_manager;///< Retrieves BTC/USDT quotes from the websocket stream.
+        market_data::BaseMarketDataProvider::bars_callback_t m_bar_data_callback; ///< Live bar data callback.
+        market_data::BaseMarketDataProvider::ticks_callback_t m_tick_data_callback; ///< Live tick data callback.
+        intrade_bar::MarketDataSubscriptionManager m_market_data_subscriptions; ///< Routes live market-data streams.
         intrade_bar::TradeManager         m_trade_manager;    ///< Manages trades and status updates.
     }; // IntradeBarPlatform
 

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -52,7 +52,7 @@ namespace optionx::platforms {
               m_active_trades_sync_manager(*this, m_request_manager, m_account_info),
               m_price_manager(*this, m_request_manager),
               m_btc_price_manager(*this),
-              m_market_data_subscriptions(*this, m_tick_data_callback, m_bar_data_callback),
+              m_market_data_subscriptions(*this, provider_id(), m_tick_data_callback, m_bar_data_callback),
               m_trade_manager(*this, m_request_manager, m_account_info) {
         }
 
@@ -140,7 +140,7 @@ namespace optionx::platforms {
 
         /// \brief Requests an Intrade Bar live tick stream subscription.
         bool subscribe_ticks(
-                market_data::MarketDataSubscriptionRequest request,
+                market_data::TickSubscriptionRequest request,
                 market_data::BaseMarketDataProvider::subscription_callback_t callback) override {
             return m_market_data_subscriptions.subscribe_ticks(
                 std::move(request),
@@ -149,7 +149,7 @@ namespace optionx::platforms {
 
         /// \brief Requests an Intrade Bar live bar stream subscription.
         bool subscribe_bars(
-                market_data::MarketDataSubscriptionRequest request,
+                market_data::BarSubscriptionRequest request,
                 market_data::BaseMarketDataProvider::subscription_callback_t callback) override {
             return m_market_data_subscriptions.subscribe_bars(
                 std::move(request),

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -21,9 +21,11 @@ namespace optionx::platforms::intrade_bar {
         /// \param bars_callback Bar stream data callback owned by the platform.
         MarketDataSubscriptionManager(
                 BaseTradingPlatform& platform,
+                market_data::ProviderInstanceId provider_id,
                 ticks_callback_t& ticks_callback,
                 bars_callback_t& bars_callback)
                 : BaseComponent(platform.event_bus()),
+                  m_provider_id(provider_id),
                   m_ticks_callback(ticks_callback),
                   m_bars_callback(bars_callback) {
             subscribe<events::PriceUpdateEvent>();
@@ -32,12 +34,12 @@ namespace optionx::platforms::intrade_bar {
 
         /// \brief Requests a live tick subscription.
         bool subscribe_ticks(
-                market_data::MarketDataSubscriptionRequest request,
+                market_data::TickSubscriptionRequest request,
                 subscription_callback_t callback);
 
         /// \brief Requests a live bar subscription.
         bool subscribe_bars(
-                market_data::MarketDataSubscriptionRequest request,
+                market_data::BarSubscriptionRequest request,
                 subscription_callback_t callback);
 
         /// \brief Stops a live market-data subscription.
@@ -52,16 +54,17 @@ namespace optionx::platforms::intrade_bar {
         void shutdown() override;
 
     private:
+        market_data::ProviderInstanceId m_provider_id; ///< Owning provider instance ID.
         ticks_callback_t& m_ticks_callback; ///< Platform tick data callback.
         bars_callback_t&  m_bars_callback;  ///< Platform bar data callback.
         std::unordered_map<
-            market_data::MarketDataSubscriptionId,
+            market_data::SubscriptionId,
             market_data::MarketDataSubscriptionHandle> m_tick_subscriptions; ///< Active tick subscriptions.
-        market_data::MarketDataSubscriptionId m_next_subscription_id = 1; ///< Next runtime handle ID.
+        market_data::SubscriptionId m_next_subscription_id = 1; ///< Next runtime handle ID.
         std::mutex m_mutex; ///< Protects subscription handles.
 
         /// \brief Returns the next non-zero subscription ID.
-        market_data::MarketDataSubscriptionId next_subscription_id();
+        market_data::SubscriptionId next_subscription_id();
 
         /// \brief Returns true when any active tick subscription matches the symbol.
         bool has_tick_subscription_no_lock(const std::string& symbol) const;
@@ -76,9 +79,8 @@ namespace optionx::platforms::intrade_bar {
     };
 
     inline bool MarketDataSubscriptionManager::subscribe_ticks(
-            market_data::MarketDataSubscriptionRequest request,
+            market_data::TickSubscriptionRequest request,
             subscription_callback_t callback) {
-        request.stream_type = market_data::MarketDataStreamType::TICKS;
         request.symbol = normalize_symbol_name(std::move(request.symbol));
         if (!request.valid()) {
             dispatch_subscription_result(
@@ -93,7 +95,8 @@ namespace optionx::platforms::intrade_bar {
         market_data::MarketDataSubscriptionHandle handle;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            handle = market_data::MarketDataSubscriptionHandle::from_request(
+            handle = market_data::MarketDataSubscriptionHandle::from_tick_request(
+                m_provider_id,
                 next_subscription_id(),
                 request);
             m_tick_subscriptions[handle.id] = handle;
@@ -106,9 +109,8 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline bool MarketDataSubscriptionManager::subscribe_bars(
-            market_data::MarketDataSubscriptionRequest request,
+            market_data::BarSubscriptionRequest request,
             subscription_callback_t callback) {
-        request.stream_type = market_data::MarketDataStreamType::BARS;
         request.symbol = normalize_symbol_name(std::move(request.symbol));
         if (!request.valid()) {
             dispatch_subscription_result(
@@ -139,6 +141,15 @@ namespace optionx::platforms::intrade_bar {
                     std::move(subscription),
                     market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
                     "Invalid Intrade Bar market-data subscription handle."));
+            return false;
+        }
+        if (subscription.provider_id != m_provider_id) {
+            dispatch_subscription_result(
+                std::move(callback),
+                market_data::MarketDataSubscriptionResult::failed(
+                    std::move(subscription),
+                    market_data::MarketDataSubscriptionStatus::WRONG_PROVIDER,
+                    "Intrade Bar market-data subscription handle belongs to another provider."));
             return false;
         }
 
@@ -175,11 +186,11 @@ namespace optionx::platforms::intrade_bar {
         m_tick_subscriptions.clear();
     }
 
-    inline market_data::MarketDataSubscriptionId
+    inline market_data::SubscriptionId
     MarketDataSubscriptionManager::next_subscription_id() {
         const auto id = m_next_subscription_id;
         ++m_next_subscription_id;
-        if (m_next_subscription_id == market_data::kInvalidMarketDataSubscriptionId) {
+        if (m_next_subscription_id == market_data::kInvalidSubscriptionId) {
             m_next_subscription_id = 1;
         }
         return id;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -1,0 +1,228 @@
+#pragma once
+#ifndef _OPTIONX_PLATFORMS_INTRADERBAR_MARKET_DATA_SUBSCRIPTION_MANAGER_HPP_INCLUDED
+#define _OPTIONX_PLATFORMS_INTRADERBAR_MARKET_DATA_SUBSCRIPTION_MANAGER_HPP_INCLUDED
+
+/// \file MarketDataSubscriptionManager.hpp
+/// \brief Defines Intrade Bar live market-data subscription routing.
+
+namespace optionx::platforms::intrade_bar {
+
+    /// \class MarketDataSubscriptionManager
+    /// \brief Routes Intrade Bar price update events to market-data subscription callbacks.
+    class MarketDataSubscriptionManager final : public components::BaseComponent {
+    public:
+        using bars_callback_t = market_data::BaseMarketDataProvider::bars_callback_t;
+        using ticks_callback_t = market_data::BaseMarketDataProvider::ticks_callback_t;
+        using subscription_callback_t = market_data::BaseMarketDataProvider::subscription_callback_t;
+
+        /// \brief Constructs the subscription manager.
+        /// \param platform Owning platform facade.
+        /// \param ticks_callback Tick stream data callback owned by the platform.
+        /// \param bars_callback Bar stream data callback owned by the platform.
+        MarketDataSubscriptionManager(
+                BaseTradingPlatform& platform,
+                ticks_callback_t& ticks_callback,
+                bars_callback_t& bars_callback)
+                : BaseComponent(platform.event_bus()),
+                  m_ticks_callback(ticks_callback),
+                  m_bars_callback(bars_callback) {
+            subscribe<events::PriceUpdateEvent>();
+            platform.register_component(this);
+        }
+
+        /// \brief Requests a live tick subscription.
+        bool subscribe_ticks(
+                market_data::MarketDataSubscriptionRequest request,
+                subscription_callback_t callback);
+
+        /// \brief Requests a live bar subscription.
+        bool subscribe_bars(
+                market_data::MarketDataSubscriptionRequest request,
+                subscription_callback_t callback);
+
+        /// \brief Stops a live market-data subscription.
+        bool unsubscribe(
+                market_data::MarketDataSubscriptionHandle subscription,
+                subscription_callback_t callback);
+
+        /// \brief Routes price events to active tick subscriptions.
+        void on_event(const utils::Event* const event) override;
+
+        /// \brief Clears all runtime subscriptions.
+        void shutdown() override;
+
+    private:
+        ticks_callback_t& m_ticks_callback; ///< Platform tick data callback.
+        bars_callback_t&  m_bars_callback;  ///< Platform bar data callback.
+        std::unordered_map<
+            market_data::MarketDataSubscriptionId,
+            market_data::MarketDataSubscriptionHandle> m_tick_subscriptions; ///< Active tick subscriptions.
+        market_data::MarketDataSubscriptionId m_next_subscription_id = 1; ///< Next runtime handle ID.
+        std::mutex m_mutex; ///< Protects subscription handles.
+
+        /// \brief Returns the next non-zero subscription ID.
+        market_data::MarketDataSubscriptionId next_subscription_id();
+
+        /// \brief Returns true when any active tick subscription matches the symbol.
+        bool has_tick_subscription_no_lock(const std::string& symbol) const;
+
+        /// \brief Delivers a subscription operation result when a callback was supplied.
+        static void dispatch_subscription_result(
+                subscription_callback_t callback,
+                market_data::MarketDataSubscriptionResult result);
+
+        /// \brief Handles incoming price update events.
+        void handle_event(const events::PriceUpdateEvent& event);
+    };
+
+    inline bool MarketDataSubscriptionManager::subscribe_ticks(
+            market_data::MarketDataSubscriptionRequest request,
+            subscription_callback_t callback) {
+        request.stream_type = market_data::MarketDataStreamType::TICKS;
+        request.symbol = normalize_symbol_name(std::move(request.symbol));
+        if (!request.valid()) {
+            dispatch_subscription_result(
+                std::move(callback),
+                market_data::MarketDataSubscriptionResult::failed(
+                    std::move(request),
+                    market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
+                    "Invalid Intrade Bar tick subscription request."));
+            return false;
+        }
+
+        market_data::MarketDataSubscriptionHandle handle;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            handle = market_data::MarketDataSubscriptionHandle::from_request(
+                next_subscription_id(),
+                request);
+            m_tick_subscriptions[handle.id] = handle;
+        }
+
+        dispatch_subscription_result(
+            std::move(callback),
+            market_data::MarketDataSubscriptionResult::subscribed(handle));
+        return true;
+    }
+
+    inline bool MarketDataSubscriptionManager::subscribe_bars(
+            market_data::MarketDataSubscriptionRequest request,
+            subscription_callback_t callback) {
+        request.stream_type = market_data::MarketDataStreamType::BARS;
+        request.symbol = normalize_symbol_name(std::move(request.symbol));
+        if (!request.valid()) {
+            dispatch_subscription_result(
+                std::move(callback),
+                market_data::MarketDataSubscriptionResult::failed(
+                    std::move(request),
+                    market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
+                    "Invalid Intrade Bar bar subscription request."));
+            return false;
+        }
+
+        dispatch_subscription_result(
+            std::move(callback),
+            market_data::MarketDataSubscriptionResult::failed(
+                std::move(request),
+                market_data::MarketDataSubscriptionStatus::UNSUPPORTED,
+                "Intrade Bar bar subscriptions require a tick-to-bar aggregator and are not supported yet."));
+        return false;
+    }
+
+    inline bool MarketDataSubscriptionManager::unsubscribe(
+            market_data::MarketDataSubscriptionHandle subscription,
+            subscription_callback_t callback) {
+        if (!subscription.valid()) {
+            dispatch_subscription_result(
+                std::move(callback),
+                market_data::MarketDataSubscriptionResult::failed(
+                    std::move(subscription),
+                    market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
+                    "Invalid Intrade Bar market-data subscription handle."));
+            return false;
+        }
+
+        bool removed = false;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            removed = m_tick_subscriptions.erase(subscription.id) > 0;
+        }
+
+        if (!removed) {
+            dispatch_subscription_result(
+                std::move(callback),
+                market_data::MarketDataSubscriptionResult::failed(
+                    std::move(subscription),
+                    market_data::MarketDataSubscriptionStatus::FAILED,
+                    "Intrade Bar market-data subscription is not active."));
+            return false;
+        }
+
+        dispatch_subscription_result(
+            std::move(callback),
+            market_data::MarketDataSubscriptionResult::unsubscribed(std::move(subscription)));
+        return true;
+    }
+
+    inline void MarketDataSubscriptionManager::on_event(const utils::Event* const event) {
+        if (const auto* msg = dynamic_cast<const events::PriceUpdateEvent*>(event)) {
+            handle_event(*msg);
+        }
+    }
+
+    inline void MarketDataSubscriptionManager::shutdown() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_tick_subscriptions.clear();
+    }
+
+    inline market_data::MarketDataSubscriptionId
+    MarketDataSubscriptionManager::next_subscription_id() {
+        const auto id = m_next_subscription_id;
+        ++m_next_subscription_id;
+        if (m_next_subscription_id == market_data::kInvalidMarketDataSubscriptionId) {
+            m_next_subscription_id = 1;
+        }
+        return id;
+    }
+
+    inline bool MarketDataSubscriptionManager::has_tick_subscription_no_lock(
+            const std::string& symbol) const {
+        for (const auto& [id, subscription] : m_tick_subscriptions) {
+            (void)id;
+            if (subscription.symbol == symbol) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    inline void MarketDataSubscriptionManager::dispatch_subscription_result(
+            subscription_callback_t callback,
+            market_data::MarketDataSubscriptionResult result) {
+        if (callback) {
+            callback(std::move(result));
+        }
+    }
+
+    inline void MarketDataSubscriptionManager::handle_event(
+            const events::PriceUpdateEvent& event) {
+        std::vector<SingleTick> ticks;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_tick_subscriptions.empty()) return;
+
+            for (const auto& tick : event.get_ticks()) {
+                if (has_tick_subscription_no_lock(normalize_symbol_name(tick.symbol))) {
+                    ticks.push_back(tick);
+                }
+            }
+        }
+
+        if (!ticks.empty() && m_ticks_callback) {
+            m_ticks_callback(ticks);
+        }
+    }
+
+} // namespace optionx::platforms::intrade_bar
+
+#endif // _OPTIONX_PLATFORMS_INTRADERBAR_MARKET_DATA_SUBSCRIPTION_MANAGER_HPP_INCLUDED

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <server_http.hpp>
@@ -57,6 +58,21 @@ public:
 
 class UnsupportedEndpointConfig final : public optionx::IEndpointConfig {
 };
+
+SingleTick make_market_data_tick(const std::string& symbol, double bid, double ask) {
+    SingleTick tick;
+    tick.symbol = symbol;
+    tick.provider = to_str(PlatformType::INTRADE_BAR);
+    tick.price_digits = price_digits_for_symbol(symbol);
+    tick.volume_digits = 0;
+    tick.tick.bid = bid;
+    tick.tick.ask = ask;
+    tick.tick.time_ms = 1000;
+    tick.tick.received_ms = 1001;
+    tick.set_flag(TickStatusFlags::INITIALIZED);
+    tick.set_flag(TickStatusFlags::REALTIME);
+    return tick;
+}
 
 using TradeHistoryHttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
 
@@ -529,6 +545,109 @@ TEST(IntradeBarApiResponses, IntradeBarPlatformExposesEndpointTradingAndMarketDa
     EXPECT_FALSE(market_data_provider->fetch_bar_history(BarHistoryRequest{}, nullptr));
     EXPECT_FALSE(endpoint->configure(std::make_unique<UnsupportedEndpointConfig>()));
     EXPECT_TRUE(endpoint->configure(std::make_unique<AuthData>()));
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents) {
+    IntradeBarPlatform platform;
+    std::vector<SingleTick> delivered_ticks;
+    int tick_callback_count = 0;
+    market_data::MarketDataSubscriptionResult subscription_result;
+
+    platform.on_tick_data() =
+        [&delivered_ticks, &tick_callback_count](const std::vector<SingleTick>& ticks) {
+            delivered_ticks = ticks;
+            ++tick_callback_count;
+        };
+
+    const bool accepted = platform.subscribe_ticks(
+        market_data::MarketDataSubscriptionRequest::ticks(
+            "EUR/USD",
+            market_data::MarketDataTransport::POLLING),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        });
+
+    EXPECT_TRUE(accepted);
+    ASSERT_TRUE(subscription_result);
+    EXPECT_EQ(subscription_result.status, market_data::MarketDataSubscriptionStatus::SUBSCRIBED);
+    EXPECT_TRUE(subscription_result.subscription.valid());
+    EXPECT_EQ(subscription_result.subscription.symbol, "EURUSD");
+    EXPECT_EQ(subscription_result.subscription.stream_type, market_data::MarketDataStreamType::TICKS);
+
+    std::vector<SingleTick> event_ticks = {
+        make_market_data_tick("EURUSD", 1.0, 1.1),
+        make_market_data_tick("BTCUSDT", 60000.0, 60001.0)
+    };
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    platform.event_bus().process();
+
+    ASSERT_EQ(tick_callback_count, 1);
+    ASSERT_EQ(delivered_ticks.size(), 1u);
+    EXPECT_EQ(delivered_ticks[0].symbol, "EURUSD");
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
+    IntradeBarPlatform platform;
+    int tick_callback_count = 0;
+    market_data::MarketDataSubscriptionResult subscription_result;
+    market_data::MarketDataSubscriptionResult unsubscribe_result;
+
+    platform.on_tick_data() =
+        [&tick_callback_count](const std::vector<SingleTick>& ticks) {
+            if (!ticks.empty()) {
+                ++tick_callback_count;
+            }
+        };
+
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::MarketDataSubscriptionRequest::ticks("BTC/USD"),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+
+    EXPECT_TRUE(platform.unsubscribe(
+        subscription_result.subscription,
+        [&unsubscribe_result](market_data::MarketDataSubscriptionResult result) {
+            unsubscribe_result = std::move(result);
+        }));
+
+    EXPECT_TRUE(unsubscribe_result);
+    EXPECT_EQ(unsubscribe_result.status, market_data::MarketDataSubscriptionStatus::UNSUBSCRIBED);
+
+    std::vector<SingleTick> event_ticks = {
+        make_market_data_tick("BTCUSDT", 60000.0, 60001.0)
+    };
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    platform.event_bus().process();
+
+    EXPECT_EQ(tick_callback_count, 0);
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionsReportUnsupportedTypedResult) {
+    IntradeBarPlatform platform;
+    market_data::MarketDataSubscriptionResult result;
+
+    const bool accepted = platform.subscribe_bars(
+        market_data::MarketDataSubscriptionRequest::bars("EUR/USD", 60),
+        [&result](market_data::MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+        });
+
+    EXPECT_FALSE(accepted);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_EQ(result.subscription.symbol, "EURUSD");
+    EXPECT_EQ(result.subscription.stream_type, market_data::MarketDataStreamType::BARS);
 
     platform.shutdown();
 }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -562,7 +562,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents
         };
 
     const bool accepted = platform.subscribe_ticks(
-        market_data::MarketDataSubscriptionRequest::ticks(
+        market_data::TickSubscriptionRequest(
             "EUR/USD",
             market_data::MarketDataTransport::POLLING),
         [&subscription_result](market_data::MarketDataSubscriptionResult result) {
@@ -573,6 +573,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents
     ASSERT_TRUE(subscription_result);
     EXPECT_EQ(subscription_result.status, market_data::MarketDataSubscriptionStatus::SUBSCRIBED);
     EXPECT_TRUE(subscription_result.subscription.valid());
+    EXPECT_EQ(subscription_result.subscription.provider_id, platform.provider_id());
     EXPECT_EQ(subscription_result.subscription.symbol, "EURUSD");
     EXPECT_EQ(subscription_result.subscription.stream_type, market_data::MarketDataStreamType::TICKS);
 
@@ -606,7 +607,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
         };
 
     ASSERT_TRUE(platform.subscribe_ticks(
-        market_data::MarketDataSubscriptionRequest::ticks("BTC/USD"),
+        market_data::TickSubscriptionRequest("BTC/USD"),
         [&subscription_result](market_data::MarketDataSubscriptionResult result) {
             subscription_result = std::move(result);
         }));
@@ -638,7 +639,7 @@ TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionsReportUnsupportedTypedRes
     market_data::MarketDataSubscriptionResult result;
 
     const bool accepted = platform.subscribe_bars(
-        market_data::MarketDataSubscriptionRequest::bars("EUR/USD", 60),
+        market_data::BarSubscriptionRequest("EUR/USD", 60),
         [&result](market_data::MarketDataSubscriptionResult subscription_result) {
             result = std::move(subscription_result);
         });


### PR DESCRIPTION
## What Changed

- Added `IntradeBarPlatform::on_tick_data()` / `on_bar_data()` overrides backed by platform-owned callbacks.
- Added an Intrade Bar market-data subscription manager that owns tick subscription handles.
- Routed existing Intrade Bar `PriceUpdateEvent` ticks into subscribed market-data callbacks with broker symbol normalization.
- Added typed subscribe/unsubscribe behavior for Intrade tick streams.
- Bound Intrade subscription handles to the provider instance ID from the market-data contract.
- Added explicit typed `UNSUPPORTED` response for live bar subscriptions until tick-to-bar aggregation is implemented.
- Added regression tests for tick routing, unsubscribe behavior, and unsupported bar subscriptions.

## Notes

- This PR is stacked on #56 and depends on the market-data subscription contract.
- Tick subscriptions use the current Intrade price event pipeline:
  - regular symbols come from the existing `/price_now` polling manager;
  - BTCUSDT comes from the existing websocket manager.
- A quotes-only lifecycle that starts market-data streams without the trading auth/connect flow is intentionally left for a follow-up PR.
- Native FX websocket fan-out and live tick-to-bar aggregation are also follow-up work.

## Validation

- `git diff --check`
- `cmake --build build-codex --target intrade_bar_api_response_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1` - 52/52 passed
- `cmake --build build-codex --target header_only_odr_test -j 4`
- `./build-codex/header_only_odr_test.exe --gtest_brief=1` - 4/4 passed
- `cmake --build build-codex --target market_data_subscription_contract_test -j 4`
- `./build-codex/market_data_subscription_contract_test.exe --gtest_brief=1` - 12/12 passed
