### PR TITLE
[codex] Improve market-data subscription lifecycle

### DIFF
--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
@@ -654,11 +654,11 @@ namespace optionx::components {
                 result->trade_state = TradeState::IN_PROGRESS;
             }
 
-            auto tick = event.get_tick_by_symbol(request->symbol);
-            if (!tick.tick.has_flag(MarketDataFlags::INITIALIZED)) continue;
+            const auto* quote = event.find_tick_by_symbol(request->symbol);
+            if (!quote || !quote->has_flag(MarketDataFlags::INITIALIZED)) continue;
 
-            result->close_price = tick.mid_price();
-            result->live_state = m_trade_state_manager.determine_trade_state(result, request, tick);
+            result->close_price = quote->mid_price();
+            result->live_state = m_trade_state_manager.determine_trade_state(result, request, *quote);
             dispatch_trade_event(transaction);
         }
     }

--- a/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
+++ b/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
@@ -29,6 +29,18 @@ namespace optionx::events {
             return m_ticks;
         }
 
+        /// \brief Finds a tick wrapper by its normalized symbol name.
+        /// \param symbol Symbol to find.
+        /// \return Pointer to the matching tick wrapper, or nullptr when absent.
+        const SingleTick* find_tick_by_symbol(const std::string& symbol) const {
+            for (const auto& tick : m_ticks) {
+                if (tick.symbol == symbol) {
+                    return &tick;
+                }
+            }
+            return nullptr;
+        }
+
         /// \brief Returns the source that produced this tick update.
         /// \return Transport-level market-data source for routing decisions.
         MarketDataUpdateSource source() const noexcept {
@@ -48,12 +60,10 @@ namespace optionx::events {
 
         /// \brief Finds a tick by its symbol name.
         /// \param symbol The name of the symbol to find.
-        /// \return An optional containing the found SingleTick.
+        /// \return Matching tick wrapper, or a default wrapper when absent.
         SingleTick get_tick_by_symbol(const std::string& symbol) const {
-            for (const auto& tick : m_ticks) {
-                if (tick.symbol == symbol) {
-                    return tick;
-                }
+            if (const auto* tick = find_tick_by_symbol(symbol)) {
+                return *tick;
             }
             return SingleTick();
         }

--- a/include/optionx_cpp/data/ticks/SingleTick.hpp
+++ b/include/optionx_cpp/data/ticks/SingleTick.hpp
@@ -46,6 +46,20 @@ namespace optionx {
         double mid_price() const {
             return utils::normalize_double(tick.mid_price(), price_digits);
         }
+
+        /// \brief Checks whether a market-data payload flag is set.
+        /// \param flag Market-data flag to check.
+        /// \return True if the wrapped tick has the flag.
+        [[nodiscard]] bool has_flag(MarketDataFlags flag) const noexcept {
+            return tick.has_flag(flag);
+        }
+
+        /// \brief Checks whether a tick update flag is set.
+        /// \param flag Tick update flag to check.
+        /// \return True if the wrapped tick has the flag.
+        [[nodiscard]] bool has_flag(TickUpdateFlags flag) const noexcept {
+            return tick.has_flag(flag);
+        }
     };
 
 } // namespace optionx

--- a/include/optionx_cpp/market_data/enums.hpp
+++ b/include/optionx_cpp/market_data/enums.hpp
@@ -47,7 +47,7 @@ namespace optionx::market_data {
         UNKNOWN = 0,  ///< No status has been assigned.
         CONNECTING,   ///< Stream connection is being established.
         CONNECTED,    ///< Transport is connected.
-        READY,        ///< Stream transport is connected and source-specific subscription is ready.
+        READY,        ///< Stream transport is connected and provider-specific setup is complete; payload may arrive later.
         DISCONNECTED, ///< Stream transport disconnected.
         RECONNECTING, ///< Stream is reconnecting.
         STOPPED,      ///< Stream was stopped intentionally.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -63,6 +63,9 @@ namespace optionx::platforms {
                   m_bar_data_callback,
                   &m_fx_price_websocket_manager),
               m_trade_manager(*this, m_request_manager, m_account_info) {
+            m_btc_price_manager.set_status_sink(
+                provider_id(),
+                &m_market_data_status_callback);
             m_fx_price_websocket_manager.set_status_sink(
                 provider_id(),
                 &m_market_data_status_callback);
@@ -71,6 +74,12 @@ namespace optionx::platforms {
         /// \brief Shuts down components while platform-owned component instances are still alive.
         ~IntradeBarPlatform() override {
             shutdown();
+            m_btc_price_manager.set_status_sink(
+                market_data::kInvalidProviderInstanceId,
+                nullptr);
+            m_fx_price_websocket_manager.set_status_sink(
+                market_data::kInvalidProviderInstanceId,
+                nullptr);
         }
 
         /// \brief Places a trade on the platform.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -42,6 +42,7 @@ namespace optionx::platforms::intrade_bar {
                     m_tick_data[0].tick.flags = 0;
                     m_is_error = false;
                     emit_status(market_data::MarketDataStreamStatus::CONNECTED);
+                    // `/bapi` is a fixed BTCUSDT stream; no subscribe frame is needed.
                     emit_status(market_data::MarketDataStreamStatus::READY);
                     break;
                 case kurlyk::WebSocketEventType::WS_MESSAGE:
@@ -106,9 +107,6 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Handles incoming WebSocket messages.
         /// \param message The received message as a JSON string.
         void handle_message(const std::string& message);
-
-        /// \brief Converts an HTTP(S) or WS(S) host setting to a websocket host.
-        static std::string make_websocket_host(const std::string& host);
 
         /// \brief Emits a public BTCUSDT stream status update when a callback is configured.
         void emit_status(
@@ -219,25 +217,6 @@ namespace optionx::platforms::intrade_bar {
                 m_tick_data,
                 MarketDataUpdateSource::WEBSOCKET));
         }
-    }
-
-    inline std::string BtcPriceManager::make_websocket_host(
-            const std::string& host) {
-        const std::string wss_prefix = "wss://";
-        const std::string ws_prefix = "ws://";
-        const std::string https_prefix = "https://";
-        const std::string http_prefix = "http://";
-
-        if (host.rfind(wss_prefix, 0) == 0 || host.rfind(ws_prefix, 0) == 0) {
-            return host;
-        }
-        if (host.rfind(https_prefix, 0) == 0) {
-            return wss_prefix + host.substr(https_prefix.size());
-        }
-        if (host.rfind(http_prefix, 0) == 0) {
-            return ws_prefix + host.substr(http_prefix.size());
-        }
-        return wss_prefix + host;
     }
 
     inline void BtcPriceManager::emit_status(

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -35,11 +35,14 @@ namespace optionx::platforms::intrade_bar {
             m_tick_data[0].provider = to_str(PlatformType::INTRADE_BAR);
 
             m_websocket_client.on_event([this](std::unique_ptr<kurlyk::WebSocketEventData> event) {
+                if (!event) return;
                 switch (event->event_type) {
                 case kurlyk::WebSocketEventType::WS_OPEN:
                     LOGIT_INFO(event->status_code, event->error_code);
                     m_tick_data[0].tick.flags = 0;
                     m_is_error = false;
+                    emit_status(market_data::MarketDataStreamStatus::CONNECTED);
+                    emit_status(market_data::MarketDataStreamStatus::READY);
                     break;
                 case kurlyk::WebSocketEventType::WS_MESSAGE:
                     handle_message(event->message);
@@ -48,12 +51,16 @@ namespace optionx::platforms::intrade_bar {
                     LOGIT_INFO(event->status_code, event->error_code);
                     m_tick_data[0].tick.flags = 0;
                     m_is_error = false;
+                    emit_status(market_data::MarketDataStreamStatus::DISCONNECTED);
                     break;
                 case kurlyk::WebSocketEventType::WS_ERROR:
                     if (m_is_error) return;
                     LOGIT_ERROR(event->status_code, event->error_code);
                     m_tick_data[0].tick.flags = 0;
                     m_is_error = true;
+                    emit_status(
+                        market_data::MarketDataStreamStatus::FAILED,
+                        event->error_code.message());
                     break;
                 default:
                     break;
@@ -80,14 +87,33 @@ namespace optionx::platforms::intrade_bar {
             m_websocket_client.set_max_send_queue_size(max);
         }
 
+        /// \brief Sets the optional status callback sink used by the public market-data API.
+        /// \param provider_id Runtime market-data provider ID.
+        /// \param callback Callback reference owned by the provider facade.
+        void set_status_sink(
+                market_data::ProviderInstanceId provider_id,
+                market_data::BaseMarketDataProvider::status_callback_t* callback);
+
     private:
         kurlyk::WebSocketClient m_websocket_client; ///< WebSocket client for BTCUSDT.
         std::vector<SingleTick>   m_tick_data;        ///< Container for tick data.
         bool                    m_is_error = false; ///< Flag indicating if an error has occurred.
+        std::mutex m_status_mutex; ///< Protects status sink metadata.
+        market_data::ProviderInstanceId m_provider_id =
+            market_data::kInvalidProviderInstanceId; ///< Optional status provider ID.
+        market_data::BaseMarketDataProvider::status_callback_t* m_status_callback = nullptr; ///< Optional status sink.
 
         /// \brief Handles incoming WebSocket messages.
         /// \param message The received message as a JSON string.
         void handle_message(const std::string& message);
+
+        /// \brief Converts an HTTP(S) or WS(S) host setting to a websocket host.
+        static std::string make_websocket_host(const std::string& host);
+
+        /// \brief Emits a public BTCUSDT stream status update when a callback is configured.
+        void emit_status(
+                market_data::MarketDataStreamStatus status,
+                std::string message = {});
 
         /// \brief Handles an authentication event.
         /// \param event The received authentication data event.
@@ -105,10 +131,18 @@ namespace optionx::platforms::intrade_bar {
         /// \param event The account info update event.
         void handle_event(const events::AccountInfoUpdateEvent& event);
         
-        /// \brief 
-        /// \param event
+        /// \brief Applies the selected auto-domain host to the BTC websocket.
+        /// \param event Auto-domain selection result.
         void handle_event(const events::AutoDomainSelectedEvent& event);
     };
+
+    inline void BtcPriceManager::set_status_sink(
+            market_data::ProviderInstanceId provider_id,
+            market_data::BaseMarketDataProvider::status_callback_t* callback) {
+        std::lock_guard<std::mutex> lock(m_status_mutex);
+        m_provider_id = provider_id;
+        m_status_callback = callback;
+    }
 
     inline void BtcPriceManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::AuthDataEvent*>(event)) {
@@ -135,9 +169,8 @@ namespace optionx::platforms::intrade_bar {
             auto [success, message] = auth_data->validate();
             if (!success) return;
             
-            if (!auth_data->auto_find_domain) {
-                std::string host = "wss://" + utils::remove_http_prefix(auth_data->host);
-                m_websocket_client.set_url(host, "/bapi");
+            if (!auth_data->auto_find_domain && !auth_data->host.empty()) {
+                m_websocket_client.set_url(make_websocket_host(auth_data->host), "/bapi");
             }
 
             m_websocket_client.set_user_agent(auth_data->user_agent);
@@ -175,9 +208,8 @@ namespace optionx::platforms::intrade_bar {
     
     inline void BtcPriceManager::handle_event(const events::AutoDomainSelectedEvent& event) {
         LOGIT_0TRACE();
-        if (event.success) {
-            std::string host = "wss://" + utils::remove_http_prefix(event.selected_host);
-            m_websocket_client.set_url(host, "/bapi");
+        if (event.success && !event.selected_host.empty()) {
+            m_websocket_client.set_url(make_websocket_host(event.selected_host), "/bapi");
         }
     }
 
@@ -187,6 +219,47 @@ namespace optionx::platforms::intrade_bar {
                 m_tick_data,
                 MarketDataUpdateSource::WEBSOCKET));
         }
+    }
+
+    inline std::string BtcPriceManager::make_websocket_host(
+            const std::string& host) {
+        const std::string wss_prefix = "wss://";
+        const std::string ws_prefix = "ws://";
+        const std::string https_prefix = "https://";
+        const std::string http_prefix = "http://";
+
+        if (host.rfind(wss_prefix, 0) == 0 || host.rfind(ws_prefix, 0) == 0) {
+            return host;
+        }
+        if (host.rfind(https_prefix, 0) == 0) {
+            return wss_prefix + host.substr(https_prefix.size());
+        }
+        if (host.rfind(http_prefix, 0) == 0) {
+            return ws_prefix + host.substr(http_prefix.size());
+        }
+        return wss_prefix + host;
+    }
+
+    inline void BtcPriceManager::emit_status(
+            market_data::MarketDataStreamStatus status,
+            std::string message) {
+        market_data::BaseMarketDataProvider::status_callback_t* callback = nullptr;
+        market_data::ProviderInstanceId provider_id = market_data::kInvalidProviderInstanceId;
+        {
+            std::lock_guard<std::mutex> lock(m_status_mutex);
+            callback = m_status_callback;
+            provider_id = m_provider_id;
+        }
+        if (!callback || !*callback) return;
+
+        market_data::MarketDataStatusUpdate update;
+        update.provider_id = provider_id;
+        update.type = market_data::MarketDataType::TICKS;
+        update.symbol = "BTCUSDT";
+        update.transport = market_data::MarketDataTransport::WEBSOCKET;
+        update.status = status;
+        update.message = std::move(message);
+        (*callback)(std::move(update));
     }
 
     inline void BtcPriceManager::process() {

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
@@ -80,9 +80,6 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Configures a websocket client from current manager settings.
         void configure_client_no_lock(kurlyk::WebSocketClient& client) const;
 
-        /// \brief Converts an HTTP(S) or WS(S) host setting to a websocket host.
-        static std::string make_websocket_host(const std::string& host);
-
         /// \brief Creates a configured websocket stream state for a normalized FX symbol.
         std::shared_ptr<FxStreamState> create_stream_no_lock(
                 const std::string& symbol,
@@ -235,25 +232,6 @@ namespace optionx::platforms::intrade_bar {
         client.set_proxy_server(m_proxy_server);
         client.set_proxy_auth(m_proxy_auth);
         client.set_proxy_type(m_proxy_type);
-    }
-
-    inline std::string FxPriceWebSocketManager::make_websocket_host(
-            const std::string& host) {
-        const std::string wss_prefix = "wss://";
-        const std::string ws_prefix = "ws://";
-        const std::string https_prefix = "https://";
-        const std::string http_prefix = "http://";
-
-        if (host.rfind(wss_prefix, 0) == 0 || host.rfind(ws_prefix, 0) == 0) {
-            return host;
-        }
-        if (host.rfind(https_prefix, 0) == 0) {
-            return wss_prefix + host.substr(https_prefix.size());
-        }
-        if (host.rfind(http_prefix, 0) == 0) {
-            return ws_prefix + host.substr(http_prefix.size());
-        }
-        return wss_prefix + host;
     }
 
     inline std::shared_ptr<FxPriceWebSocketManager::FxStreamState>

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -175,6 +175,8 @@ namespace optionx::platforms::intrade_bar {
         std::vector<market_data::MarketDataSubscriptionHandle> removed_subscriptions;
         std::vector<market_data::MarketDataSubscriptionResult> results;
         market_data::MarketDataSubscriptionBatchResult failure_result;
+        market_data::SubscriptionId previous_next_subscription_id =
+            market_data::kInvalidSubscriptionId;
         bool failed = false;
         results.reserve(batch.changes.size());
 
@@ -192,6 +194,7 @@ namespace optionx::platforms::intrade_bar {
         {
             std::lock_guard<std::mutex> lock(m_mutex);
 
+            previous_next_subscription_id = m_next_subscription_id;
             auto next_id = m_next_subscription_id;
             for (auto& change : batch.changes) {
                 switch (change.action) {
@@ -336,12 +339,25 @@ namespace optionx::platforms::intrade_bar {
                     for (const auto& activated : activated_fx_subscriptions) {
                         m_fx_websocket_source->remove_symbol_subscription(activated.symbol);
                     }
+                    for (const auto& removed : removed_subscriptions) {
+                        if (uses_fx_websocket_source(removed) &&
+                            !m_fx_websocket_source->add_symbol_subscription(removed.symbol)) {
+                            LOGIT_WARN(
+                                "Failed to restore Intrade Bar FX websocket tick source for ",
+                                removed.symbol,
+                                " after subscription batch rollback.");
+                        }
+                    }
 
                     {
                         std::lock_guard<std::mutex> lock(m_mutex);
                         for (const auto& added : added_subscriptions) {
                             m_tick_subscriptions.erase(added.id);
                         }
+                        for (const auto& removed : removed_subscriptions) {
+                            m_tick_subscriptions[removed.id] = removed;
+                        }
+                        m_next_subscription_id = previous_next_subscription_id;
                     }
 
                     dispatch_subscription_batch_result(

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/http_utils.hpp
@@ -50,6 +50,27 @@ namespace optionx::platforms::intrade_bar {
         return 5;
     }
 
+    /// \brief Converts an HTTP(S) or WS(S) host setting to a websocket host.
+    /// \param host Broker host value from endpoint configuration.
+    /// \return Host with `ws://` or `wss://` scheme.
+    inline std::string make_websocket_host(const std::string& host) {
+        const std::string wss_prefix = "wss://";
+        const std::string ws_prefix = "ws://";
+        const std::string https_prefix = "https://";
+        const std::string http_prefix = "http://";
+
+        if (host.rfind(wss_prefix, 0) == 0 || host.rfind(ws_prefix, 0) == 0) {
+            return host;
+        }
+        if (host.rfind(https_prefix, 0) == 0) {
+            return wss_prefix + host.substr(https_prefix.size());
+        }
+        if (host.rfind(http_prefix, 0) == 0) {
+            return ws_prefix + host.substr(http_prefix.size());
+        }
+        return wss_prefix + host;
+    }
+
     /// \brief Marks a SpreadPack as a known zero-spread Intrade Bar value.
     /// \param spread Spread pack to fill.
     /// \param symbol Symbol whose price precision should be stored.

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -233,6 +233,14 @@ struct LocalFxConnectServer {
                 R"({"Updates":1783028728,"ask":1.10002,"bid":1.10001,"symbol":"EUR\/USD"})");
         };
 
+        auto& bapi = server.endpoint["^/bapi/?$"];
+        bapi.on_open = [this](
+                std::shared_ptr<MarketDataWsServer::Connection> connection) {
+            ++bapi_connection_count;
+            connection->send(
+                R"({"stream":"btcusdt@aggTrade","data":{"e":"aggTrade","E":1783028778697,"s":"BTCUSDT","a":4005288360,"p":"61521.34000000","q":"0.00017000","f":6473852503,"l":6473852503,"T":1783028778697,"m":false,"M":true}})");
+        };
+
         auto port_promise = std::make_shared<std::promise<unsigned short>>();
         auto port_future = port_promise->get_future();
         thread = std::thread([this, port_promise]() {
@@ -271,6 +279,7 @@ struct LocalFxConnectServer {
     std::thread thread;
     unsigned short port = 0;
     std::atomic<int> subscription_count{0};
+    std::atomic<int> bapi_connection_count{0};
     mutable std::mutex mutex;
     std::string last_subscription;
 };
@@ -950,6 +959,86 @@ TEST(IntradeBarApiResponses, ParsesBtcusdtWebSocketTickWithEpochMilliseconds) {
     EXPECT_TRUE(tick.tick.has_flag(TickUpdateFlags::VOLUME_UPDATED));
     EXPECT_TRUE(tick.tick.has_flag(MarketDataFlags::INITIALIZED));
     EXPECT_TRUE(tick.tick.has_flag(MarketDataFlags::REALTIME));
+}
+
+TEST(IntradeBarApiResponses, BtcWebSocketSubscriptionReportsStatusAndRoutesTick) {
+    LocalFxConnectServer server;
+    ASSERT_TRUE(server.start());
+
+    IntradeBarPlatform platform;
+    std::vector<market_data::MarketDataStatusUpdate> status_updates;
+    market_data::TickDataBatch delivered_batch;
+    std::mutex callback_mutex;
+    int tick_callback_count = 0;
+
+    platform.on_market_data_status() =
+        [&status_updates, &callback_mutex](market_data::MarketDataStatusUpdate update) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            status_updates.push_back(std::move(update));
+        };
+    platform.on_tick_data() =
+        [&delivered_batch, &tick_callback_count, &callback_mutex](
+                std::unique_ptr<market_data::TickDataBatch> batch) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            ++tick_callback_count;
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+        };
+
+    auto auth = std::make_unique<AuthData>();
+    auth->set_email_password("user@example.test", "unused");
+    auth->host = server.host();
+    ASSERT_TRUE(platform.configure_auth(std::move(auth)));
+    platform.event_bus().drain();
+
+    market_data::MarketDataSubscriptionResult subscription_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "BTCUSDT",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(subscription_result);
+
+    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            const bool ready = std::any_of(
+                status_updates.begin(),
+                status_updates.end(),
+                [](const market_data::MarketDataStatusUpdate& update) {
+                    return update.symbol == "BTCUSDT" &&
+                           update.type == market_data::MarketDataType::TICKS &&
+                           update.transport == market_data::MarketDataTransport::WEBSOCKET &&
+                           update.status == market_data::MarketDataStreamStatus::READY;
+                });
+            return ready && !delivered_batch.items.empty();
+        }));
+
+    EXPECT_GE(server.bapi_connection_count.load(), 1);
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex);
+        EXPECT_GE(tick_callback_count, 1);
+        EXPECT_EQ(delivered_batch.symbol, "BTCUSDT");
+        EXPECT_EQ(delivered_batch.subscription.id, subscription_result.subscription.id);
+        ASSERT_EQ(delivered_batch.items.size(), 1u);
+        EXPECT_DOUBLE_EQ(delivered_batch.items[0].last, 61521.34);
+        EXPECT_TRUE(delivered_batch.items[0].has_flag(TickUpdateFlags::LAST_UPDATED));
+        EXPECT_TRUE(delivered_batch.items[0].has_flag(MarketDataFlags::REALTIME));
+        EXPECT_TRUE(std::any_of(
+            status_updates.begin(),
+            status_updates.end(),
+            [](const market_data::MarketDataStatusUpdate& update) {
+                return update.symbol == "BTCUSDT" &&
+                       update.status == market_data::MarketDataStreamStatus::CONNECTED;
+            }));
+    }
+
+    platform.shutdown();
 }
 
 TEST(IntradeBarApiResponses, FxWebSocketSubscriptionReceivesLocalTick) {

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -211,6 +211,9 @@ struct LocalTradeHistoryServer {
 };
 
 struct LocalFxConnectServer {
+    explicit LocalFxConnectServer(bool send_bapi_tick = true)
+        : send_bapi_tick(send_bapi_tick) {}
+
     ~LocalFxConnectServer() {
         stop();
     }
@@ -237,8 +240,10 @@ struct LocalFxConnectServer {
         bapi.on_open = [this](
                 std::shared_ptr<MarketDataWsServer::Connection> connection) {
             ++bapi_connection_count;
-            connection->send(
-                R"({"stream":"btcusdt@aggTrade","data":{"e":"aggTrade","E":1783028778697,"s":"BTCUSDT","a":4005288360,"p":"61521.34000000","q":"0.00017000","f":6473852503,"l":6473852503,"T":1783028778697,"m":false,"M":true}})");
+            if (send_bapi_tick) {
+                connection->send(
+                    R"({"stream":"btcusdt@aggTrade","data":{"e":"aggTrade","E":1783028778697,"s":"BTCUSDT","a":4005288360,"p":"61521.34000000","q":"0.00017000","f":6473852503,"l":6473852503,"T":1783028778697,"m":false,"M":true}})");
+            }
         };
 
         auto port_promise = std::make_shared<std::promise<unsigned short>>();
@@ -282,6 +287,7 @@ struct LocalFxConnectServer {
     std::atomic<int> bapi_connection_count{0};
     mutable std::mutex mutex;
     std::string last_subscription;
+    bool send_bapi_tick = true;
 };
 
 struct CombinedHistoryTestResult {
@@ -1036,6 +1042,70 @@ TEST(IntradeBarApiResponses, BtcWebSocketSubscriptionReportsStatusAndRoutesTick)
                 return update.symbol == "BTCUSDT" &&
                        update.status == market_data::MarketDataStreamStatus::CONNECTED;
             }));
+    }
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, BtcWebSocketReportsReadyWhenOpenBeforeFirstPayload) {
+    LocalFxConnectServer server(false);
+    ASSERT_TRUE(server.start());
+
+    IntradeBarPlatform platform;
+    std::vector<market_data::MarketDataStatusUpdate> status_updates;
+    std::mutex callback_mutex;
+    int tick_callback_count = 0;
+
+    platform.on_market_data_status() =
+        [&status_updates, &callback_mutex](market_data::MarketDataStatusUpdate update) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            status_updates.push_back(std::move(update));
+        };
+    platform.on_tick_data() =
+        [&tick_callback_count, &callback_mutex](
+                std::unique_ptr<market_data::TickDataBatch> batch) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            if (batch && !batch->items.empty()) {
+                ++tick_callback_count;
+            }
+        };
+
+    auto auth = std::make_unique<AuthData>();
+    auth->set_email_password("user@example.test", "unused");
+    auth->host = server.host();
+    ASSERT_TRUE(platform.configure_auth(std::move(auth)));
+    platform.event_bus().drain();
+
+    market_data::MarketDataSubscriptionResult subscription_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "BTCUSDT",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(subscription_result);
+
+    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            return std::any_of(
+                status_updates.begin(),
+                status_updates.end(),
+                [](const market_data::MarketDataStatusUpdate& update) {
+                    return update.symbol == "BTCUSDT" &&
+                           update.status == market_data::MarketDataStreamStatus::READY;
+                });
+        }));
+
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex);
+        EXPECT_EQ(tick_callback_count, 0);
+        ASSERT_GE(status_updates.size(), 2u);
+        EXPECT_EQ(status_updates[0].status, market_data::MarketDataStreamStatus::CONNECTED);
+        EXPECT_EQ(status_updates[1].status, market_data::MarketDataStreamStatus::READY);
     }
 
     platform.shutdown();


### PR DESCRIPTION
## What Changed
- Added BTCUSDT websocket market-data status updates so BTC streams now report CONNECTED, READY, DISCONNECTED, and FAILED through `on_market_data_status()` like FX websocket streams.
- Normalized BTC websocket host mapping so local `http://...` test hosts become `ws://...`, while HTTPS hosts still become WSS.
- Made subscription batch rollback restore removed FX subscriptions and the subscription ID counter if FX websocket activation fails.
- Added pointer lookup helpers for `PriceUpdateEvent` and used them in the trade queue to avoid copying tick wrappers and the awkward `tick.tick` access in the trade lifecycle path.
- Added a local `/bapi` websocket regression test that validates BTC status delivery and routed tick batches.

## Validation
- `cmake --build build-codex --target intrade_bar_api_response_test market_data_subscription_contract_test trade_manager_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe`
- `./build-codex/market_data_subscription_contract_test.exe`
- `./build-codex/trade_manager_test.exe --gtest_filter=TradeManagerTestFixture.ValidTradeTest:TradeManagerTestFixture.ShutdownTest`
- `git diff --check`

## Notes
- Full removal of `SingleTick` from the internal `PriceUpdateEvent` pipeline is intentionally left for the next market-data cleanup PR because it touches polling, FX, BTC, parser tests, and smoke helpers together.