### PR TITLE
[codex] Route price updates through tick batches

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Run market_data_subscription_contract_test
         run: ./build-linux/market_data_subscription_contract_test --gtest_brief=1
 
+      - name: Build trade_manager_test
+        run: cmake --build build-linux --target trade_manager_test -j
+
+      - name: Run trade_manager_test
+        run: ./build-linux/trade_manager_test --gtest_brief=1
+
       - name: Build intrade_bar_api_response_test
         run: cmake --build build-linux --target intrade_bar_api_response_test -j
 

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -109,6 +109,11 @@ Contract rules:
   Shared stream metadata (`symbol`, `timeframe`, digits, subscription handle)
   lives on the batch; individual `Tick`/`Bar` payloads keep only price/time data
   plus compact `flags`.
+- Live data callbacks are flushed from the provider/platform lifecycle
+  (`process()` or the worker loop started by `run()`), after queued price events
+  are routed and coalesced. Calling `event_bus().drain()` alone is an internal
+  event-bus operation and is not part of the public market-data delivery
+  contract.
 - Payload `flags` encode realtime/history/backfill state through
   `MarketDataFlags` and the compact price stream through `MarketPriceType`.
 - `on_market_data_status()` is a separate stream-status callback. Data callbacks

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -94,6 +94,10 @@ Subscription rules:
 - Data callbacks receive batches. Shared metadata (`symbol`, `timeframe`,
   digits and subscription handle) lives on the batch; compact payload flags live
   on `Tick` and `Bar`.
+- Data callbacks are delivered by the provider/platform lifecycle. With the
+  default worker loop this happens automatically after `run()`. If you use
+  `run(false)` or an external event loop, call `platform.process()`; draining
+  `event_bus()` directly is not enough to flush public market-data batches.
 - Use `MarketDataFlags` for realtime/history/backfill markers and
   `MarketPriceType` for bid/ask/mid/last payload identity.
 - `MarketDataContinuityService` routes recovered historical bars into the same

--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
@@ -660,8 +660,9 @@ namespace optionx::components {
             const auto& quote = quote_batch->items.back();
             if (!quote.has_flag(MarketDataFlags::INITIALIZED)) continue;
 
-            result->close_price = utils::normalize_double(quote.mid_price(), quote_batch->price_digits);
-            result->live_state = m_trade_state_manager.determine_trade_state(result, request, quote);
+            const double close_price = quote.normalized_mid_price(quote_batch->price_digits);
+            result->close_price = close_price;
+            result->live_state = m_trade_state_manager.determine_trade_state(result, request, close_price);
             dispatch_trade_event(transaction);
         }
     }

--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
@@ -660,7 +660,7 @@ namespace optionx::components {
             const auto& quote = quote_batch->items.back();
             if (!quote.has_flag(MarketDataFlags::INITIALIZED)) continue;
 
-            const double close_price = quote.normalized_mid_price(quote_batch->price_digits);
+            const double close_price = quote.mid_price(quote_batch->price_digits);
             result->close_price = close_price;
             result->live_state = m_trade_state_manager.determine_trade_state(result, request, close_price);
             dispatch_trade_event(transaction);

--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeQueueManager.hpp
@@ -654,11 +654,14 @@ namespace optionx::components {
                 result->trade_state = TradeState::IN_PROGRESS;
             }
 
-            const auto* quote = event.find_tick_by_symbol(request->symbol);
-            if (!quote || !quote->has_flag(MarketDataFlags::INITIALIZED)) continue;
+            const auto* quote_batch = event.find_tick_batch_by_symbol(request->symbol);
+            if (!quote_batch || quote_batch->items.empty()) continue;
 
-            result->close_price = quote->mid_price();
-            result->live_state = m_trade_state_manager.determine_trade_state(result, request, *quote);
+            const auto& quote = quote_batch->items.back();
+            if (!quote.has_flag(MarketDataFlags::INITIALIZED)) continue;
+
+            result->close_price = utils::normalize_double(quote.mid_price(), quote_batch->price_digits);
+            result->live_state = m_trade_state_manager.determine_trade_state(result, request, quote);
             dispatch_trade_event(transaction);
         }
     }

--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
@@ -35,7 +35,7 @@ namespace optionx::components {
         TradeState determine_trade_state(
                 const std::shared_ptr<TradeResult>& result,
                 const std::shared_ptr<TradeRequest>& request,
-                const SingleTick& tick) const;
+                const Tick& tick) const;
 
         /// \brief Checks if the given trade state allows closing.
         /// \param state The current trade state.
@@ -103,7 +103,7 @@ namespace optionx::components {
     inline TradeState TradeStateManager::determine_trade_state(
             const std::shared_ptr<TradeResult>& result,
             const std::shared_ptr<TradeRequest>& request,
-            const SingleTick& tick) const {
+            const Tick& tick) const {
         if (!result->open_price) {
             return TradeState::STANDOFF;
         }

--- a/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
+++ b/include/optionx_cpp/components/BaseTradeExecutionComponent/TradeStateManager.hpp
@@ -27,15 +27,15 @@ namespace optionx::components {
         TradeErrorCode validate_request(
                 const std::shared_ptr<TradeRequest>& request) const;
 
-        /// \brief Determines the trade outcome based on the latest price update.
+        /// \brief Determines the trade outcome based on the latest comparable close price.
         /// \param result Shared pointer to the trade result.
         /// \param request Shared pointer to the trade request.
-        /// \param tick The latest tick data.
+        /// \param close_price Price already normalized to the traded symbol precision.
         /// \return The final trade state (WIN, LOSS, STANDOFF).
         TradeState determine_trade_state(
                 const std::shared_ptr<TradeResult>& result,
                 const std::shared_ptr<TradeRequest>& request,
-                const Tick& tick) const;
+                double close_price) const;
 
         /// \brief Checks if the given trade state allows closing.
         /// \param state The current trade state.
@@ -103,21 +103,20 @@ namespace optionx::components {
     inline TradeState TradeStateManager::determine_trade_state(
             const std::shared_ptr<TradeResult>& result,
             const std::shared_ptr<TradeRequest>& request,
-            const Tick& tick) const {
+            double close_price) const {
         if (!result->open_price) {
             return TradeState::STANDOFF;
         }
 
-        double mid_price = tick.mid_price();
         if (request->order_type == OrderType::BUY) {
-            if (mid_price > result->open_price) return TradeState::WIN;
-            if (mid_price < result->open_price) return TradeState::LOSS;
+            if (close_price > result->open_price) return TradeState::WIN;
+            if (close_price < result->open_price) return TradeState::LOSS;
             return TradeState::STANDOFF;
         }
 
         if (request->order_type == OrderType::SELL) {
-            if (mid_price < result->open_price) return TradeState::WIN;
-            if (mid_price > result->open_price) return TradeState::LOSS;
+            if (close_price < result->open_price) return TradeState::WIN;
+            if (close_price > result->open_price) return TradeState::LOSS;
             return TradeState::STANDOFF;
         }
 

--- a/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
+++ b/include/optionx_cpp/data/events/PriceUpdateEvent.hpp
@@ -5,37 +5,81 @@
 /// \file PriceUpdateEvent.hpp
 /// \brief Defines the PriceUpdateEvent class for updating tick information.
 
+#include <cstdint>
+#include <cstddef>
 #include <vector>
-#include <memory>
+#include <string>
+#include <utility>
 
 namespace optionx::events {
 
-    /// \class PriceUpdateEvent
-    /// \brief Event containing updated tick information for multiple symbols.
-    class PriceUpdateEvent : public utils::Event {
-    public:
-        /// \brief Constructor initializing the tick data.
-        /// \param ticks A vector of tick information.
-        /// \param source Transport-level source that produced the ticks.
-        explicit PriceUpdateEvent(
-                std::vector<SingleTick> ticks,
-                MarketDataUpdateSource source = MarketDataUpdateSource::POLLING)
-            : m_ticks(std::move(ticks)),
-              m_source(source) {}
+    /// \struct TickUpdateBatch
+    /// \brief Batch of tick payloads sharing one source symbol and precision metadata.
+    struct TickUpdateBatch {
+        std::vector<Tick> items;       ///< Tick payloads delivered together.
+        std::string symbol;            ///< Provider symbol shared by all items.
+        std::string provider;          ///< Data provider that produced the ticks.
+        std::uint32_t price_digits = 0; ///< Decimal places for price fields.
+        std::uint32_t volume_digits = 0; ///< Decimal places for volume fields.
 
-        /// \brief Gets the tick data associated with this event.
-        /// \return A constant reference to the vector of tick information.
-        const std::vector<SingleTick>& get_ticks() const {
-            return m_ticks;
+        /// \brief Returns true when the batch has no payload items.
+        [[nodiscard]] bool empty() const noexcept {
+            return items.empty();
         }
 
-        /// \brief Finds a tick wrapper by its normalized symbol name.
+        /// \brief Returns the number of tick payloads.
+        [[nodiscard]] std::size_t size() const noexcept {
+            return items.size();
+        }
+    };
+
+    /// \class PriceUpdateEvent
+    /// \brief Event containing updated tick batches for multiple symbols.
+    class PriceUpdateEvent : public utils::Event {
+    public:
+        /// \brief Constructor initializing tick batches.
+        /// \param tick_batches Tick batches grouped by symbol and precision metadata.
+        /// \param source Transport-level source that produced the ticks.
+        explicit PriceUpdateEvent(
+                std::vector<TickUpdateBatch> tick_batches,
+                MarketDataUpdateSource source = MarketDataUpdateSource::POLLING)
+            : m_tick_batches(std::move(tick_batches)),
+              m_source(source) {}
+
+        /// \brief Builds a single-item tick batch.
+        /// \param tick Tick payload.
+        /// \param symbol Provider symbol.
+        /// \param provider Data provider name.
+        /// \param price_digits Decimal places for price fields.
+        /// \param volume_digits Decimal places for volume fields.
+        static TickUpdateBatch make_tick_batch(
+                Tick tick,
+                std::string symbol,
+                std::string provider,
+                std::uint32_t price_digits,
+                std::uint32_t volume_digits) {
+            TickUpdateBatch batch;
+            batch.symbol = std::move(symbol);
+            batch.provider = std::move(provider);
+            batch.price_digits = price_digits;
+            batch.volume_digits = volume_digits;
+            batch.items.push_back(std::move(tick));
+            return batch;
+        }
+
+        /// \brief Gets the tick batches associated with this event.
+        /// \return A constant reference to grouped tick payloads.
+        const std::vector<TickUpdateBatch>& get_tick_batches() const {
+            return m_tick_batches;
+        }
+
+        /// \brief Finds a tick batch by its normalized symbol name.
         /// \param symbol Symbol to find.
-        /// \return Pointer to the matching tick wrapper, or nullptr when absent.
-        const SingleTick* find_tick_by_symbol(const std::string& symbol) const {
-            for (const auto& tick : m_ticks) {
-                if (tick.symbol == symbol) {
-                    return &tick;
+        /// \return Pointer to the matching tick batch, or nullptr when absent.
+        const TickUpdateBatch* find_tick_batch_by_symbol(const std::string& symbol) const {
+            for (const auto& batch : m_tick_batches) {
+                if (batch.symbol == symbol) {
+                    return &batch;
                 }
             }
             return nullptr;
@@ -58,18 +102,8 @@ namespace optionx::events {
             return "PriceUpdateEvent";
         }
 
-        /// \brief Finds a tick by its symbol name.
-        /// \param symbol The name of the symbol to find.
-        /// \return Matching tick wrapper, or a default wrapper when absent.
-        SingleTick get_tick_by_symbol(const std::string& symbol) const {
-            if (const auto* tick = find_tick_by_symbol(symbol)) {
-                return *tick;
-            }
-            return SingleTick();
-        }
-
     private:
-        std::vector<SingleTick> m_ticks; ///< Tick information associated with this event.
+        std::vector<TickUpdateBatch> m_tick_batches; ///< Tick batches associated with this event.
         MarketDataUpdateSource m_source = MarketDataUpdateSource::UNKNOWN; ///< Tick update source.
     };
 

--- a/include/optionx_cpp/data/ticks/SingleTick.hpp
+++ b/include/optionx_cpp/data/ticks/SingleTick.hpp
@@ -44,7 +44,7 @@ namespace optionx {
         /// \brief Returns the normalized quote midpoint or last traded price.
         /// \return The normalized value returned by Tick::mid_price().
         double mid_price() const {
-            return utils::normalize_double(tick.mid_price(), price_digits);
+            return tick.normalized_mid_price(price_digits);
         }
 
         /// \brief Checks whether a market-data payload flag is set.

--- a/include/optionx_cpp/data/ticks/SingleTick.hpp
+++ b/include/optionx_cpp/data/ticks/SingleTick.hpp
@@ -44,7 +44,7 @@ namespace optionx {
         /// \brief Returns the normalized quote midpoint or last traded price.
         /// \return The normalized value returned by Tick::mid_price().
         double mid_price() const {
-            return tick.normalized_mid_price(price_digits);
+            return tick.mid_price(price_digits);
         }
 
         /// \brief Checks whether a market-data payload flag is set.

--- a/include/optionx_cpp/data/ticks/Tick.hpp
+++ b/include/optionx_cpp/data/ticks/Tick.hpp
@@ -58,6 +58,13 @@ namespace optionx {
             return ask != 0.0 ? ask : bid;
         }
 
+        /// \brief Calculates and normalizes the midpoint or last traded price.
+        /// \param price_digits Number of decimal places for price rounding.
+        /// \return The value returned by mid_price() rounded to price_digits.
+        double normalized_mid_price(std::uint32_t price_digits) const {
+            return utils::normalize_double(mid_price(), price_digits);
+        }
+
         /// \brief Sets a specific flag in the tick's flags.
         /// \param flag The flag to set (from TickUpdateFlags).
         void set_flag(TickUpdateFlags flag) {

--- a/include/optionx_cpp/data/ticks/Tick.hpp
+++ b/include/optionx_cpp/data/ticks/Tick.hpp
@@ -58,10 +58,10 @@ namespace optionx {
             return ask != 0.0 ? ask : bid;
         }
 
-        /// \brief Calculates and normalizes the midpoint or last traded price.
+        /// \brief Calculates the midpoint or last traded price rounded to symbol precision.
         /// \param price_digits Number of decimal places for price rounding.
         /// \return The value returned by mid_price() rounded to price_digits.
-        double normalized_mid_price(std::uint32_t price_digits) const {
+        double mid_price(std::uint32_t price_digits) const {
             return utils::normalize_double(mid_price(), price_digits);
         }
 

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -55,6 +55,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Returns a reference to the live bar-data callback.
+        /// \details Providers may coalesce queued updates and invoke this callback
+        ///          from their lifecycle `process()`/platform loop, not directly
+        ///          from a low-level event-bus drain.
         /// \return Mutable callback reference, or a null callback if live bars are unsupported.
         virtual bars_callback_t& on_bar_data() {
             static bars_callback_t null_callback;
@@ -62,6 +65,9 @@ namespace optionx::market_data {
         }
 
         /// \brief Returns a reference to the live tick-data callback.
+        /// \details Providers may coalesce queued updates and invoke this callback
+        ///          from their lifecycle `process()`/platform loop, not directly
+        ///          from a low-level event-bus drain.
         /// \return Mutable callback reference, or a null callback if live ticks are unsupported.
         virtual ticks_callback_t& on_tick_data() {
             static ticks_callback_t null_callback;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -213,8 +213,15 @@ namespace optionx::platforms::intrade_bar {
 
     inline void BtcPriceManager::handle_message(const std::string& message) {
         if (parse_btcusdt_tick(message, m_tick_data[0])) {
+            std::vector<events::TickUpdateBatch> batches;
+            batches.push_back(events::PriceUpdateEvent::make_tick_batch(
+                m_tick_data[0].tick,
+                m_tick_data[0].symbol,
+                m_tick_data[0].provider,
+                m_tick_data[0].price_digits,
+                m_tick_data[0].volume_digits));
             notify_async(std::make_unique<events::PriceUpdateEvent>(
-                m_tick_data,
+                std::move(batches),
                 MarketDataUpdateSource::WEBSOCKET));
         }
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
@@ -353,10 +353,15 @@ namespace optionx::platforms::intrade_bar {
             if (!parse_fxconnect_tick(message, tick)) return;
             if (tick.symbol != stream->symbol) return;
 
-            std::vector<SingleTick> ticks;
-            ticks.push_back(std::move(tick));
+            std::vector<events::TickUpdateBatch> batches;
+            batches.push_back(events::PriceUpdateEvent::make_tick_batch(
+                tick.tick,
+                tick.symbol,
+                tick.provider,
+                tick.price_digits,
+                tick.volume_digits));
             notify_async(std::make_unique<events::PriceUpdateEvent>(
-                std::move(ticks),
+                std::move(batches),
                 MarketDataUpdateSource::WEBSOCKET));
         } catch (const std::exception& ex) {
             LOGIT_WARN("Intrade Bar FX websocket: failed to parse tick for ",

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -61,6 +61,9 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Routes price events to active tick subscriptions.
         void on_event(const utils::Event* const event) override;
 
+        /// \brief Flushes pending market-data batches to public callbacks.
+        void process() override;
+
         /// \brief Clears all runtime subscriptions.
         void shutdown() override;
 
@@ -81,6 +84,7 @@ namespace optionx::platforms::intrade_bar {
         std::unordered_map<
             market_data::SubscriptionId,
             market_data::MarketDataSubscriptionHandle> m_tick_subscriptions; ///< Active tick subscriptions.
+        std::vector<market_data::TickDataBatch> m_pending_tick_batches; ///< Tick batches waiting for the next process cycle.
         market_data::SubscriptionId m_next_subscription_id = 1; ///< Next runtime handle ID.
         std::mutex m_mutex; ///< Protects subscription handles.
 
@@ -117,6 +121,15 @@ namespace optionx::platforms::intrade_bar {
 
         /// \brief Handles incoming price update events.
         void handle_event(const events::PriceUpdateEvent& event);
+
+        /// \brief Finds or creates a pending tick delivery batch.
+        market_data::TickDataBatch& pending_tick_batch_for(
+                const market_data::MarketDataSubscriptionHandle& subscription,
+                const events::TickUpdateBatch& source_batch);
+
+        /// \brief Removes queued tick data for an inactive subscription.
+        /// \pre The caller holds m_mutex.
+        void remove_pending_tick_batch_no_lock(market_data::SubscriptionId subscription_id);
     };
 
     inline bool MarketDataSubscriptionManager::subscribe_ticks(
@@ -305,6 +318,7 @@ namespace optionx::platforms::intrade_bar {
             if (!failed) {
                 for (const auto& subscription : removed_subscriptions) {
                     m_tick_subscriptions.erase(subscription.id);
+                    remove_pending_tick_batch_no_lock(subscription.id);
                 }
                 for (const auto& subscription : added_subscriptions) {
                     m_tick_subscriptions[subscription.id] = subscription;
@@ -353,6 +367,7 @@ namespace optionx::platforms::intrade_bar {
                         std::lock_guard<std::mutex> lock(m_mutex);
                         for (const auto& added : added_subscriptions) {
                             m_tick_subscriptions.erase(added.id);
+                            remove_pending_tick_batch_no_lock(added.id);
                         }
                         for (const auto& removed : removed_subscriptions) {
                             m_tick_subscriptions[removed.id] = removed;
@@ -394,6 +409,22 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
+    inline void MarketDataSubscriptionManager::process() {
+        std::vector<market_data::TickDataBatch> batches;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            batches.swap(m_pending_tick_batches);
+        }
+
+        if (!m_ticks_callback) return;
+        for (auto& batch : batches) {
+            if (!batch.empty()) {
+                m_ticks_callback(
+                    std::make_unique<market_data::TickDataBatch>(std::move(batch)));
+            }
+        }
+    }
+
     inline void MarketDataSubscriptionManager::shutdown() {
         std::vector<market_data::MarketDataSubscriptionHandle> subscriptions;
         {
@@ -415,6 +446,7 @@ namespace optionx::platforms::intrade_bar {
 
         std::lock_guard<std::mutex> lock(m_mutex);
         m_tick_subscriptions.clear();
+        m_pending_tick_batches.clear();
     }
 
     inline market_data::SubscriptionId
@@ -519,52 +551,54 @@ namespace optionx::platforms::intrade_bar {
 
     inline void MarketDataSubscriptionManager::handle_event(
             const events::PriceUpdateEvent& event) {
-        std::vector<market_data::TickDataBatch> batches;
-        {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            if (m_tick_subscriptions.empty()) return;
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_tick_subscriptions.empty()) return;
 
-            for (const auto& source_batch : event.get_tick_batches()) {
-                const auto normalized_symbol = normalize_symbol_name(source_batch.symbol);
-                for (const auto& [id, subscription] : m_tick_subscriptions) {
-                    (void)id;
-                    if (subscription.symbol != normalized_symbol) continue;
-                    if (!source_matches_subscription(subscription, event.source())) continue;
+        for (const auto& source_batch : event.get_tick_batches()) {
+            const auto normalized_symbol = normalize_symbol_name(source_batch.symbol);
+            for (const auto& [id, subscription] : m_tick_subscriptions) {
+                (void)id;
+                if (subscription.symbol != normalized_symbol) continue;
+                if (!source_matches_subscription(subscription, event.source())) continue;
 
-                    market_data::TickDataBatch* batch = nullptr;
-                    for (auto& candidate : batches) {
-                        if (candidate.subscription.id == subscription.id) {
-                            batch = &candidate;
-                            break;
-                        }
-                    }
-
-                    if (!batch) {
-                        market_data::TickDataBatch created;
-                        created.subscription = subscription;
-                        created.type = market_data::MarketDataType::TICKS;
-                        created.symbol = subscription.symbol;
-                        created.timeframe = 0;
-                        created.price_digits = source_batch.price_digits;
-                        created.volume_digits = source_batch.volume_digits;
-                        batches.push_back(std::move(created));
-                        batch = &batches.back();
-                    }
-
-                    for (const auto& tick : source_batch.items) {
-                        batch->items.push_back(tick);
-                        batch->items.back().set_flag(MarketDataFlags::REALTIME);
-                    }
+                auto& batch = pending_tick_batch_for(subscription, source_batch);
+                for (const auto& tick : source_batch.items) {
+                    batch.items.push_back(tick);
+                    batch.items.back().set_flag(MarketDataFlags::REALTIME);
                 }
             }
         }
+    }
 
-        if (m_ticks_callback) {
-            for (auto& batch : batches) {
-                if (!batch.empty()) {
-                    m_ticks_callback(
-                        std::make_unique<market_data::TickDataBatch>(std::move(batch)));
-                }
+    inline market_data::TickDataBatch&
+    MarketDataSubscriptionManager::pending_tick_batch_for(
+            const market_data::MarketDataSubscriptionHandle& subscription,
+            const events::TickUpdateBatch& source_batch) {
+        for (auto& batch : m_pending_tick_batches) {
+            if (batch.subscription.id == subscription.id) {
+                return batch;
+            }
+        }
+
+        market_data::TickDataBatch created;
+        created.subscription = subscription;
+        created.type = market_data::MarketDataType::TICKS;
+        created.symbol = subscription.symbol;
+        created.timeframe = 0;
+        created.price_digits = source_batch.price_digits;
+        created.volume_digits = source_batch.volume_digits;
+        m_pending_tick_batches.push_back(std::move(created));
+        return m_pending_tick_batches.back();
+    }
+
+    inline void MarketDataSubscriptionManager::remove_pending_tick_batch_no_lock(
+            market_data::SubscriptionId subscription_id) {
+        for (auto it = m_pending_tick_batches.begin();
+             it != m_pending_tick_batches.end();) {
+            if (it->subscription.id == subscription_id) {
+                it = m_pending_tick_batches.erase(it);
+            } else {
+                ++it;
             }
         }
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -524,8 +524,8 @@ namespace optionx::platforms::intrade_bar {
             std::lock_guard<std::mutex> lock(m_mutex);
             if (m_tick_subscriptions.empty()) return;
 
-            for (const auto& tick : event.get_ticks()) {
-                const auto normalized_symbol = normalize_symbol_name(tick.symbol);
+            for (const auto& source_batch : event.get_tick_batches()) {
+                const auto normalized_symbol = normalize_symbol_name(source_batch.symbol);
                 for (const auto& [id, subscription] : m_tick_subscriptions) {
                     (void)id;
                     if (subscription.symbol != normalized_symbol) continue;
@@ -545,14 +545,16 @@ namespace optionx::platforms::intrade_bar {
                         created.type = market_data::MarketDataType::TICKS;
                         created.symbol = subscription.symbol;
                         created.timeframe = 0;
-                        created.price_digits = tick.price_digits;
-                        created.volume_digits = tick.volume_digits;
+                        created.price_digits = source_batch.price_digits;
+                        created.volume_digits = source_batch.volume_digits;
                         batches.push_back(std::move(created));
                         batch = &batches.back();
                     }
 
-                    batch->items.push_back(tick.tick);
-                    batch->items.back().set_flag(MarketDataFlags::REALTIME);
+                    for (const auto& tick : source_batch.items) {
+                        batch->items.push_back(tick);
+                        batch->items.back().set_flag(MarketDataFlags::REALTIME);
+                    }
                 }
             }
         }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/PriceManager.hpp
@@ -160,7 +160,18 @@ namespace optionx::platforms::intrade_bar {
                     it->second = tick;
                 }
             }
-            notify(events::PriceUpdateEvent(std::move(ticks), MarketDataUpdateSource::POLLING));
+
+            std::vector<events::TickUpdateBatch> batches;
+            batches.reserve(ticks.size());
+            for (const auto& tick : ticks) {
+                batches.push_back(events::PriceUpdateEvent::make_tick_batch(
+                    tick.tick,
+                    tick.symbol,
+                    tick.provider,
+                    tick.price_digits,
+                    tick.volume_digits));
+            }
+            notify(events::PriceUpdateEvent(std::move(batches), MarketDataUpdateSource::POLLING));
         });
     }
 

--- a/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
+++ b/tests/intrade_bar_api/IntradeBarSmokeSupport.hpp
@@ -275,9 +275,9 @@ public:
         subscribe<optionx::events::PriceUpdateEvent>(
             [this](const optionx::events::PriceUpdateEvent& event) {
                 std::lock_guard<std::mutex> lock(m_mutex);
-                m_ticks = event.get_ticks();
+                m_batches = event.get_tick_batches();
                 ++m_update_count;
-                LOGIT_INFO("Intrade Bar smoke price update: ticks=", m_ticks.size());
+                LOGIT_INFO("Intrade Bar smoke price update: batches=", m_batches.size());
             });
     }
 
@@ -286,7 +286,18 @@ public:
 
     std::vector<optionx::SingleTick> ticks() const {
         std::lock_guard<std::mutex> lock(m_mutex);
-        return m_ticks;
+        std::vector<optionx::SingleTick> ticks;
+        for (const auto& batch : m_batches) {
+            for (const auto& item : batch.items) {
+                ticks.emplace_back(
+                    item,
+                    batch.symbol,
+                    batch.provider,
+                    batch.price_digits,
+                    batch.volume_digits);
+            }
+        }
+        return ticks;
     }
 
     std::size_t update_count() const {
@@ -296,15 +307,15 @@ public:
 
     bool has_symbol(const std::string& symbol) const {
         std::lock_guard<std::mutex> lock(m_mutex);
-        for (const auto& tick : m_ticks) {
-            if (tick.symbol == symbol) return true;
+        for (const auto& batch : m_batches) {
+            if (batch.symbol == symbol && !batch.empty()) return true;
         }
         return false;
     }
 
 private:
     mutable std::mutex m_mutex;
-    std::vector<optionx::SingleTick> m_ticks;
+    std::vector<optionx::events::TickUpdateBatch> m_batches;
     std::size_t m_update_count = 0;
 };
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -99,6 +99,15 @@ void publish_account_status(
     platform.event_bus().drain();
 }
 
+void pump_platform(
+        IntradeBarPlatform& platform,
+        int passes = 3) {
+    for (int i = 0; i < passes; ++i) {
+        platform.process();
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+}
+
 template <class Predicate>
 bool wait_for_platform(
         IntradeBarPlatform& platform,
@@ -106,10 +115,12 @@ bool wait_for_platform(
         std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (!predicate() && std::chrono::steady_clock::now() < deadline) {
+        pump_platform(platform, 1);
         platform.event_bus().drain();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     platform.event_bus().drain();
+    pump_platform(platform, 1);
     return predicate();
 }
 
@@ -671,6 +682,7 @@ TEST(IntradeBarApiResponses, IntradeBarPlatformExposesEndpointTradingAndMarketDa
 
 TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents) {
     IntradeBarPlatform platform;
+    platform.run(false);
     market_data::TickDataBatch delivered_batch;
     int tick_callback_count = 0;
     market_data::MarketDataSubscriptionResult subscription_result;
@@ -707,7 +719,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents
 
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
-    platform.event_bus().process();
+    pump_platform(platform);
 
     ASSERT_EQ(tick_callback_count, 1);
     ASSERT_EQ(delivered_batch.items.size(), 2u);
@@ -719,8 +731,55 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents
     platform.shutdown();
 }
 
+TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionCoalescesQueuedPriceEvents) {
+    IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::TickDataBatch delivered_batch;
+    int tick_callback_count = 0;
+    market_data::MarketDataSubscriptionResult subscription_result;
+
+    platform.on_tick_data() =
+        [&delivered_batch, &tick_callback_count](std::unique_ptr<market_data::TickDataBatch> batch) {
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+            ++tick_callback_count;
+        };
+
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "EUR/USD",
+            market_data::MarketDataTransport::POLLING),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(subscription_result);
+
+    std::vector<events::TickUpdateBatch> first_event_ticks = {
+        make_market_data_batch("EURUSD", 1.0, 1.1)
+    };
+    std::vector<events::TickUpdateBatch> second_event_ticks = {
+        make_market_data_batch("EUR/USD", 1.2, 1.3)
+    };
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(first_event_ticks)));
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(second_event_ticks)));
+    pump_platform(platform);
+
+    ASSERT_EQ(tick_callback_count, 1);
+    ASSERT_EQ(delivered_batch.items.size(), 2u);
+    EXPECT_EQ(delivered_batch.subscription.id, subscription_result.subscription.id);
+    EXPECT_TRUE(delivered_batch.items[0].has_flag(MarketDataFlags::REALTIME));
+    EXPECT_TRUE(delivered_batch.items[1].has_flag(MarketDataFlags::REALTIME));
+
+    platform.shutdown();
+}
+
 TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
     IntradeBarPlatform platform;
+    platform.run(false);
     int tick_callback_count = 0;
     market_data::MarketDataSubscriptionResult subscription_result;
     market_data::MarketDataSubscriptionResult unsubscribe_result;
@@ -753,7 +812,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
 
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
-    platform.event_bus().process();
+    pump_platform(platform);
 
     EXPECT_EQ(tick_callback_count, 0);
 
@@ -762,6 +821,7 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
 
 TEST(IntradeBarApiResponses, IntradeBarAppliesTickSubscriptionBatchAtomically) {
     IntradeBarPlatform platform;
+    platform.run(false);
     std::vector<market_data::TickDataBatch> delivered_batches;
     market_data::MarketDataSubscriptionBatchResult apply_result;
     market_data::MarketDataSubscriptionBatchResult unsubscribe_result;
@@ -800,7 +860,7 @@ TEST(IntradeBarApiResponses, IntradeBarAppliesTickSubscriptionBatchAtomically) {
 
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
-    platform.event_bus().process();
+    pump_platform(platform);
 
     ASSERT_EQ(delivered_batches.size(), 2u);
     EXPECT_EQ(delivered_batches[0].items.size(), 1u);
@@ -818,6 +878,7 @@ TEST(IntradeBarApiResponses, IntradeBarAppliesTickSubscriptionBatchAtomically) {
 
 TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartiallySubscribe) {
     IntradeBarPlatform platform;
+    platform.run(false);
     int tick_callback_count = 0;
     market_data::MarketDataSubscriptionBatchResult result;
 
@@ -848,7 +909,7 @@ TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartially
     };
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
-    platform.event_bus().process();
+    pump_platform(platform);
 
     EXPECT_EQ(tick_callback_count, 0);
 
@@ -985,6 +1046,7 @@ TEST(IntradeBarApiResponses, BtcWebSocketSubscriptionReportsStatusAndRoutesTick)
     ASSERT_TRUE(server.start());
 
     IntradeBarPlatform platform;
+    platform.run(false);
     std::vector<market_data::MarketDataStatusUpdate> status_updates;
     market_data::TickDataBatch delivered_batch;
     std::mutex callback_mutex;
@@ -1129,6 +1191,7 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionReceivesLocalTick) {
     ASSERT_TRUE(server.start());
 
     IntradeBarPlatform platform;
+    platform.run(false);
     market_data::TickDataBatch delivered_batch;
     int callback_count = 0;
     platform.on_tick_data() =
@@ -1189,6 +1252,7 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionReceivesLocalTick) {
 
 TEST(IntradeBarApiResponses, WebsocketSubscriptionIgnoresPollingSnapshotForSameSymbol) {
     IntradeBarPlatform platform;
+    platform.run(false);
     int callback_count = 0;
     market_data::TickDataBatch delivered_batch;
     platform.on_tick_data() =
@@ -1213,7 +1277,7 @@ TEST(IntradeBarApiResponses, WebsocketSubscriptionIgnoresPollingSnapshotForSameS
     polling_ticks.push_back(make_market_data_batch("EURUSD", 1.10001, 1.10002));
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(polling_ticks)));
-    platform.event_bus().drain();
+    pump_platform(platform);
 
     EXPECT_EQ(callback_count, 0);
     EXPECT_TRUE(delivered_batch.items.empty());
@@ -1224,7 +1288,7 @@ TEST(IntradeBarApiResponses, WebsocketSubscriptionIgnoresPollingSnapshotForSameS
         std::make_unique<events::PriceUpdateEvent>(
             std::move(websocket_ticks),
             MarketDataUpdateSource::WEBSOCKET));
-    platform.event_bus().drain();
+    pump_platform(platform);
 
     EXPECT_EQ(callback_count, 1);
     ASSERT_EQ(delivered_batch.items.size(), 1u);

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -76,6 +76,19 @@ SingleTick make_market_data_tick(const std::string& symbol, double bid, double a
     return tick;
 }
 
+events::TickUpdateBatch make_market_data_batch(
+        const std::string& symbol,
+        double bid,
+        double ask) {
+    const auto tick = make_market_data_tick(symbol, bid, ask);
+    return events::PriceUpdateEvent::make_tick_batch(
+        tick.tick,
+        tick.symbol,
+        tick.provider,
+        tick.price_digits,
+        tick.volume_digits);
+}
+
 void publish_account_status(
         IntradeBarPlatform& platform,
         AccountUpdateStatus status) {
@@ -686,10 +699,10 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionRoutesMatchingPriceEvents
     EXPECT_EQ(subscription_result.subscription.symbol, "EURUSD");
     EXPECT_EQ(subscription_result.subscription.stream_type, market_data::MarketDataType::TICKS);
 
-    std::vector<SingleTick> event_ticks = {
-        make_market_data_tick("EURUSD", 1.0, 1.1),
-        make_market_data_tick("EUR/USD", 1.2, 1.3),
-        make_market_data_tick("BTCUSDT", 60000.0, 60001.0)
+    std::vector<events::TickUpdateBatch> event_ticks = {
+        make_market_data_batch("EURUSD", 1.0, 1.1),
+        make_market_data_batch("EUR/USD", 1.2, 1.3),
+        make_market_data_batch("BTCUSDT", 60000.0, 60001.0)
     };
 
     platform.event_bus().notify_async(
@@ -734,8 +747,8 @@ TEST(IntradeBarApiResponses, IntradeBarTickSubscriptionStopsAfterUnsubscribe) {
     EXPECT_TRUE(unsubscribe_result);
     EXPECT_EQ(unsubscribe_result.status, market_data::MarketDataSubscriptionStatus::UNSUBSCRIBED);
 
-    std::vector<SingleTick> event_ticks = {
-        make_market_data_tick("BTCUSDT", 60000.0, 60001.0)
+    std::vector<events::TickUpdateBatch> event_ticks = {
+        make_market_data_batch("BTCUSDT", 60000.0, 60001.0)
     };
 
     platform.event_bus().notify_async(
@@ -780,9 +793,9 @@ TEST(IntradeBarApiResponses, IntradeBarAppliesTickSubscriptionBatchAtomically) {
     EXPECT_EQ(apply_result.results[0].subscription.symbol, "EURUSD");
     EXPECT_EQ(apply_result.results[1].subscription.symbol, "BTCUSDT");
 
-    std::vector<SingleTick> event_ticks = {
-        make_market_data_tick("EURUSD", 1.0, 1.1),
-        make_market_data_tick("BTCUSDT", 60000.0, 60001.0)
+    std::vector<events::TickUpdateBatch> event_ticks = {
+        make_market_data_batch("EURUSD", 1.0, 1.1),
+        make_market_data_batch("BTCUSDT", 60000.0, 60001.0)
     };
 
     platform.event_bus().notify_async(
@@ -830,8 +843,8 @@ TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartially
     EXPECT_FALSE(result);
     EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::UNSUPPORTED);
 
-    std::vector<SingleTick> event_ticks = {
-        make_market_data_tick("EURUSD", 1.0, 1.1)
+    std::vector<events::TickUpdateBatch> event_ticks = {
+        make_market_data_batch("EURUSD", 1.0, 1.1)
     };
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
@@ -1196,8 +1209,8 @@ TEST(IntradeBarApiResponses, WebsocketSubscriptionIgnoresPollingSnapshotForSameS
         }));
     ASSERT_TRUE(subscription_result);
 
-    std::vector<SingleTick> polling_ticks;
-    polling_ticks.push_back(make_market_data_tick("EURUSD", 1.10001, 1.10002));
+    std::vector<events::TickUpdateBatch> polling_ticks;
+    polling_ticks.push_back(make_market_data_batch("EURUSD", 1.10001, 1.10002));
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(std::move(polling_ticks)));
     platform.event_bus().drain();
@@ -1205,8 +1218,8 @@ TEST(IntradeBarApiResponses, WebsocketSubscriptionIgnoresPollingSnapshotForSameS
     EXPECT_EQ(callback_count, 0);
     EXPECT_TRUE(delivered_batch.items.empty());
 
-    std::vector<SingleTick> websocket_ticks;
-    websocket_ticks.push_back(make_market_data_tick("EURUSD", 1.10003, 1.10004));
+    std::vector<events::TickUpdateBatch> websocket_ticks;
+    websocket_ticks.push_back(make_market_data_batch("EURUSD", 1.10003, 1.10004));
     platform.event_bus().notify_async(
         std::make_unique<events::PriceUpdateEvent>(
             std::move(websocket_ticks),

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -590,7 +590,7 @@ TEST(TradeStateManagerTest, DetermineTradeStateUsesNormalizedClosePrice) {
     tick.set_flag(MarketDataFlags::INITIALIZED);
 
     ASSERT_GT(tick.mid_price(), result->open_price);
-    const double close_price = tick.normalized_mid_price(5);
+    const double close_price = tick.mid_price(5);
     EXPECT_DOUBLE_EQ(close_price, 1.12335);
     EXPECT_EQ(
         manager.determine_trade_state(result, request, close_price),

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -526,6 +526,20 @@ std::unique_ptr<TradeRequest> make_valid_sprint_trade_request() {
     return trade_request;
 }
 
+std::unique_ptr<events::PriceUpdateEvent> make_price_update_event(
+        const std::string& symbol,
+        const Tick& tick,
+        std::uint32_t price_digits) {
+    std::vector<events::TickUpdateBatch> batches;
+    batches.push_back(events::PriceUpdateEvent::make_tick_batch(
+        tick,
+        symbol,
+        "test",
+        price_digits,
+        0));
+    return std::make_unique<events::PriceUpdateEvent>(std::move(batches));
+}
+
 TEST(AccountInfoDataTest, PayoutAboveMinAcceptsBrokerPayoutGreaterThanMinimum) {
     optionx::platforms::intrade_bar::AccountInfoData account_info;
     account_info.currency = CurrencyType::USD;
@@ -1068,17 +1082,14 @@ TEST_F(TradeManagerTestFixture, ValidTradeTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    SingleTick tick;
+    Tick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
-    tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
-    tick.symbol       = "EURUSD";
-    tick.price_digits = 5;
-    tick.tick.set_flag(optionx::MarketDataFlags::REALTIME);
-    tick.tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
-    std::vector<SingleTick> ticks = { tick };
+    tick = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
+    tick.set_flag(optionx::MarketDataFlags::REALTIME);
+    tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
 
-    bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
+    bus.notify_async(make_price_update_event("EURUSD", tick, 5));
 
     // Wait a short time for the callback to be invoked.
     int wait_iterations = 0;
@@ -1164,17 +1175,14 @@ TEST_F(TradeManagerTestFixture, InvalidTradeTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    SingleTick tick;
+    Tick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
-    tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
-    tick.symbol       = "EURUSD";
-    tick.price_digits = 5;
-    tick.tick.set_flag(optionx::MarketDataFlags::REALTIME);
-    tick.tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
-    std::vector<SingleTick> ticks = { tick };
+    tick = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
+    tick.set_flag(optionx::MarketDataFlags::REALTIME);
+    tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
 
-    bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
+    bus.notify_async(make_price_update_event("EURUSD", tick, 5));
 
     // Wait a short time for the callback to be invoked.
     int wait_iterations = 0;
@@ -1262,17 +1270,14 @@ TEST_F(TradeManagerTestFixture, ShutdownTest) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
     // Simulate a price update event to trigger closing.
-    SingleTick tick;
+    Tick tick;
     // Set tick price data so that mid_price > open_price.
     // For example, for BUY order if mid_price > 1.12335 then trade is WIN.
-    tick.tick         = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
-    tick.symbol       = "EURUSD";
-    tick.price_digits = 5;
-    tick.tick.set_flag(optionx::MarketDataFlags::REALTIME);
-    tick.tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
-    std::vector<SingleTick> ticks = { tick };
+    tick = { 1.12350, 1.12340, 0.1, 1695483030000, 1695483031000, 0 };
+    tick.set_flag(optionx::MarketDataFlags::REALTIME);
+    tick.set_flag(optionx::MarketDataFlags::INITIALIZED);
 
-    bus.notify_async(std::make_unique<events::PriceUpdateEvent>(ticks));
+    bus.notify_async(make_price_update_event("EURUSD", tick, 5));
 
     // Wait a short time for the callback to be invoked.
     std::this_thread::sleep_for(std::chrono::milliseconds(5000));

--- a/tests/trade_manager_test.cpp
+++ b/tests/trade_manager_test.cpp
@@ -574,6 +574,29 @@ TEST(AccountInfoDataTest, PayoutAboveMinAcceptsBrokerPayoutGreaterThanMinimum) {
         timestamp));
 }
 
+TEST(TradeStateManagerTest, DetermineTradeStateUsesNormalizedClosePrice) {
+    auto account_info = std::make_shared<AccountInfoData>();
+    AccountInfoProvider account_info_provider(account_info);
+    TradeStateManager manager(account_info_provider);
+
+    auto result = std::make_shared<TradeResult>();
+    auto request = std::make_shared<TradeRequest>();
+    result->open_price = 1.12335;
+    request->order_type = OrderType::BUY;
+
+    Tick tick;
+    tick.bid = 1.1233548;
+    tick.ask = 1.1233550;
+    tick.set_flag(MarketDataFlags::INITIALIZED);
+
+    ASSERT_GT(tick.mid_price(), result->open_price);
+    const double close_price = tick.normalized_mid_price(5);
+    EXPECT_DOUBLE_EQ(close_price, 1.12335);
+    EXPECT_EQ(
+        manager.determine_trade_state(result, request, close_price),
+        TradeState::STANDOFF);
+}
+
 TEST_F(TradeManagerTestFixture, OrderIntervalDelaysQueuedTrades) {
     utils::EventBus bus;
     auto account_info = std::make_shared<AccountInfoData>();


### PR DESCRIPTION
## What Changed
- Replaced `PriceUpdateEvent` payloads with `events::TickUpdateBatch`, which carries raw `Tick` payloads plus shared symbol/provider precision metadata.
- Updated Intrade polling, FX WebSocket, and BTC WebSocket sources to convert parser `SingleTick` snapshots into tick update batches before publishing price events.
- Added the `Tick::mid_price(price_digits)` overload and kept live trade-state evaluation on the normalized close price, matching the value stored in `TradeResult::close_price`.
- Updated market-data subscription routing to accumulate queued price events and flush public tick callbacks from the platform process cycle.
- Documented the market-data callback lifecycle contract: public callbacks flush from `process()`/`run()` provider lifecycle, not from direct `event_bus().drain()` calls.
- Updated smoke/test helpers, trade-manager tests, and Ubuntu Smoke coverage for the new event payload contract.

## Notes
- `SingleTick` intentionally remains available for parser and snapshot DTOs, including `PriceSnapshot` and smoke support helpers.
- The event bus no longer exposes `SingleTick` wrappers for price updates; batch metadata now lives once per batch instead of once per tick wrapper.
- If multiple price events are queued before the platform loop flushes subscriptions, matching ticks are coalesced into one `TickDataBatch` per subscription.
- Consumers that run platforms manually must call `platform.process()`; draining the internal event bus alone is not a market-data delivery API.

## Validation
- `cmake --build build-codex --target market_data_subscription_contract_test -j 4`
- `./build-codex/trade_manager_test.exe --gtest_brief=1`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1`
- `./build-codex/market_data_subscription_contract_test.exe --gtest_brief=1`
- GitHub Actions: Ubuntu Smoke pending after latest doc update