### PR TITLE
[codex] Build live bars from Intrade ticks

### DIFF
--- a/examples/intrade_market_data_example.cpp
+++ b/examples/intrade_market_data_example.cpp
@@ -109,8 +109,18 @@ int main() {
         .subscribe_ticks(market_data::TickSubscriptionRequest(
             "BTCUSDT",
             market_data::MarketDataTransport::WEBSOCKET))
+        .subscribe_bars(market_data::BarSubscriptionRequest(
+            "BTCUSDT",
+            60,
+            BarPriceSource::LAST,
+            market_data::MarketDataTransport::WEBSOCKET))
         .subscribe_ticks(market_data::TickSubscriptionRequest(
             "EUR/USD",
+            market_data::MarketDataTransport::POLLING))
+        .subscribe_bars(market_data::BarSubscriptionRequest(
+            "EUR/USD",
+            60,
+            BarPriceSource::MID,
             market_data::MarketDataTransport::POLLING))
         .subscribe_ticks(market_data::TickSubscriptionRequest(
             "EUR/USD",

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -116,6 +116,14 @@ Contract rules:
   contract.
 - Payload `flags` encode realtime/history/backfill state through
   `MarketDataFlags` and the compact price stream through `MarketPriceType`.
+- Live bar payloads with `INCOMPLETE` are mutable snapshots. Consumers that keep
+  a local time series should upsert by `(provider_id, subscription_id, symbol,
+  timeframe, time_ms)` until a `FINALIZED` payload for the same key arrives.
+  Appending every incomplete snapshot as a new candle will create duplicate bars.
+- Tick-driven live bar aggregation finalizes a bar when the first tick from the
+  next timeframe bucket arrives. If the stream becomes silent, the latest bar can
+  remain `INCOMPLETE`. Future work: add timer/process-based finalization as a
+  separate change.
 - `on_market_data_status()` is a separate stream-status callback. Data callbacks
   should carry data batches, not connection lifecycle sentinel payloads.
 - `apply_subscriptions()` applies subscription changes atomically. The old

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -100,6 +100,12 @@ Subscription rules:
   `event_bus()` directly is not enough to flush public market-data batches.
 - Use `MarketDataFlags` for realtime/history/backfill markers and
   `MarketPriceType` for bid/ask/mid/last payload identity.
+- Live bar streams can deliver several `INCOMPLETE` snapshots with the same
+  `(provider_id, subscription_id, symbol, timeframe, time_ms)` key before the
+  final `FINALIZED` snapshot. Treat them as upserts, not append-only candles.
+- Tick-driven bar streams finalize the current bar only when a tick from the next
+  timeframe bucket arrives. Timer/process-based finalization is tracked as
+  future work.
 - `MarketDataContinuityService` routes recovered historical bars into the same
   `BarDataBatch` pipeline and marks them as `HISTORICAL`/`BACKFILL`.
 - `BaseMarketDataProvider` is non-copyable and non-movable so provider identity

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -57,7 +57,9 @@ namespace optionx::market_data {
         /// \brief Returns a reference to the live bar-data callback.
         /// \details Providers may coalesce queued updates and invoke this callback
         ///          from their lifecycle `process()`/platform loop, not directly
-        ///          from a low-level event-bus drain.
+        ///          from a low-level event-bus drain. Live bar streams may emit
+        ///          multiple `INCOMPLETE` snapshots for the same bar key before a
+        ///          later `FINALIZED` snapshot arrives.
         /// \return Mutable callback reference, or a null callback if live bars are unsupported.
         virtual bars_callback_t& on_bar_data() {
             static bars_callback_t null_callback;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -85,6 +85,21 @@ namespace optionx::platforms::intrade_bar {
             market_data::SubscriptionId,
             market_data::MarketDataSubscriptionHandle> m_tick_subscriptions; ///< Active tick subscriptions.
         std::vector<market_data::TickDataBatch> m_pending_tick_batches; ///< Tick batches waiting for the next process cycle.
+        std::unordered_map<
+            market_data::SubscriptionId,
+            market_data::MarketDataSubscriptionHandle> m_bar_subscriptions; ///< Active bar subscriptions.
+
+        /// \struct BarAggregationState
+        /// \brief Runtime OHLC accumulator for one live bar subscription.
+        struct BarAggregationState {
+            Bar current; ///< Current in-progress bar.
+            bool initialized = false; ///< True after the first valid tick was applied.
+        };
+
+        std::unordered_map<
+            market_data::SubscriptionId,
+            BarAggregationState> m_bar_states; ///< Bar accumulators keyed by subscription ID.
+        std::vector<market_data::BarDataBatch> m_pending_bar_batches; ///< Bar batches waiting for the next process cycle.
         market_data::SubscriptionId m_next_subscription_id = 1; ///< Next runtime handle ID.
         std::mutex m_mutex; ///< Protects subscription handles.
 
@@ -99,6 +114,10 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Selects the concrete Intrade Bar tick source for a tick request.
         static TickSource select_tick_source(
                 const market_data::TickSubscriptionRequest& request);
+
+        /// \brief Selects the concrete Intrade Bar tick source used to build live bars.
+        static TickSource select_tick_source(
+                const market_data::BarSubscriptionRequest& request);
 
         /// \brief Returns the public transport represented by a concrete source.
         static market_data::MarketDataTransport transport_for_source(
@@ -127,9 +146,33 @@ namespace optionx::platforms::intrade_bar {
                 const market_data::MarketDataSubscriptionHandle& subscription,
                 const events::TickUpdateBatch& source_batch);
 
+        /// \brief Finds or creates a pending bar delivery batch.
+        market_data::BarDataBatch& pending_bar_batch_for(
+                const market_data::MarketDataSubscriptionHandle& subscription,
+                const events::TickUpdateBatch& source_batch);
+
         /// \brief Removes queued tick data for an inactive subscription.
         /// \pre The caller holds m_mutex.
         void remove_pending_tick_batch_no_lock(market_data::SubscriptionId subscription_id);
+
+        /// \brief Removes queued bar data for an inactive subscription.
+        /// \pre The caller holds m_mutex.
+        void remove_pending_bar_batch_no_lock(market_data::SubscriptionId subscription_id);
+
+        /// \brief Extracts the configured price from a tick payload.
+        static double price_from_tick(
+                const Tick& tick,
+                BarPriceSource price_source) noexcept;
+
+        /// \brief Returns the event timestamp used for live bar bucketing.
+        static std::uint64_t tick_time_ms(const Tick& tick) noexcept;
+
+        /// \brief Applies one tick to a live bar accumulator.
+        static void append_bar_updates(
+                const market_data::MarketDataSubscriptionHandle& subscription,
+                const Tick& tick,
+                BarAggregationState& state,
+                std::vector<Bar>& updates);
     };
 
     inline bool MarketDataSubscriptionManager::subscribe_ticks(
@@ -186,6 +229,7 @@ namespace optionx::platforms::intrade_bar {
         std::vector<market_data::MarketDataSubscriptionHandle> added_subscriptions;
         std::vector<TickSource> added_sources;
         std::vector<market_data::MarketDataSubscriptionHandle> removed_subscriptions;
+        std::vector<std::pair<market_data::SubscriptionId, BarAggregationState>> removed_bar_states;
         std::vector<market_data::MarketDataSubscriptionResult> results;
         market_data::MarketDataSubscriptionBatchResult failure_result;
         market_data::SubscriptionId previous_next_subscription_id =
@@ -247,20 +291,36 @@ namespace optionx::platforms::intrade_bar {
                 }
                 case market_data::MarketDataSubscriptionAction::SUBSCRIBE_BARS: {
                     change.bar_request.symbol = normalize_symbol_name(std::move(change.bar_request.symbol));
-                    const bool valid = change.bar_request.valid();
-                    const auto status = valid
-                        ? market_data::MarketDataSubscriptionStatus::UNSUPPORTED
-                        : market_data::MarketDataSubscriptionStatus::INVALID_REQUEST;
-                    const std::string message = valid
-                        ? "Intrade Bar bar subscriptions require a tick-to-bar aggregator and are not supported yet."
-                        : "Invalid Intrade Bar bar subscription request.";
-                    set_failure(
-                        status,
-                        message,
-                        {market_data::MarketDataSubscriptionResult::failed(
-                            std::move(change.bar_request),
-                            status,
-                            message)});
+                    if (!change.bar_request.valid()) {
+                        set_failure(
+                            market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
+                            "Invalid Intrade Bar bar subscription request.",
+                            {market_data::MarketDataSubscriptionResult::failed(
+                                std::move(change.bar_request),
+                                market_data::MarketDataSubscriptionStatus::INVALID_REQUEST,
+                                "Invalid Intrade Bar bar subscription request.")});
+                        break;
+                    }
+                    const auto source = select_tick_source(change.bar_request);
+                    if (source == TickSource::UNKNOWN) {
+                        set_failure(
+                            market_data::MarketDataSubscriptionStatus::UNSUPPORTED,
+                            "Intrade Bar bar subscription source is not supported for this symbol/transport.",
+                            {market_data::MarketDataSubscriptionResult::failed(
+                                std::move(change.bar_request),
+                                market_data::MarketDataSubscriptionStatus::UNSUPPORTED,
+                                "Intrade Bar bar subscription source is not supported for this symbol/transport.")});
+                        break;
+                    }
+
+                    auto handle = market_data::MarketDataSubscriptionHandle::from_bar_request(
+                        m_provider_id,
+                        next_subscription_id_from(next_id),
+                        change.bar_request);
+                    handle.transport = transport_for_source(source);
+                    added_subscriptions.push_back(handle);
+                    added_sources.push_back(source);
+                    results.push_back(market_data::MarketDataSubscriptionResult::subscribed(handle));
                     break;
                 }
                 case market_data::MarketDataSubscriptionAction::UNSUBSCRIBE: {
@@ -285,8 +345,10 @@ namespace optionx::platforms::intrade_bar {
                         break;
                     }
 
-                    auto it = m_tick_subscriptions.find(change.subscription.id);
-                    if (it == m_tick_subscriptions.end()) {
+                    auto tick_it = m_tick_subscriptions.find(change.subscription.id);
+                    auto bar_it = m_bar_subscriptions.find(change.subscription.id);
+                    if (tick_it == m_tick_subscriptions.end() &&
+                        bar_it == m_bar_subscriptions.end()) {
                         set_failure(
                             market_data::MarketDataSubscriptionStatus::FAILED,
                             "Intrade Bar market-data subscription is not active.",
@@ -297,12 +359,20 @@ namespace optionx::platforms::intrade_bar {
                         break;
                     }
 
-                    removed_subscriptions.push_back(it->second);
-                    results.push_back(market_data::MarketDataSubscriptionResult::unsubscribed(it->second));
+                    const auto subscription = tick_it != m_tick_subscriptions.end()
+                        ? tick_it->second
+                        : bar_it->second;
+                    removed_subscriptions.push_back(subscription);
+                    results.push_back(market_data::MarketDataSubscriptionResult::unsubscribed(subscription));
                     break;
                 }
                 case market_data::MarketDataSubscriptionAction::UNSUBSCRIBE_ALL:
                     for (const auto& [id, subscription] : m_tick_subscriptions) {
+                        (void)id;
+                        removed_subscriptions.push_back(subscription);
+                        results.push_back(market_data::MarketDataSubscriptionResult::unsubscribed(subscription));
+                    }
+                    for (const auto& [id, subscription] : m_bar_subscriptions) {
                         (void)id;
                         removed_subscriptions.push_back(subscription);
                         results.push_back(market_data::MarketDataSubscriptionResult::unsubscribed(subscription));
@@ -319,9 +389,20 @@ namespace optionx::platforms::intrade_bar {
                 for (const auto& subscription : removed_subscriptions) {
                     m_tick_subscriptions.erase(subscription.id);
                     remove_pending_tick_batch_no_lock(subscription.id);
+                    m_bar_subscriptions.erase(subscription.id);
+                    remove_pending_bar_batch_no_lock(subscription.id);
+                    auto state_it = m_bar_states.find(subscription.id);
+                    if (state_it != m_bar_states.end()) {
+                        removed_bar_states.push_back(*state_it);
+                    }
+                    m_bar_states.erase(subscription.id);
                 }
                 for (const auto& subscription : added_subscriptions) {
-                    m_tick_subscriptions[subscription.id] = subscription;
+                    if (subscription.stream_type == market_data::MarketDataType::BARS) {
+                        m_bar_subscriptions[subscription.id] = subscription;
+                    } else {
+                        m_tick_subscriptions[subscription.id] = subscription;
+                    }
                 }
                 m_next_subscription_id = next_id;
             }
@@ -368,9 +449,19 @@ namespace optionx::platforms::intrade_bar {
                         for (const auto& added : added_subscriptions) {
                             m_tick_subscriptions.erase(added.id);
                             remove_pending_tick_batch_no_lock(added.id);
+                            m_bar_subscriptions.erase(added.id);
+                            remove_pending_bar_batch_no_lock(added.id);
+                            m_bar_states.erase(added.id);
                         }
                         for (const auto& removed : removed_subscriptions) {
-                            m_tick_subscriptions[removed.id] = removed;
+                            if (removed.stream_type == market_data::MarketDataType::BARS) {
+                                m_bar_subscriptions[removed.id] = removed;
+                            } else {
+                                m_tick_subscriptions[removed.id] = removed;
+                            }
+                        }
+                        for (const auto& [id, state] : removed_bar_states) {
+                            m_bar_states[id] = state;
                         }
                         m_next_subscription_id = previous_next_subscription_id;
                     }
@@ -411,16 +502,28 @@ namespace optionx::platforms::intrade_bar {
 
     inline void MarketDataSubscriptionManager::process() {
         std::vector<market_data::TickDataBatch> batches;
+        std::vector<market_data::BarDataBatch> bar_batches;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
             batches.swap(m_pending_tick_batches);
+            bar_batches.swap(m_pending_bar_batches);
         }
 
-        if (!m_ticks_callback) return;
-        for (auto& batch : batches) {
-            if (!batch.empty()) {
-                m_ticks_callback(
-                    std::make_unique<market_data::TickDataBatch>(std::move(batch)));
+        if (m_ticks_callback) {
+            for (auto& batch : batches) {
+                if (!batch.empty()) {
+                    m_ticks_callback(
+                        std::make_unique<market_data::TickDataBatch>(std::move(batch)));
+                }
+            }
+        }
+
+        if (m_bars_callback) {
+            for (auto& batch : bar_batches) {
+                if (!batch.empty()) {
+                    m_bars_callback(
+                        std::make_unique<market_data::BarDataBatch>(std::move(batch)));
+                }
             }
         }
     }
@@ -429,8 +532,12 @@ namespace optionx::platforms::intrade_bar {
         std::vector<market_data::MarketDataSubscriptionHandle> subscriptions;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            subscriptions.reserve(m_tick_subscriptions.size());
+            subscriptions.reserve(m_tick_subscriptions.size() + m_bar_subscriptions.size());
             for (const auto& [id, subscription] : m_tick_subscriptions) {
+                (void)id;
+                subscriptions.push_back(subscription);
+            }
+            for (const auto& [id, subscription] : m_bar_subscriptions) {
                 (void)id;
                 subscriptions.push_back(subscription);
             }
@@ -447,6 +554,9 @@ namespace optionx::platforms::intrade_bar {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_tick_subscriptions.clear();
         m_pending_tick_batches.clear();
+        m_bar_subscriptions.clear();
+        m_bar_states.clear();
+        m_pending_bar_batches.clear();
     }
 
     inline market_data::SubscriptionId
@@ -464,7 +574,8 @@ namespace optionx::platforms::intrade_bar {
 
     inline bool MarketDataSubscriptionManager::uses_fx_websocket_source(
             const market_data::MarketDataSubscriptionHandle& subscription) {
-        if (subscription.stream_type != market_data::MarketDataType::TICKS) {
+        if (subscription.stream_type != market_data::MarketDataType::TICKS &&
+            subscription.stream_type != market_data::MarketDataType::BARS) {
             return false;
         }
         return subscription.transport == market_data::MarketDataTransport::WEBSOCKET &&
@@ -492,6 +603,15 @@ namespace optionx::platforms::intrade_bar {
         default:
             return TickSource::UNKNOWN;
         }
+    }
+
+    inline MarketDataSubscriptionManager::TickSource
+    MarketDataSubscriptionManager::select_tick_source(
+            const market_data::BarSubscriptionRequest& request) {
+        market_data::TickSubscriptionRequest tick_request(
+            request.symbol,
+            request.transport);
+        return select_tick_source(tick_request);
     }
 
     inline market_data::MarketDataTransport
@@ -552,7 +672,7 @@ namespace optionx::platforms::intrade_bar {
     inline void MarketDataSubscriptionManager::handle_event(
             const events::PriceUpdateEvent& event) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        if (m_tick_subscriptions.empty()) return;
+        if (m_tick_subscriptions.empty() && m_bar_subscriptions.empty()) return;
 
         for (const auto& source_batch : event.get_tick_batches()) {
             const auto normalized_symbol = normalize_symbol_name(source_batch.symbol);
@@ -565,6 +685,18 @@ namespace optionx::platforms::intrade_bar {
                 for (const auto& tick : source_batch.items) {
                     batch.items.push_back(tick);
                     batch.items.back().set_flag(MarketDataFlags::REALTIME);
+                }
+            }
+
+            for (const auto& [id, subscription] : m_bar_subscriptions) {
+                (void)id;
+                if (subscription.symbol != normalized_symbol) continue;
+                if (!source_matches_subscription(subscription, event.source())) continue;
+
+                auto& batch = pending_bar_batch_for(subscription, source_batch);
+                auto& state = m_bar_states[subscription.id];
+                for (const auto& tick : source_batch.items) {
+                    append_bar_updates(subscription, tick, state, batch.items);
                 }
             }
         }
@@ -591,6 +723,27 @@ namespace optionx::platforms::intrade_bar {
         return m_pending_tick_batches.back();
     }
 
+    inline market_data::BarDataBatch&
+    MarketDataSubscriptionManager::pending_bar_batch_for(
+            const market_data::MarketDataSubscriptionHandle& subscription,
+            const events::TickUpdateBatch& source_batch) {
+        for (auto& batch : m_pending_bar_batches) {
+            if (batch.subscription.id == subscription.id) {
+                return batch;
+            }
+        }
+
+        market_data::BarDataBatch created;
+        created.subscription = subscription;
+        created.type = market_data::MarketDataType::BARS;
+        created.symbol = subscription.symbol;
+        created.timeframe = subscription.timeframe;
+        created.price_digits = source_batch.price_digits;
+        created.volume_digits = source_batch.volume_digits;
+        m_pending_bar_batches.push_back(std::move(created));
+        return m_pending_bar_batches.back();
+    }
+
     inline void MarketDataSubscriptionManager::remove_pending_tick_batch_no_lock(
             market_data::SubscriptionId subscription_id) {
         for (auto it = m_pending_tick_batches.begin();
@@ -601,6 +754,89 @@ namespace optionx::platforms::intrade_bar {
                 ++it;
             }
         }
+    }
+
+    inline void MarketDataSubscriptionManager::remove_pending_bar_batch_no_lock(
+            market_data::SubscriptionId subscription_id) {
+        for (auto it = m_pending_bar_batches.begin();
+             it != m_pending_bar_batches.end();) {
+            if (it->subscription.id == subscription_id) {
+                it = m_pending_bar_batches.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    inline double MarketDataSubscriptionManager::price_from_tick(
+            const Tick& tick,
+            BarPriceSource price_source) noexcept {
+        switch (price_source) {
+        case BarPriceSource::BID:
+            return tick.bid;
+        case BarPriceSource::ASK:
+            return tick.ask;
+        case BarPriceSource::LAST:
+            return tick.last != 0.0 ? tick.last : tick.mid_price();
+        case BarPriceSource::MID:
+        case BarPriceSource::UNKNOWN:
+        default:
+            return tick.mid_price();
+        }
+    }
+
+    inline std::uint64_t MarketDataSubscriptionManager::tick_time_ms(
+            const Tick& tick) noexcept {
+        return tick.time_ms != 0 ? tick.time_ms : tick.received_ms;
+    }
+
+    inline void MarketDataSubscriptionManager::append_bar_updates(
+            const market_data::MarketDataSubscriptionHandle& subscription,
+            const Tick& tick,
+            BarAggregationState& state,
+            std::vector<Bar>& updates) {
+        if (!tick.has_flag(MarketDataFlags::INITIALIZED)) return;
+
+        const auto timestamp_ms = tick_time_ms(tick);
+        if (timestamp_ms == 0 || subscription.timeframe <= 0) return;
+
+        const auto timeframe_ms =
+            static_cast<std::uint64_t>(subscription.timeframe) * time_shield::MS_PER_SEC;
+        if (timeframe_ms == 0) return;
+
+        const auto price = price_from_tick(tick, subscription.price_source);
+        if (price == 0.0) return;
+
+        const auto bucket_ms = (timestamp_ms / timeframe_ms) * timeframe_ms;
+        const auto price_type = market_price_type_from_bar_price_source(subscription.price_source);
+
+        if (!state.initialized || state.current.time_ms != bucket_ms) {
+            if (state.initialized) {
+                state.current.set_flag(MarketDataFlags::INCOMPLETE, false);
+                state.current.set_flag(MarketDataFlags::FINALIZED);
+                updates.push_back(state.current);
+            }
+
+            state.current = Bar(price, price, price, price, tick.volume, bucket_ms);
+            state.current.set_flag(MarketDataFlags::REALTIME);
+            state.current.set_flag(MarketDataFlags::INCOMPLETE);
+            state.current.set_flag(MarketDataFlags::INITIALIZED);
+            state.current.set_price_type(price_type);
+            state.initialized = true;
+            updates.push_back(state.current);
+            return;
+        }
+
+        state.current.high = std::max(state.current.high, price);
+        state.current.low = std::min(state.current.low, price);
+        state.current.close = price;
+        state.current.volume += tick.volume;
+        state.current.set_flag(MarketDataFlags::REALTIME);
+        state.current.set_flag(MarketDataFlags::INCOMPLETE);
+        state.current.set_flag(MarketDataFlags::FINALIZED, false);
+        state.current.set_flag(MarketDataFlags::INITIALIZED);
+        state.current.set_price_type(price_type);
+        updates.push_back(state.current);
     }
 
 } // namespace optionx::platforms::intrade_bar

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -503,16 +503,16 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void MarketDataSubscriptionManager::process() {
-        std::vector<market_data::TickDataBatch> batches;
+        std::vector<market_data::TickDataBatch> tick_batches;
         std::vector<market_data::BarDataBatch> bar_batches;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            batches.swap(m_pending_tick_batches);
+            tick_batches.swap(m_pending_tick_batches);
             bar_batches.swap(m_pending_bar_batches);
         }
 
         if (m_ticks_callback) {
-            for (auto& batch : batches) {
+            for (auto& batch : tick_batches) {
                 if (!batch.empty()) {
                     m_ticks_callback(
                         std::make_unique<market_data::TickDataBatch>(std::move(batch)));

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -93,6 +93,8 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Runtime OHLC accumulator for one live bar subscription.
         struct BarAggregationState {
             Bar current; ///< Current in-progress bar.
+            std::uint64_t first_tick_time_ms = 0; ///< Earliest tick timestamp in the current bar bucket.
+            std::uint64_t last_tick_time_ms = 0; ///< Latest tick timestamp in the current bar bucket.
             bool initialized = false; ///< True after the first valid tick was applied.
         };
 
@@ -810,6 +812,10 @@ namespace optionx::platforms::intrade_bar {
         const auto bucket_ms = (timestamp_ms / timeframe_ms) * timeframe_ms;
         const auto price_type = market_price_type_from_bar_price_source(subscription.price_source);
 
+        if (state.initialized && bucket_ms < state.current.time_ms) {
+            return;
+        }
+
         if (!state.initialized || state.current.time_ms != bucket_ms) {
             if (state.initialized) {
                 state.current.set_flag(MarketDataFlags::INCOMPLETE, false);
@@ -822,14 +828,23 @@ namespace optionx::platforms::intrade_bar {
             state.current.set_flag(MarketDataFlags::INCOMPLETE);
             state.current.set_flag(MarketDataFlags::INITIALIZED);
             state.current.set_price_type(price_type);
+            state.first_tick_time_ms = timestamp_ms;
+            state.last_tick_time_ms = timestamp_ms;
             state.initialized = true;
             updates.push_back(state.current);
             return;
         }
 
+        if (state.first_tick_time_ms == 0 || timestamp_ms < state.first_tick_time_ms) {
+            state.current.open = price;
+            state.first_tick_time_ms = timestamp_ms;
+        }
         state.current.high = std::max(state.current.high, price);
         state.current.low = std::min(state.current.low, price);
-        state.current.close = price;
+        if (state.last_tick_time_ms == 0 || timestamp_ms >= state.last_tick_time_ms) {
+            state.current.close = price;
+            state.last_tick_time_ms = timestamp_ms;
+        }
         state.current.volume += tick.volume;
         state.current.set_flag(MarketDataFlags::REALTIME);
         state.current.set_flag(MarketDataFlags::INCOMPLETE);

--- a/tests/intrade_bar_api/CLI.md
+++ b/tests/intrade_bar_api/CLI.md
@@ -167,7 +167,8 @@ Smoke live market-data streams:
 subscriptions, prints stream status updates, and prints every delivered tick
 batch. When `--bars` is set, it also:
 
-- tries the provider-level live bar subscription and prints the typed result;
+- applies provider-level live bar subscriptions backed by tick-to-bar
+  aggregation and prints the typed result;
 - builds local realtime OHLC updates from the live tick stream for terminal
   inspection;
 - requests a historical/backfill bar batch through `MarketDataContinuityService`
@@ -206,10 +207,9 @@ Expected output includes lines like:
 [bar-batch] symbol=BTCUSDT timeframe=60 items=...
 ```
 
-Intrade live bars are not provider-native yet, so `--bars` currently uses
-local CLI aggregation for realtime bar updates and history/backfill for
-historical bars. The provider-level `subscribe_bars()` result is still printed
-so this command will expose the change when native bar streams are added.
+Intrade live bars are built from the selected tick transport. The CLI also
+keeps its local aggregation output visible so manual smoke runs can compare the
+provider-level bar batches against the raw tick stream.
 
 Fetch closed trade history:
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1004,6 +1004,165 @@ TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionAggregatesTickUpdates) {
     platform.shutdown();
 }
 
+TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionIgnoresPreviousBucketTicks) {
+    IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::BarDataBatch delivered_batch;
+    int bar_callback_count = 0;
+    market_data::MarketDataSubscriptionResult result;
+
+    platform.on_bar_data() =
+        [&delivered_batch, &bar_callback_count](std::unique_ptr<market_data::BarDataBatch> batch) {
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+            ++bar_callback_count;
+        };
+
+    ASSERT_TRUE(platform.subscribe_bars(
+        market_data::BarSubscriptionRequest(
+            "EUR/USD",
+            60,
+            BarPriceSource::MID,
+            market_data::MarketDataTransport::POLLING),
+        [&result](market_data::MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+        }));
+
+    ASSERT_TRUE(result);
+
+    auto first_batch = make_market_data_batch("EURUSD", 1.10000, 1.10020);
+    first_batch.items[0].time_ms = 120000;
+    auto next_batch = make_market_data_batch("EURUSD", 1.10040, 1.10060);
+    next_batch.items[0].time_ms = 180000;
+    auto late_batch = make_market_data_batch("EURUSD", 1.20000, 1.20020);
+    late_batch.items[0].time_ms = 120500;
+
+    std::vector<events::TickUpdateBatch> event_ticks;
+    event_ticks.push_back(std::move(first_batch));
+    event_ticks.push_back(std::move(next_batch));
+    event_ticks.push_back(std::move(late_batch));
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    pump_platform(platform);
+
+    ASSERT_EQ(bar_callback_count, 1);
+    ASSERT_EQ(delivered_batch.items.size(), 3u);
+    EXPECT_EQ(delivered_batch.items[0].time_ms, 120000u);
+    EXPECT_EQ(delivered_batch.items[1].time_ms, 120000u);
+    EXPECT_TRUE(delivered_batch.items[1].has_flag(MarketDataFlags::FINALIZED));
+    EXPECT_EQ(delivered_batch.items[2].time_ms, 180000u);
+    EXPECT_DOUBLE_EQ(delivered_batch.items[2].open, 1.10050);
+    EXPECT_DOUBLE_EQ(delivered_batch.items[2].close, 1.10050);
+    EXPECT_DOUBLE_EQ(delivered_batch.items[2].high, 1.10050);
+    EXPECT_DOUBLE_EQ(delivered_batch.items[2].low, 1.10050);
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionKeepsCloseFromLatestTickInBucket) {
+    IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::BarDataBatch delivered_batch;
+    int bar_callback_count = 0;
+    market_data::MarketDataSubscriptionResult result;
+
+    platform.on_bar_data() =
+        [&delivered_batch, &bar_callback_count](std::unique_ptr<market_data::BarDataBatch> batch) {
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+            ++bar_callback_count;
+        };
+
+    ASSERT_TRUE(platform.subscribe_bars(
+        market_data::BarSubscriptionRequest(
+            "EUR/USD",
+            60,
+            BarPriceSource::MID,
+            market_data::MarketDataTransport::POLLING),
+        [&result](market_data::MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+        }));
+
+    ASSERT_TRUE(result);
+
+    auto later_batch = make_market_data_batch("EURUSD", 1.10040, 1.10060);
+    later_batch.items[0].time_ms = 121000;
+    auto earlier_batch = make_market_data_batch("EURUSD", 1.10000, 1.10020);
+    earlier_batch.items[0].time_ms = 120000;
+
+    std::vector<events::TickUpdateBatch> event_ticks;
+    event_ticks.push_back(std::move(later_batch));
+    event_ticks.push_back(std::move(earlier_batch));
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    pump_platform(platform);
+
+    ASSERT_EQ(bar_callback_count, 1);
+    ASSERT_EQ(delivered_batch.items.size(), 2u);
+    const auto& updated = delivered_batch.items[1];
+    EXPECT_EQ(updated.time_ms, 120000u);
+    EXPECT_DOUBLE_EQ(updated.open, 1.10010);
+    EXPECT_DOUBLE_EQ(updated.close, 1.10050);
+    EXPECT_DOUBLE_EQ(updated.high, 1.10050);
+    EXPECT_DOUBLE_EQ(updated.low, 1.10010);
+    EXPECT_TRUE(updated.has_flag(MarketDataFlags::INCOMPLETE));
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionClearsPendingUpdatesOnUnsubscribe) {
+    IntradeBarPlatform platform;
+    platform.run(false);
+    int bar_callback_count = 0;
+    market_data::MarketDataSubscriptionResult result;
+    market_data::MarketDataSubscriptionResult unsubscribe_result;
+
+    platform.on_bar_data() =
+        [&bar_callback_count](std::unique_ptr<market_data::BarDataBatch> batch) {
+            if (batch && !batch->items.empty()) {
+                ++bar_callback_count;
+            }
+        };
+
+    ASSERT_TRUE(platform.subscribe_bars(
+        market_data::BarSubscriptionRequest(
+            "EUR/USD",
+            60,
+            BarPriceSource::MID,
+            market_data::MarketDataTransport::POLLING),
+        [&result](market_data::MarketDataSubscriptionResult subscription_result) {
+            result = std::move(subscription_result);
+        }));
+
+    ASSERT_TRUE(result);
+
+    std::vector<events::TickUpdateBatch> event_ticks = {
+        make_market_data_batch("EURUSD", 1.10000, 1.10020)
+    };
+    event_ticks[0].items[0].time_ms = 120000;
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    platform.event_bus().drain();
+
+    EXPECT_TRUE(platform.unsubscribe(
+        result.subscription,
+        [&unsubscribe_result](market_data::MarketDataSubscriptionResult unsubscribe) {
+            unsubscribe_result = std::move(unsubscribe);
+        }));
+    EXPECT_TRUE(unsubscribe_result);
+    EXPECT_EQ(unsubscribe_result.status, market_data::MarketDataSubscriptionStatus::UNSUBSCRIBED);
+
+    pump_platform(platform);
+    EXPECT_EQ(bar_callback_count, 0);
+
+    platform.shutdown();
+}
+
 TEST(IntradeBarApiResponses, PriceDigitsMatchBrokerSymbols) {
     EXPECT_EQ(price_digits_for_symbol("BTCUSD"), 2);
     EXPECT_EQ(price_digits_for_symbol("BTCUSDT"), 2);

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -893,7 +893,7 @@ TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartially
     batch.subscribe_ticks(market_data::TickSubscriptionRequest(
         "EUR/USD",
         market_data::MarketDataTransport::POLLING));
-    batch.subscribe_bars(market_data::BarSubscriptionRequest("EUR/USD", 60));
+    batch.subscribe_bars(market_data::BarSubscriptionRequest("EUR/USD", 0));
 
     EXPECT_FALSE(platform.apply_subscriptions(
         std::move(batch),
@@ -902,7 +902,7 @@ TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartially
         }));
 
     EXPECT_FALSE(result);
-    EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::INVALID_REQUEST);
 
     std::vector<events::TickUpdateBatch> event_ticks = {
         make_market_data_batch("EURUSD", 1.0, 1.1)
@@ -916,21 +916,90 @@ TEST(IntradeBarApiResponses, IntradeBarRejectedSubscriptionBatchDoesNotPartially
     platform.shutdown();
 }
 
-TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionsReportUnsupportedTypedResult) {
+TEST(IntradeBarApiResponses, IntradeBarBarSubscriptionAggregatesTickUpdates) {
     IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::BarDataBatch delivered_batch;
+    int bar_callback_count = 0;
     market_data::MarketDataSubscriptionResult result;
 
+    platform.on_bar_data() =
+        [&delivered_batch, &bar_callback_count](std::unique_ptr<market_data::BarDataBatch> batch) {
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+            ++bar_callback_count;
+        };
+
     const bool accepted = platform.subscribe_bars(
-        market_data::BarSubscriptionRequest("EUR/USD", 60),
+        market_data::BarSubscriptionRequest(
+            "EUR/USD",
+            60,
+            BarPriceSource::MID,
+            market_data::MarketDataTransport::POLLING),
         [&result](market_data::MarketDataSubscriptionResult subscription_result) {
             result = std::move(subscription_result);
         });
 
-    EXPECT_FALSE(accepted);
-    EXPECT_FALSE(result);
-    EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::UNSUPPORTED);
+    EXPECT_TRUE(accepted);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.status, market_data::MarketDataSubscriptionStatus::SUBSCRIBED);
     EXPECT_EQ(result.subscription.symbol, "EURUSD");
     EXPECT_EQ(result.subscription.stream_type, market_data::MarketDataType::BARS);
+    EXPECT_EQ(result.subscription.timeframe, 60);
+
+    auto first_batch = make_market_data_batch("EURUSD", 1.10000, 1.10020);
+    first_batch.items[0].time_ms = 120000;
+    auto second_batch = make_market_data_batch("EURUSD", 1.10040, 1.10060);
+    second_batch.items[0].time_ms = 121000;
+    auto third_batch = make_market_data_batch("EURUSD", 1.09980, 1.10000);
+    third_batch.items[0].time_ms = 180000;
+
+    std::vector<events::TickUpdateBatch> event_ticks;
+    event_ticks.push_back(std::move(first_batch));
+    event_ticks.push_back(std::move(second_batch));
+    event_ticks.push_back(std::move(third_batch));
+
+    platform.event_bus().notify_async(
+        std::make_unique<events::PriceUpdateEvent>(std::move(event_ticks)));
+    pump_platform(platform);
+
+    ASSERT_EQ(bar_callback_count, 1);
+    ASSERT_EQ(delivered_batch.items.size(), 4u);
+    EXPECT_EQ(delivered_batch.symbol, "EURUSD");
+    EXPECT_EQ(delivered_batch.timeframe, 60);
+    EXPECT_EQ(delivered_batch.subscription.id, result.subscription.id);
+
+    const auto& first_update = delivered_batch.items[0];
+    EXPECT_EQ(first_update.time_ms, 120000u);
+    EXPECT_DOUBLE_EQ(first_update.open, 1.10010);
+    EXPECT_DOUBLE_EQ(first_update.high, 1.10010);
+    EXPECT_DOUBLE_EQ(first_update.low, 1.10010);
+    EXPECT_DOUBLE_EQ(first_update.close, 1.10010);
+    EXPECT_TRUE(first_update.has_flag(MarketDataFlags::REALTIME));
+    EXPECT_TRUE(first_update.has_flag(MarketDataFlags::INCOMPLETE));
+    EXPECT_TRUE(first_update.has_flag(MarketDataFlags::INITIALIZED));
+    EXPECT_EQ(first_update.price_type(), MarketPriceType::MID);
+
+    const auto& second_update = delivered_batch.items[1];
+    EXPECT_EQ(second_update.time_ms, 120000u);
+    EXPECT_DOUBLE_EQ(second_update.open, 1.10010);
+    EXPECT_DOUBLE_EQ(second_update.high, 1.10050);
+    EXPECT_DOUBLE_EQ(second_update.low, 1.10010);
+    EXPECT_DOUBLE_EQ(second_update.close, 1.10050);
+    EXPECT_TRUE(second_update.has_flag(MarketDataFlags::INCOMPLETE));
+
+    const auto& finalized = delivered_batch.items[2];
+    EXPECT_EQ(finalized.time_ms, 120000u);
+    EXPECT_DOUBLE_EQ(finalized.close, 1.10050);
+    EXPECT_TRUE(finalized.has_flag(MarketDataFlags::FINALIZED));
+    EXPECT_FALSE(finalized.has_flag(MarketDataFlags::INCOMPLETE));
+
+    const auto& next_bar = delivered_batch.items[3];
+    EXPECT_EQ(next_bar.time_ms, 180000u);
+    EXPECT_DOUBLE_EQ(next_bar.open, 1.09990);
+    EXPECT_DOUBLE_EQ(next_bar.close, 1.09990);
+    EXPECT_TRUE(next_bar.has_flag(MarketDataFlags::INCOMPLETE));
 
     platform.shutdown();
 }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1636,6 +1636,68 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionsAreRefCountedBySymbol) {
     platform.shutdown();
 }
 
+TEST(IntradeBarApiResponses, FxWebSocketBarSubscriptionsAreRefCountedBySymbol) {
+    LocalFxConnectServer server;
+    ASSERT_TRUE(server.start());
+
+    IntradeBarPlatform platform;
+    auto auth = std::make_unique<AuthData>();
+    auth->set_email_password("user@example.test", "unused");
+    auth->host = server.host();
+    ASSERT_TRUE(platform.configure_auth(std::move(auth)));
+    platform.event_bus().drain();
+
+    market_data::MarketDataSubscriptionResult tick_result;
+    market_data::MarketDataSubscriptionResult bar_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "EUR/USD",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&tick_result](market_data::MarketDataSubscriptionResult result) {
+            tick_result = std::move(result);
+        }));
+    ASSERT_TRUE(platform.subscribe_bars(
+        market_data::BarSubscriptionRequest(
+            "EURUSD",
+            60,
+            BarPriceSource::MID,
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&bar_result](market_data::MarketDataSubscriptionResult result) {
+            bar_result = std::move(result);
+        }));
+    ASSERT_TRUE(tick_result);
+    ASSERT_TRUE(bar_result);
+
+    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            return server.subscription_count.load() >= 1;
+        }));
+
+    EXPECT_EQ(server.subscription_count.load(), 1);
+
+    market_data::MarketDataSubscriptionResult unsubscribe_result;
+    EXPECT_TRUE(platform.unsubscribe(
+        tick_result.subscription,
+        [&unsubscribe_result](market_data::MarketDataSubscriptionResult result) {
+            unsubscribe_result = std::move(result);
+        }));
+    EXPECT_TRUE(unsubscribe_result);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    platform.event_bus().drain();
+    EXPECT_EQ(server.subscription_count.load(), 1);
+
+    EXPECT_TRUE(platform.unsubscribe(
+        bar_result.subscription,
+        [&unsubscribe_result](market_data::MarketDataSubscriptionResult result) {
+            unsubscribe_result = std::move(result);
+        }));
+
+    platform.shutdown();
+}
+
 TEST(IntradeBarApiResponses, FxWebSocketReconnectsDesiredSubscriptions) {
     LocalFxConnectServer server;
     ASSERT_TRUE(server.start());

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1694,6 +1694,23 @@ TEST(IntradeBarApiResponses, FxWebSocketBarSubscriptionsAreRefCountedBySymbol) {
         [&unsubscribe_result](market_data::MarketDataSubscriptionResult result) {
             unsubscribe_result = std::move(result);
         }));
+    EXPECT_TRUE(unsubscribe_result);
+
+    market_data::MarketDataSubscriptionResult reopen_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "EUR/USD",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&reopen_result](market_data::MarketDataSubscriptionResult result) {
+            reopen_result = std::move(result);
+        }));
+    ASSERT_TRUE(reopen_result);
+
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            return server.subscription_count.load() >= 2;
+        }));
 
     platform.shutdown();
 }


### PR DESCRIPTION
## What Changed
- Added provider-level live bar subscriptions for Intrade Bar by aggregating subscribed tick streams into OHLCV bars.
- Tracks one runtime accumulator per bar subscription and emits in-progress updates plus finalized bars when the timeframe bucket advances.
- Keeps OHLC stable when ticks arrive out of order: previous-bucket ticks are ignored, and same-bucket late ticks can update open/high/low without overwriting close from the latest tick.
- Lets bar subscriptions use the same transport selection as ticks, including FX websocket ref-counting and polling fallback behavior.
- Keeps subscription batch rollback atomic for bar handles and accumulator state, and clears pending bar updates on unsubscribe.
- Documents live-bar snapshot semantics and the current tick-driven finalization contract.
- Updates the market-data smoke CLI docs and maintained market-data example to show live bar subscriptions.

## Notes
- Intrade does not provide provider-native live candle streams here; live bars are built from the selected tick transport.
- Live `INCOMPLETE` bars are mutable snapshots. Consumers should upsert by `(provider_id, subscription_id, symbol, timeframe, time_ms)` until a `FINALIZED` snapshot arrives.
- The latest realtime bar is finalized only when a tick from the next timeframe bucket arrives. Timer/process-based finalization is tracked as a follow-up task.
- The CLI still keeps its local aggregation output visible for manual comparison against provider-level bar batches.

## Validation
- `cmake --build build-codex --target intrade_bar_api_response_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1`
- `./build-codex/market_data_subscription_contract_test.exe --gtest_brief=1`
- `git diff --check`