### PR TITLE
[codex] Mirror Intrade bar stream status

### DIFF
--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -126,6 +126,10 @@ Contract rules:
   separate change.
 - `on_market_data_status()` is a separate stream-status callback. Data callbacks
   should carry data batches, not connection lifecycle sentinel payloads.
+- `on_market_data_status()` is a stream-level event bus, not a per-subscription
+  status API. Status updates are keyed by `provider_id`, payload type, symbol,
+  timeframe and transport; providers are not required to replay cached `READY`
+  status to subscriptions created after the source was already ready.
 - `apply_subscriptions()` applies subscription changes atomically. The old
   single-operation helpers (`subscribe_ticks`, `subscribe_bars`, `unsubscribe`)
   are wrappers around a one-operation batch.

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -91,6 +91,9 @@ Subscription rules:
 - `SUBSCRIBED` confirms desired state and handle ownership. It does not mean
   the physical transport has already reached the source; stream readiness is
   reported separately as `READY` through `on_market_data_status()`.
+- `on_market_data_status()` is a stream-level status event bus, not a
+  per-subscription state snapshot. Late subscribers should not assume they will
+  receive a replayed `READY` event if the underlying source was already ready.
 - Data callbacks receive batches. Shared metadata (`symbol`, `timeframe`,
   digits and subscription handle) lives on the batch; compact payload flags live
   on `Tick` and `Bar`.

--- a/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
+++ b/include/optionx_cpp/market_data/BaseMarketDataProvider.hpp
@@ -77,6 +77,10 @@ namespace optionx::market_data {
         }
 
         /// \brief Returns a reference to the market-data stream status callback.
+        /// \details Status updates describe stream-level lifecycle events keyed by
+        ///          symbol/type/timeframe/transport. They are not per-subscription
+        ///          callbacks and providers are not required to replay cached
+        ///          READY status to late subscribers.
         /// \return Mutable callback reference, or a null callback if status updates are unsupported.
         virtual status_callback_t& on_market_data_status() {
             static status_callback_t null_callback;

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -61,14 +61,15 @@ namespace optionx::platforms {
                   provider_id(),
                   m_tick_data_callback,
                   m_bar_data_callback,
+                  m_market_data_status_callback,
                   &m_fx_price_websocket_manager),
               m_trade_manager(*this, m_request_manager, m_account_info) {
             m_btc_price_manager.set_status_sink(
                 provider_id(),
-                &m_market_data_status_callback);
+                &m_market_data_subscriptions.on_source_status());
             m_fx_price_websocket_manager.set_status_sink(
                 provider_id(),
-                &m_market_data_status_callback);
+                &m_market_data_subscriptions.on_source_status());
         }
 
         /// \brief Shuts down components while platform-owned component instances are still alive.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -13,6 +13,7 @@ namespace optionx::platforms::intrade_bar {
     public:
         using bars_callback_t = market_data::BaseMarketDataProvider::bars_callback_t;
         using ticks_callback_t = market_data::BaseMarketDataProvider::ticks_callback_t;
+        using status_callback_t = market_data::BaseMarketDataProvider::status_callback_t;
         using subscription_callback_t = market_data::BaseMarketDataProvider::subscription_callback_t;
         using subscription_batch_callback_t = market_data::BaseMarketDataProvider::subscription_batch_callback_t;
 
@@ -25,12 +26,18 @@ namespace optionx::platforms::intrade_bar {
                 market_data::ProviderInstanceId provider_id,
                 ticks_callback_t& ticks_callback,
                 bars_callback_t& bars_callback,
+                status_callback_t& status_callback,
                 FxPriceWebSocketManager* fx_websocket_source = nullptr)
                 : BaseComponent(platform.event_bus()),
                   m_provider_id(provider_id),
                   m_ticks_callback(ticks_callback),
                   m_bars_callback(bars_callback),
+                  m_status_callback(status_callback),
                   m_fx_websocket_source(fx_websocket_source) {
+            m_source_status_callback =
+                [this](market_data::MarketDataStatusUpdate update) {
+                    handle_status_update(std::move(update));
+                };
             subscribe<events::PriceUpdateEvent>();
             platform.register_component(this);
         }
@@ -58,6 +65,9 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Stops all active market-data subscriptions.
         bool unsubscribe_all(subscription_batch_callback_t callback);
 
+        /// \brief Returns the status sink used by concrete Intrade Bar tick sources.
+        status_callback_t& on_source_status();
+
         /// \brief Routes price events to active tick subscriptions.
         void on_event(const utils::Event* const event) override;
 
@@ -80,6 +90,8 @@ namespace optionx::platforms::intrade_bar {
         market_data::ProviderInstanceId m_provider_id; ///< Owning provider instance ID.
         ticks_callback_t& m_ticks_callback; ///< Platform tick data callback.
         bars_callback_t&  m_bars_callback;  ///< Platform bar data callback.
+        status_callback_t& m_status_callback; ///< Platform stream status callback.
+        status_callback_t m_source_status_callback; ///< Internal source status callback.
         FxPriceWebSocketManager* m_fx_websocket_source = nullptr; ///< Optional FX websocket source.
         std::unordered_map<
             market_data::SubscriptionId,
@@ -160,6 +172,9 @@ namespace optionx::platforms::intrade_bar {
         /// \brief Removes queued bar data for an inactive subscription.
         /// \pre The caller holds m_mutex.
         void remove_pending_bar_batch_no_lock(market_data::SubscriptionId subscription_id);
+
+        /// \brief Fans source status updates out to public tick and bar streams.
+        void handle_status_update(market_data::MarketDataStatusUpdate update);
 
         /// \brief Extracts the configured price from a tick payload.
         static double price_from_tick(
@@ -496,6 +511,11 @@ namespace optionx::platforms::intrade_bar {
         return apply_subscriptions(std::move(batch), std::move(callback));
     }
 
+    inline MarketDataSubscriptionManager::status_callback_t&
+    MarketDataSubscriptionManager::on_source_status() {
+        return m_source_status_callback;
+    }
+
     inline void MarketDataSubscriptionManager::on_event(const utils::Event* const event) {
         if (const auto* msg = dynamic_cast<const events::PriceUpdateEvent*>(event)) {
             handle_event(*msg);
@@ -767,6 +787,39 @@ namespace optionx::platforms::intrade_bar {
             } else {
                 ++it;
             }
+        }
+    }
+
+    inline void MarketDataSubscriptionManager::handle_status_update(
+            market_data::MarketDataStatusUpdate update) {
+        if (!m_status_callback) return;
+
+        std::vector<market_data::MarketDataStatusUpdate> updates;
+        updates.push_back(update);
+
+        if (update.type == market_data::MarketDataType::TICKS) {
+            const auto normalized_symbol = normalize_symbol_name(update.symbol);
+            std::lock_guard<std::mutex> lock(m_mutex);
+            for (const auto& [id, subscription] : m_bar_subscriptions) {
+                (void)id;
+                if (subscription.symbol != normalized_symbol) continue;
+                if (subscription.transport != update.transport &&
+                    subscription.transport != market_data::MarketDataTransport::AUTO &&
+                    subscription.transport != market_data::MarketDataTransport::HYBRID) {
+                    continue;
+                }
+
+                auto bar_update = update;
+                bar_update.type = market_data::MarketDataType::BARS;
+                bar_update.symbol = subscription.symbol;
+                bar_update.timeframe = subscription.timeframe;
+                bar_update.transport = subscription.transport;
+                updates.push_back(std::move(bar_update));
+            }
+        }
+
+        for (auto& item : updates) {
+            m_status_callback(std::move(item));
         }
     }
 

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1389,26 +1389,60 @@ TEST(IntradeBarApiResponses, BtcWebSocketReportsReadyWhenOpenBeforeFirstPayload)
         }));
     ASSERT_TRUE(subscription_result);
 
+    market_data::MarketDataSubscriptionResult bar_subscription_result;
+    ASSERT_TRUE(platform.subscribe_bars(
+        market_data::BarSubscriptionRequest(
+            "BTCUSDT",
+            60,
+            BarPriceSource::LAST,
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&bar_subscription_result](market_data::MarketDataSubscriptionResult result) {
+            bar_subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(bar_subscription_result);
+
     publish_account_status(platform, AccountUpdateStatus::CONNECTED);
     ASSERT_TRUE(wait_for_platform(
         platform,
         [&]() {
             std::lock_guard<std::mutex> lock(callback_mutex);
-            return std::any_of(
+            const bool tick_ready = std::any_of(
                 status_updates.begin(),
                 status_updates.end(),
                 [](const market_data::MarketDataStatusUpdate& update) {
                     return update.symbol == "BTCUSDT" &&
+                           update.type == market_data::MarketDataType::TICKS &&
                            update.status == market_data::MarketDataStreamStatus::READY;
                 });
+            const bool bar_ready = std::any_of(
+                status_updates.begin(),
+                status_updates.end(),
+                [](const market_data::MarketDataStatusUpdate& update) {
+                    return update.symbol == "BTCUSDT" &&
+                           update.type == market_data::MarketDataType::BARS &&
+                           update.timeframe == 60 &&
+                           update.status == market_data::MarketDataStreamStatus::READY;
+                });
+            return tick_ready && bar_ready;
         }));
 
     {
         std::lock_guard<std::mutex> lock(callback_mutex);
         EXPECT_EQ(tick_callback_count, 0);
-        ASSERT_GE(status_updates.size(), 2u);
-        EXPECT_EQ(status_updates[0].status, market_data::MarketDataStreamStatus::CONNECTED);
-        EXPECT_EQ(status_updates[1].status, market_data::MarketDataStreamStatus::READY);
+        EXPECT_TRUE(std::any_of(
+            status_updates.begin(),
+            status_updates.end(),
+            [](const market_data::MarketDataStatusUpdate& update) {
+                return update.type == market_data::MarketDataType::TICKS &&
+                       update.status == market_data::MarketDataStreamStatus::CONNECTED;
+            }));
+        EXPECT_TRUE(std::any_of(
+            status_updates.begin(),
+            status_updates.end(),
+            [](const market_data::MarketDataStatusUpdate& update) {
+                return update.type == market_data::MarketDataType::BARS &&
+                       update.status == market_data::MarketDataStreamStatus::CONNECTED;
+            }));
     }
 
     platform.shutdown();


### PR DESCRIPTION
## What Changed
- Routes BTC/FX websocket source status updates through `MarketDataSubscriptionManager` instead of wiring source managers directly to the platform callback.
- Preserves existing public tick stream status updates.
- Mirrors matching tick-source status updates to active live bar subscriptions, including timeframe and selected transport metadata.
- Documents `on_market_data_status()` as a stream-level status event bus, not a per-subscription state snapshot/replay API.
- Adds a regression check that a BTCUSDT bar subscription receives `BARS READY` when the underlying BTC websocket is ready, even before the first tick payload.

## Why
Live bars are built from tick streams. A consumer subscribed only to bars still needs lifecycle/status visibility for that derived stream instead of seeing only raw `TICKS` source status.

## Notes
- Status events describe stream keys: provider, payload type, symbol, timeframe, and transport.
- The provider does not replay cached `READY` to subscriptions created after the underlying source was already ready. A higher-level router/hub can add per-subscriber replay later.

## Validation
- `cmake --build build-codex --target intrade_bar_api_response_test market_data_subscription_contract_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_brief=1`
- `./build-codex/market_data_subscription_contract_test.exe --gtest_brief=1`
- `git diff --check`