### PR TITLE
[codex] Start Intrade websocket quotes from subscriptions

### DIFF
--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -148,6 +148,11 @@ Contract rules:
   even when no public subscription exists, because trading logic can also need
   current prices. Public subscriptions are the routing contract for external
   consumers, not necessarily the only source lifecycle.
+- Public market-data subscriptions are independent from the trading account
+  connection state. An account `DISCONNECTED` status must not tear down active
+  quote streams that were started by public subscriptions, while an explicit
+  platform disconnect or shutdown is still a full stop and should close
+  physical streams.
 - Historical bars use `BarHistoryResult` so callers can distinguish an empty
   successful range from transport, validation or parser failures.
 - `MarketDataContinuityService` is the thin helper for routing recovered history

--- a/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform.hpp
@@ -62,6 +62,7 @@ namespace optionx::platforms {
                   m_tick_data_callback,
                   m_bar_data_callback,
                   m_market_data_status_callback,
+                  &m_btc_price_manager,
                   &m_fx_price_websocket_manager),
               m_trade_manager(*this, m_request_manager, m_account_info) {
             m_btc_price_manager.set_status_sink(

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -33,6 +33,12 @@ namespace optionx::platforms::intrade_bar {
             m_tick_data[0].volume_digits = 5;
             m_tick_data[0].symbol = "BTCUSDT";
             m_tick_data[0].provider = to_str(PlatformType::INTRADE_BAR);
+            m_websocket_client.set_url("wss://intrade.bar", "/bapi");
+            m_websocket_client.set_user_agent(OPTIONX_DEFAULT_BROWSER_USER_AGENT);
+            m_websocket_client.set_accept_language(OPTIONX_DEFAULT_ACCEPT_LANGUAGE);
+            m_websocket_client.set_accept_encoding(true, true, true, true);
+            m_websocket_client.set_reconnect(true);
+            m_websocket_client.set_request_timeout(20);
 
             m_websocket_client.on_event([this](std::unique_ptr<kurlyk::WebSocketEventData> event) {
                 if (!event) return;
@@ -95,10 +101,20 @@ namespace optionx::platforms::intrade_bar {
                 market_data::ProviderInstanceId provider_id,
                 market_data::BaseMarketDataProvider::status_callback_t* callback);
 
+        /// \brief Adds one public market-data subscription reference.
+        /// \return True when the BTC websocket source was accepted.
+        bool add_market_data_subscription();
+
+        /// \brief Removes one public market-data subscription reference.
+        void remove_market_data_subscription();
+
     private:
         kurlyk::WebSocketClient m_websocket_client; ///< WebSocket client for BTCUSDT.
         std::vector<SingleTick>   m_tick_data;        ///< Container for tick data.
         bool                    m_is_error = false; ///< Flag indicating if an error has occurred.
+        std::mutex m_source_mutex; ///< Protects subscription-driven source state.
+        std::size_t m_market_data_ref_count = 0; ///< Public market-data subscriptions using BTC ticks.
+        bool m_platform_connected = false; ///< Whether trading lifecycle wants the BTC stream connected.
         std::mutex m_status_mutex; ///< Protects status sink metadata.
         market_data::ProviderInstanceId m_provider_id =
             market_data::kInvalidProviderInstanceId; ///< Optional status provider ID.
@@ -112,6 +128,15 @@ namespace optionx::platforms::intrade_bar {
         void emit_status(
                 market_data::MarketDataStreamStatus status,
                 std::string message = {});
+
+        /// \brief Returns true when any lifecycle path wants the websocket connected.
+        bool should_connect_no_lock() const noexcept;
+
+        /// \brief Reconnects the websocket if any lifecycle path is active.
+        void reconnect_if_active();
+
+        /// \brief Disconnects the websocket when no lifecycle path is active.
+        void disconnect_if_idle();
 
         /// \brief Handles an authentication event.
         /// \param event The received authentication data event.
@@ -140,6 +165,25 @@ namespace optionx::platforms::intrade_bar {
         std::lock_guard<std::mutex> lock(m_status_mutex);
         m_provider_id = provider_id;
         m_status_callback = callback;
+    }
+
+    inline bool BtcPriceManager::add_market_data_subscription() {
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            ++m_market_data_ref_count;
+        }
+        m_websocket_client.connect();
+        return true;
+    }
+
+    inline void BtcPriceManager::remove_market_data_subscription() {
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            if (m_market_data_ref_count > 0) {
+                --m_market_data_ref_count;
+            }
+        }
+        disconnect_if_idle();
     }
 
     inline void BtcPriceManager::on_event(const utils::Event* const event) {
@@ -179,16 +223,25 @@ namespace optionx::platforms::intrade_bar {
             m_websocket_client.set_proxy_server(auth_data->proxy_server);
             m_websocket_client.set_proxy_auth(auth_data->proxy_auth);
             m_websocket_client.set_proxy_type(auth_data->proxy_type);
+            reconnect_if_active();
         }
     }
 
     inline void BtcPriceManager::handle_event(const events::ConnectRequestEvent& event) {
         LOGIT_0TRACE();
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            m_platform_connected = false;
+        }
         m_websocket_client.disconnect();
     }
 
     inline void BtcPriceManager::handle_event(const events::DisconnectRequestEvent& event) {
         LOGIT_0TRACE();
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            m_platform_connected = false;
+        }
         m_websocket_client.disconnect();
     }
 
@@ -196,11 +249,19 @@ namespace optionx::platforms::intrade_bar {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             LOGIT_0TRACE();
+            {
+                std::lock_guard<std::mutex> lock(m_source_mutex);
+                m_platform_connected = true;
+            }
             m_websocket_client.connect();
         } else
         if (event.status == Status::DISCONNECTED) {
             LOGIT_0TRACE();
-            m_websocket_client.disconnect();
+            {
+                std::lock_guard<std::mutex> lock(m_source_mutex);
+                m_platform_connected = false;
+            }
+            disconnect_if_idle();
         }
     }
     
@@ -208,6 +269,7 @@ namespace optionx::platforms::intrade_bar {
         LOGIT_0TRACE();
         if (event.success && !event.selected_host.empty()) {
             m_websocket_client.set_url(make_websocket_host(event.selected_host), "/bapi");
+            reconnect_if_active();
         }
     }
 
@@ -253,8 +315,40 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline void BtcPriceManager::shutdown() {
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            m_market_data_ref_count = 0;
+            m_platform_connected = false;
+        }
         m_websocket_client.disconnect_and_wait();
         m_tick_data[0].tick.flags = 0;
+    }
+
+    inline bool BtcPriceManager::should_connect_no_lock() const noexcept {
+        return m_platform_connected || m_market_data_ref_count > 0;
+    }
+
+    inline void BtcPriceManager::reconnect_if_active() {
+        bool should_connect = false;
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            should_connect = should_connect_no_lock();
+        }
+        if (!should_connect) return;
+
+        m_websocket_client.disconnect();
+        m_websocket_client.connect();
+    }
+
+    inline void BtcPriceManager::disconnect_if_idle() {
+        bool should_disconnect = false;
+        {
+            std::lock_guard<std::mutex> lock(m_source_mutex);
+            should_disconnect = !should_connect_no_lock();
+        }
+        if (should_disconnect) {
+            m_websocket_client.disconnect();
+        }
     }
 
 } // namespace optionx::platforms::intrade_bar

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -33,7 +33,7 @@ namespace optionx::platforms::intrade_bar {
             m_tick_data[0].volume_digits = 5;
             m_tick_data[0].symbol = "BTCUSDT";
             m_tick_data[0].provider = to_str(PlatformType::INTRADE_BAR);
-            m_websocket_client.set_url("wss://intrade.bar", "/bapi");
+            m_websocket_client.set_url(m_ws_host, "/bapi");
             m_websocket_client.set_user_agent(OPTIONX_DEFAULT_BROWSER_USER_AGENT);
             m_websocket_client.set_accept_language(OPTIONX_DEFAULT_ACCEPT_LANGUAGE);
             m_websocket_client.set_accept_encoding(true, true, true, true);
@@ -110,6 +110,7 @@ namespace optionx::platforms::intrade_bar {
 
     private:
         kurlyk::WebSocketClient m_websocket_client; ///< WebSocket client for BTCUSDT.
+        std::string m_ws_host = make_websocket_host(AuthData{}.host); ///< Websocket host.
         std::vector<SingleTick>   m_tick_data;        ///< Container for tick data.
         bool                    m_is_error = false; ///< Flag indicating if an error has occurred.
         std::mutex m_source_mutex; ///< Protects subscription-driven source state.
@@ -168,11 +169,16 @@ namespace optionx::platforms::intrade_bar {
     }
 
     inline bool BtcPriceManager::add_market_data_subscription() {
+        bool should_connect = false;
         {
             std::lock_guard<std::mutex> lock(m_source_mutex);
+            should_connect = m_market_data_ref_count == 0 ||
+                             !m_websocket_client.is_connected();
             ++m_market_data_ref_count;
         }
-        m_websocket_client.connect();
+        if (should_connect) {
+            m_websocket_client.connect();
+        }
         return true;
     }
 
@@ -212,7 +218,8 @@ namespace optionx::platforms::intrade_bar {
             if (!success) return;
             
             if (!auth_data->auto_find_domain && !auth_data->host.empty()) {
-                m_websocket_client.set_url(make_websocket_host(auth_data->host), "/bapi");
+                m_ws_host = make_websocket_host(auth_data->host);
+                m_websocket_client.set_url(m_ws_host, "/bapi");
             }
 
             m_websocket_client.set_user_agent(auth_data->user_agent);
@@ -253,7 +260,9 @@ namespace optionx::platforms::intrade_bar {
                 std::lock_guard<std::mutex> lock(m_source_mutex);
                 m_platform_connected = true;
             }
-            m_websocket_client.connect();
+            if (!m_websocket_client.is_connected()) {
+                m_websocket_client.connect();
+            }
         } else
         if (event.status == Status::DISCONNECTED) {
             LOGIT_0TRACE();
@@ -268,7 +277,8 @@ namespace optionx::platforms::intrade_bar {
     inline void BtcPriceManager::handle_event(const events::AutoDomainSelectedEvent& event) {
         LOGIT_0TRACE();
         if (event.success && !event.selected_host.empty()) {
-            m_websocket_client.set_url(make_websocket_host(event.selected_host), "/bapi");
+            m_ws_host = make_websocket_host(event.selected_host);
+            m_websocket_client.set_url(m_ws_host, "/bapi");
             reconnect_if_active();
         }
     }

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/BtcPriceManager.hpp
@@ -172,8 +172,7 @@ namespace optionx::platforms::intrade_bar {
         bool should_connect = false;
         {
             std::lock_guard<std::mutex> lock(m_source_mutex);
-            should_connect = m_market_data_ref_count == 0 ||
-                             !m_websocket_client.is_connected();
+            should_connect = !should_connect_no_lock();
             ++m_market_data_ref_count;
         }
         if (should_connect) {
@@ -256,11 +255,13 @@ namespace optionx::platforms::intrade_bar {
         using Status = events::AccountInfoUpdateEvent::Status;
         if (event.status == Status::CONNECTED) {
             LOGIT_0TRACE();
+            bool should_connect = false;
             {
                 std::lock_guard<std::mutex> lock(m_source_mutex);
+                should_connect = m_market_data_ref_count == 0;
                 m_platform_connected = true;
             }
-            if (!m_websocket_client.is_connected()) {
+            if (should_connect && !m_websocket_client.is_connected()) {
                 m_websocket_client.connect();
             }
         } else

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
@@ -144,10 +144,11 @@ namespace optionx::platforms::intrade_bar {
                 stream = create_stream_no_lock(normalized, stream_symbol);
                 stream->ref_count = 1;
                 m_streams.emplace(normalized, stream);
-                should_connect = m_platform_connected;
+                should_connect = true;
             } else {
                 stream = it->second;
                 ++stream->ref_count;
+                should_connect = !stream->client->is_connected();
             }
         }
 
@@ -286,7 +287,7 @@ namespace optionx::platforms::intrade_bar {
         bool should_connect = false;
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            should_connect = m_platform_connected;
+            should_connect = m_platform_connected || !m_streams.empty();
             for (auto& [symbol, stream] : m_streams) {
                 (void)symbol;
                 configure_client_no_lock(*stream->client);

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/FxPriceWebSocketManager.hpp
@@ -64,7 +64,7 @@ namespace optionx::platforms::intrade_bar {
             bool is_error = false;     ///< Suppresses repeated error logging.
         };
 
-        std::string m_ws_host = "wss://intrade.bar"; ///< Websocket host.
+        std::string m_ws_host = make_websocket_host(AuthData{}.host); ///< Websocket host.
         std::string m_user_agent = OPTIONX_DEFAULT_BROWSER_USER_AGENT; ///< User-Agent header.
         std::string m_accept_language = OPTIONX_DEFAULT_ACCEPT_LANGUAGE; ///< Accept-Language header.
         std::string m_proxy_server; ///< Proxy address in <ip:port> format.
@@ -75,7 +75,7 @@ namespace optionx::platforms::intrade_bar {
         market_data::ProviderInstanceId m_provider_id =
             market_data::kInvalidProviderInstanceId; ///< Optional status provider ID.
         market_data::BaseMarketDataProvider::status_callback_t* m_status_callback = nullptr; ///< Optional status sink.
-        bool m_platform_connected = false; ///< Whether physical sockets may be connected.
+        bool m_platform_connected = false; ///< Whether the trading account lifecycle is connected.
 
         /// \brief Configures a websocket client from current manager settings.
         void configure_client_no_lock(kurlyk::WebSocketClient& client) const;
@@ -93,6 +93,9 @@ namespace optionx::platforms::intrade_bar {
 
         /// \brief Reconnects all active streams after a host/proxy/header change.
         void reconnect_all_streams();
+
+        /// \brief Connects active streams that are not currently connected.
+        void connect_all_streams();
 
         /// \brief Disconnects all active streams without changing subscription refcounts.
         void disconnect_all_streams();
@@ -301,6 +304,22 @@ namespace optionx::platforms::intrade_bar {
         }
     }
 
+    inline void FxPriceWebSocketManager::connect_all_streams() {
+        std::vector<std::shared_ptr<FxStreamState>> streams;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            streams.reserve(m_streams.size());
+            for (auto& [symbol, stream] : m_streams) {
+                (void)symbol;
+                streams.push_back(stream);
+            }
+        }
+
+        for (auto& stream : streams) {
+            connect_stream(stream);
+        }
+    }
+
     inline void FxPriceWebSocketManager::handle_websocket_event(
             const std::shared_ptr<FxStreamState>& stream,
             const kurlyk::WebSocketEventData& event) {
@@ -448,13 +467,12 @@ namespace optionx::platforms::intrade_bar {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_platform_connected = true;
             }
-            reconnect_all_streams();
+            connect_all_streams();
         } else if (event.status == Status::DISCONNECTED) {
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 m_platform_connected = false;
             }
-            disconnect_all_streams();
         }
     }
 

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -27,12 +27,14 @@ namespace optionx::platforms::intrade_bar {
                 ticks_callback_t& ticks_callback,
                 bars_callback_t& bars_callback,
                 status_callback_t& status_callback,
+                BtcPriceManager* btc_websocket_source = nullptr,
                 FxPriceWebSocketManager* fx_websocket_source = nullptr)
                 : BaseComponent(platform.event_bus()),
                   m_provider_id(provider_id),
                   m_ticks_callback(ticks_callback),
                   m_bars_callback(bars_callback),
                   m_status_callback(status_callback),
+                  m_btc_websocket_source(btc_websocket_source),
                   m_fx_websocket_source(fx_websocket_source) {
             m_source_status_callback =
                 [this](market_data::MarketDataStatusUpdate update) {
@@ -92,6 +94,7 @@ namespace optionx::platforms::intrade_bar {
         bars_callback_t&  m_bars_callback;  ///< Platform bar data callback.
         status_callback_t& m_status_callback; ///< Platform stream status callback.
         status_callback_t m_source_status_callback; ///< Internal source status callback.
+        BtcPriceManager* m_btc_websocket_source = nullptr; ///< Optional BTC websocket source.
         FxPriceWebSocketManager* m_fx_websocket_source = nullptr; ///< Optional FX websocket source.
         std::unordered_map<
             market_data::SubscriptionId,
@@ -123,6 +126,10 @@ namespace optionx::platforms::intrade_bar {
 
         /// \brief Returns true when a subscription should activate the FX websocket source.
         static bool uses_fx_websocket_source(
+                const market_data::MarketDataSubscriptionHandle& subscription);
+
+        /// \brief Returns true when a subscription should activate the BTC websocket source.
+        static bool uses_btc_websocket_source(
                 const market_data::MarketDataSubscriptionHandle& subscription);
 
         /// \brief Selects the concrete Intrade Bar tick source for a tick request.
@@ -432,6 +439,71 @@ namespace optionx::platforms::intrade_bar {
             return false;
         }
 
+        std::vector<market_data::MarketDataSubscriptionHandle> activated_btc_subscriptions;
+        if (m_btc_websocket_source) {
+            for (const auto& subscription : removed_subscriptions) {
+                if (uses_btc_websocket_source(subscription)) {
+                    m_btc_websocket_source->remove_market_data_subscription();
+                }
+            }
+
+            for (std::size_t i = 0; i < added_subscriptions.size(); ++i) {
+                const auto& subscription = added_subscriptions[i];
+                const auto source = i < added_sources.size()
+                    ? added_sources[i]
+                    : TickSource::UNKNOWN;
+                if (source != TickSource::BTC_WEBSOCKET) continue;
+
+                if (!m_btc_websocket_source->add_market_data_subscription()) {
+                    for (const auto& activated : activated_btc_subscriptions) {
+                        (void)activated;
+                        m_btc_websocket_source->remove_market_data_subscription();
+                    }
+                    for (const auto& removed : removed_subscriptions) {
+                        if (uses_btc_websocket_source(removed) &&
+                            !m_btc_websocket_source->add_market_data_subscription()) {
+                            LOGIT_WARN(
+                                "Failed to restore Intrade Bar BTC websocket tick source for ",
+                                removed.symbol,
+                                " after subscription batch rollback.");
+                        }
+                    }
+
+                    {
+                        std::lock_guard<std::mutex> lock(m_mutex);
+                        for (const auto& added : added_subscriptions) {
+                            m_tick_subscriptions.erase(added.id);
+                            m_bar_subscriptions.erase(added.id);
+                            m_bar_states.erase(added.id);
+                        }
+                        for (const auto& removed : removed_subscriptions) {
+                            if (removed.stream_type == market_data::MarketDataType::BARS) {
+                                m_bar_subscriptions[removed.id] = removed;
+                            } else {
+                                m_tick_subscriptions[removed.id] = removed;
+                            }
+                        }
+                        for (const auto& [id, state] : removed_bar_states) {
+                            m_bar_states[id] = state;
+                        }
+                        m_next_subscription_id = previous_next_subscription_id;
+                    }
+
+                    dispatch_subscription_batch_result(
+                        std::move(callback),
+                        market_data::MarketDataSubscriptionBatchResult::failed(
+                            market_data::MarketDataSubscriptionStatus::FAILED,
+                            "Failed to activate Intrade Bar BTC websocket tick source.",
+                            {market_data::MarketDataSubscriptionResult::failed(
+                                subscription,
+                                market_data::MarketDataSubscriptionStatus::FAILED,
+                                "Failed to activate Intrade Bar BTC websocket tick source.")}));
+                    return false;
+                }
+                activated_btc_subscriptions.push_back(subscription);
+            }
+        }
+
         if (m_fx_websocket_source) {
             for (const auto& subscription : removed_subscriptions) {
                 if (uses_fx_websocket_source(subscription)) {
@@ -450,6 +522,21 @@ namespace optionx::platforms::intrade_bar {
                 if (!m_fx_websocket_source->add_symbol_subscription(subscription.symbol)) {
                     for (const auto& activated : activated_fx_subscriptions) {
                         m_fx_websocket_source->remove_symbol_subscription(activated.symbol);
+                    }
+                    if (m_btc_websocket_source) {
+                        for (const auto& activated : activated_btc_subscriptions) {
+                            (void)activated;
+                            m_btc_websocket_source->remove_market_data_subscription();
+                        }
+                        for (const auto& removed : removed_subscriptions) {
+                            if (uses_btc_websocket_source(removed) &&
+                                !m_btc_websocket_source->add_market_data_subscription()) {
+                                LOGIT_WARN(
+                                    "Failed to restore Intrade Bar BTC websocket tick source for ",
+                                    removed.symbol,
+                                    " after subscription batch rollback.");
+                            }
+                        }
                     }
                     for (const auto& removed : removed_subscriptions) {
                         if (uses_fx_websocket_source(removed) &&
@@ -572,6 +659,13 @@ namespace optionx::platforms::intrade_bar {
                 }
             }
         }
+        if (m_btc_websocket_source) {
+            for (const auto& subscription : subscriptions) {
+                if (uses_btc_websocket_source(subscription)) {
+                    m_btc_websocket_source->remove_market_data_subscription();
+                }
+            }
+        }
 
         std::lock_guard<std::mutex> lock(m_mutex);
         m_tick_subscriptions.clear();
@@ -602,6 +696,16 @@ namespace optionx::platforms::intrade_bar {
         }
         return subscription.transport == market_data::MarketDataTransport::WEBSOCKET &&
                is_fxconnect_supported_symbol(subscription.symbol);
+    }
+
+    inline bool MarketDataSubscriptionManager::uses_btc_websocket_source(
+            const market_data::MarketDataSubscriptionHandle& subscription) {
+        if (subscription.stream_type != market_data::MarketDataType::TICKS &&
+            subscription.stream_type != market_data::MarketDataType::BARS) {
+            return false;
+        }
+        return subscription.transport == market_data::MarketDataTransport::WEBSOCKET &&
+               is_btc_symbol(subscription.symbol);
     }
 
     inline MarketDataSubscriptionManager::TickSource

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1867,7 +1867,7 @@ TEST(IntradeBarApiResponses, FxWebSocketBarSubscriptionsAreRefCountedBySymbol) {
     platform.shutdown();
 }
 
-TEST(IntradeBarApiResponses, FxWebSocketReconnectsDesiredSubscriptions) {
+TEST(IntradeBarApiResponses, FxWebSocketSubscriptionSurvivesAccountDisconnect) {
     LocalFxConnectServer server;
     ASSERT_TRUE(server.start());
 
@@ -1894,17 +1894,30 @@ TEST(IntradeBarApiResponses, FxWebSocketReconnectsDesiredSubscriptions) {
         [&]() {
             return server.subscription_count.load() >= 1;
         }));
+    const auto subscriptions_after_connect = server.subscription_count.load();
+    EXPECT_EQ(subscriptions_after_connect, 1);
 
     publish_account_status(platform, AccountUpdateStatus::DISCONNECTED);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     platform.event_bus().drain();
 
-    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
-    EXPECT_TRUE(wait_for_platform(
-        platform,
-        [&]() {
-            return server.subscription_count.load() >= 2;
+    market_data::MarketDataSubscriptionResult second_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "EURUSD",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&second_result](market_data::MarketDataSubscriptionResult result) {
+            second_result = std::move(result);
         }));
+    ASSERT_TRUE(second_result);
+
+    pump_platform(platform);
+    EXPECT_EQ(server.subscription_count.load(), subscriptions_after_connect);
+
+    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    platform.event_bus().drain();
+    EXPECT_EQ(server.subscription_count.load(), subscriptions_after_connect);
 
     platform.shutdown();
 }

--- a/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
+++ b/tests/intrade_bar_api/intrade_bar_api_response_test.cpp
@@ -1448,6 +1448,71 @@ TEST(IntradeBarApiResponses, BtcWebSocketReportsReadyWhenOpenBeforeFirstPayload)
     platform.shutdown();
 }
 
+TEST(IntradeBarApiResponses, BtcWebSocketSubscriptionRunsWithoutAccountConnection) {
+    LocalFxConnectServer server;
+    ASSERT_TRUE(server.start());
+
+    IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::TickDataBatch delivered_batch;
+    std::vector<market_data::MarketDataStatusUpdate> status_updates;
+    std::mutex callback_mutex;
+
+    platform.on_market_data_status() =
+        [&status_updates, &callback_mutex](market_data::MarketDataStatusUpdate update) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            status_updates.push_back(std::move(update));
+        };
+    platform.on_tick_data() =
+        [&delivered_batch, &callback_mutex](std::unique_ptr<market_data::TickDataBatch> batch) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+        };
+
+    auto auth = std::make_unique<AuthData>();
+    auth->set_email_password("user@example.test", "unused");
+    auth->host = server.host();
+    ASSERT_TRUE(platform.configure_auth(std::move(auth)));
+    platform.event_bus().drain();
+
+    market_data::MarketDataSubscriptionResult subscription_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "BTCUSDT",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(subscription_result);
+
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            const bool ready = std::any_of(
+                status_updates.begin(),
+                status_updates.end(),
+                [](const market_data::MarketDataStatusUpdate& update) {
+                    return update.symbol == "BTCUSDT" &&
+                           update.type == market_data::MarketDataType::TICKS &&
+                           update.status == market_data::MarketDataStreamStatus::READY;
+                });
+            return ready && !delivered_batch.items.empty();
+        }));
+
+    EXPECT_GE(server.bapi_connection_count.load(), 1);
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex);
+        EXPECT_EQ(delivered_batch.symbol, "BTCUSDT");
+        ASSERT_EQ(delivered_batch.items.size(), 1u);
+        EXPECT_DOUBLE_EQ(delivered_batch.items[0].last, 61521.34);
+    }
+
+    platform.shutdown();
+}
+
 TEST(IntradeBarApiResponses, FxWebSocketSubscriptionReceivesLocalTick) {
     LocalFxConnectServer server;
     ASSERT_TRUE(server.start());
@@ -1508,6 +1573,59 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionReceivesLocalTick) {
             unsubscribe_result = std::move(result);
         }));
     EXPECT_TRUE(unsubscribe_result);
+
+    platform.shutdown();
+}
+
+TEST(IntradeBarApiResponses, FxWebSocketSubscriptionRunsWithoutAccountConnection) {
+    LocalFxConnectServer server;
+    ASSERT_TRUE(server.start());
+
+    IntradeBarPlatform platform;
+    platform.run(false);
+    market_data::TickDataBatch delivered_batch;
+    std::mutex callback_mutex;
+
+    platform.on_tick_data() =
+        [&delivered_batch, &callback_mutex](std::unique_ptr<market_data::TickDataBatch> batch) {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            if (batch) {
+                delivered_batch = std::move(*batch);
+            }
+        };
+
+    auto auth = std::make_unique<AuthData>();
+    auth->set_email_password("user@example.test", "unused");
+    auth->host = server.host();
+    ASSERT_TRUE(platform.configure_auth(std::move(auth)));
+    platform.event_bus().drain();
+
+    market_data::MarketDataSubscriptionResult subscription_result;
+    ASSERT_TRUE(platform.subscribe_ticks(
+        market_data::TickSubscriptionRequest(
+            "EUR/USD",
+            market_data::MarketDataTransport::WEBSOCKET),
+        [&subscription_result](market_data::MarketDataSubscriptionResult result) {
+            subscription_result = std::move(result);
+        }));
+    ASSERT_TRUE(subscription_result);
+
+    ASSERT_TRUE(wait_for_platform(
+        platform,
+        [&]() {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            return !delivered_batch.items.empty();
+        }));
+
+    EXPECT_GE(server.subscription_count.load(), 1);
+    EXPECT_EQ(server.subscribed_symbol(), "EUR/USD");
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex);
+        EXPECT_EQ(delivered_batch.symbol, "EURUSD");
+        ASSERT_EQ(delivered_batch.items.size(), 1u);
+        EXPECT_DOUBLE_EQ(delivered_batch.items[0].bid, 1.10001);
+        EXPECT_DOUBLE_EQ(delivered_batch.items[0].ask, 1.10002);
+    }
 
     platform.shutdown();
 }
@@ -1585,6 +1703,7 @@ TEST(IntradeBarApiResponses, PollingSubscriptionDoesNotOpenFxWebSocket) {
     ASSERT_TRUE(server.start());
 
     IntradeBarPlatform platform;
+    platform.run(false);
     auto auth = std::make_unique<AuthData>();
     auth->set_email_password("user@example.test", "unused");
     auth->host = server.host();
@@ -1640,14 +1759,14 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionsAreRefCountedBySymbol) {
     ASSERT_TRUE(first_result);
     ASSERT_TRUE(second_result);
 
-    publish_account_status(platform, AccountUpdateStatus::CONNECTED);
     ASSERT_TRUE(wait_for_platform(
         platform,
         [&]() {
             return server.subscription_count.load() >= 1;
         }));
 
-    EXPECT_EQ(server.subscription_count.load(), 1);
+    const auto subscriptions_after_subscribe = server.subscription_count.load();
+    EXPECT_EQ(subscriptions_after_subscribe, 1);
 
     market_data::MarketDataSubscriptionResult unsubscribe_result;
     EXPECT_TRUE(platform.unsubscribe(
@@ -1657,9 +1776,8 @@ TEST(IntradeBarApiResponses, FxWebSocketSubscriptionsAreRefCountedBySymbol) {
         }));
     EXPECT_TRUE(unsubscribe_result);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(150));
-    platform.event_bus().drain();
-    EXPECT_EQ(server.subscription_count.load(), 1);
+    pump_platform(platform);
+    EXPECT_EQ(server.subscription_count.load(), subscriptions_after_subscribe);
 
     EXPECT_TRUE(platform.unsubscribe(
         second_result.subscription,


### PR DESCRIPTION
﻿## What Changed
- Made Intrade BTC and FX websocket market-data sources subscription-driven, so live websocket quotes can start without waiting for account `CONNECTED`.
- Added a BTC websocket subscription refcount and default `/bapi` host/header setup.
- Let FX `/fxconnect` streams connect as soon as a public websocket subscription is added, while preserving reconnect behavior when auth host/proxy settings change.
- Wired BTC websocket source activation through `MarketDataSubscriptionManager`, including rollback and shutdown cleanup.
- Added local websocket-server regression tests for BTCUSDT and EUR/USD websocket tick subscriptions without publishing an account-connected event.

## Why
Market-data-only use should not require the full trading authentication/connect lifecycle when the broker quote endpoints are public. The public subscription API now activates websocket quote sources directly after configuration.

## Validation
- `cmake --build build-codex --target intrade_bar_api_response_test -j 4`
- `./build-codex/intrade_bar_api_response_test.exe --gtest_filter=IntradeBarApiResponses.BtcWebSocketSubscriptionRunsWithoutAccountConnection:IntradeBarApiResponses.FxWebSocketSubscriptionRunsWithoutAccountConnection:IntradeBarApiResponses.BtcWebSocketSubscriptionReportsStatusAndRoutesTick:IntradeBarApiResponses.FxWebSocketSubscriptionReceivesLocalTick`
- `./build-codex/intrade_bar_api_response_test.exe`

## Notes
- This PR is stacked on #62.
- Polling price snapshots still follow the existing connected account lifecycle; this PR only changes websocket quote sources.
