### PR TITLE
[codex] Add market data subscriber hub

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Run market_data_subscription_contract_test
         run: ./build-linux/market_data_subscription_contract_test --gtest_brief=1
 
+      - name: Build market_data_hub_test
+        run: cmake --build build-linux --target market_data_hub_test -j
+
+      - name: Run market_data_hub_test
+        run: ./build-linux/market_data_hub_test --gtest_brief=1
+
       - name: Build trade_manager_test
         run: cmake --build build-linux --target trade_manager_test -j
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,41 @@ if(OPTIONX_BUILD_EXAMPLES)
         )
     endif()
 
+    add_executable(market_data_hub_example examples/market_data_hub_example.cpp)
+
+    target_include_directories(market_data_hub_example PRIVATE
+        ${EXAMPLE_INCLUDE_DIRS}
+        ${EXAMPLE_DEPS_INCLUDE_DIRS}
+    )
+
+    target_link_directories(market_data_hub_example PRIVATE ${EXAMPLE_LIBRARY_DIRS})
+    target_compile_definitions(
+        market_data_hub_example PRIVATE
+        ${EXAMPLE_DEFINES}
+        LOGIT_BASE_PATH="${LOGIT_BASE_PATH_FWD}"
+    )
+    target_link_libraries(market_data_hub_example PRIVATE ${EXAMPLE_LIBS} optionx_cpp)
+
+    if(OPTIONX_BUILD_DEPS)
+        add_dependencies(market_data_hub_example mdbx-static AES)
+    endif()
+
+    foreach(dll ${EXAMPLE_DLL_FILES})
+        add_custom_command(TARGET market_data_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${dll}" "$<TARGET_FILE_DIR:market_data_hub_example>"
+        )
+    endforeach()
+
+    if(WIN32)
+        add_custom_command(TARGET market_data_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND}
+                -DOPTIONX_RUNTIME_DLL_DIR="${EXAMPLE_BUILD_LIBS_DIR}/bin"
+                -DOPTIONX_RUNTIME_TARGET_DIR="$<TARGET_FILE_DIR:market_data_hub_example>"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_runtime_dlls.cmake"
+        )
+    endif()
+
     add_executable(intrade_market_data_example examples/intrade_market_data_example.cpp)
 
     target_include_directories(intrade_market_data_example PRIVATE

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,8 @@ Currently maintained examples:
   subscriptions, stream status callbacks, direct bar history, and history routed
   through `MarketDataContinuityService`. Live authenticated lifecycle reads
   `OPTIONX_INTRADE_EMAIL` and `OPTIONX_INTRADE_PASSWORD` from the environment.
+- `market_data_hub_example.cpp` demonstrates routing provider callbacks through
+  `MarketDataHub` into an `IMarketDataSubscriber` implementation.
 - `trade_record_db_example.cpp` demonstrates basic `TradeRecordDB` usage.
 
 Old exploratory broker and component probes were removed because they referenced

--- a/examples/market_data_hub_example.cpp
+++ b/examples/market_data_hub_example.cpp
@@ -71,17 +71,28 @@ public:
                   << " "
                   << optionx::market_data::to_str(update.type)
                   << " -> "
-                  << optionx::market_data::to_str(update.status)
-                  << '\n';
+                  << optionx::market_data::to_str(update.status);
+        if (update.subscription.valid()) {
+            std::cout << " subscription_id=" << update.subscription.id;
+        }
+        std::cout << '\n';
     }
 };
 
 optionx::market_data::MarketDataStatusUpdate make_ready_status() {
+    const optionx::market_data::TickSubscriptionRequest request(
+        "BTCUSDT",
+        optionx::market_data::MarketDataTransport::WEBSOCKET);
+
     optionx::market_data::MarketDataStatusUpdate update;
     update.provider_id = 1;
+    update.subscription = optionx::market_data::MarketDataSubscriptionHandle::from_tick_request(
+        update.provider_id,
+        42,
+        request);
     update.type = optionx::market_data::MarketDataType::TICKS;
-    update.symbol = "BTCUSDT";
-    update.transport = optionx::market_data::MarketDataTransport::WEBSOCKET;
+    update.symbol = request.symbol;
+    update.transport = request.transport;
     update.status = optionx::market_data::MarketDataStreamStatus::READY;
     return update;
 }

--- a/examples/market_data_hub_example.cpp
+++ b/examples/market_data_hub_example.cpp
@@ -1,0 +1,154 @@
+#include <optionx_cpp/market_data.hpp>
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+namespace {
+
+class DemoMarketDataProvider final : public optionx::market_data::BaseMarketDataProvider {
+public:
+    bars_callback_t& on_bar_data() override {
+        return m_bars_callback;
+    }
+
+    ticks_callback_t& on_tick_data() override {
+        return m_ticks_callback;
+    }
+
+    status_callback_t& on_market_data_status() override {
+        return m_status_callback;
+    }
+
+    void emit_status(optionx::market_data::MarketDataStatusUpdate update) {
+        if (m_status_callback) {
+            m_status_callback(std::move(update));
+        }
+    }
+
+    void emit_ticks(std::unique_ptr<optionx::market_data::TickDataBatch> batch) {
+        if (m_ticks_callback) {
+            m_ticks_callback(std::move(batch));
+        }
+    }
+
+    void emit_bars(std::unique_ptr<optionx::market_data::BarDataBatch> batch) {
+        if (m_bars_callback) {
+            m_bars_callback(std::move(batch));
+        }
+    }
+
+private:
+    bars_callback_t m_bars_callback;
+    ticks_callback_t m_ticks_callback;
+    status_callback_t m_status_callback;
+};
+
+class ConsoleMarketDataSubscriber final : public optionx::market_data::IMarketDataSubscriber {
+public:
+    void on_tick_data(const optionx::market_data::TickDataBatch& batch) override {
+        std::cout << "[ticks] "
+                  << batch.symbol
+                  << " items=" << batch.items.size();
+        if (!batch.items.empty()) {
+            std::cout << " last=" << batch.items.back().mid_price(batch.price_digits);
+        }
+        std::cout << '\n';
+    }
+
+    void on_bar_data(const optionx::market_data::BarDataBatch& batch) override {
+        std::cout << "[bars] "
+                  << batch.symbol
+                  << " timeframe=" << batch.timeframe
+                  << " items=" << batch.items.size()
+                  << '\n';
+    }
+
+    void on_market_data_status(
+            const optionx::market_data::MarketDataStatusUpdate& update) override {
+        std::cout << "[status] "
+                  << update.symbol
+                  << " "
+                  << optionx::market_data::to_str(update.type)
+                  << " -> "
+                  << optionx::market_data::to_str(update.status)
+                  << '\n';
+    }
+};
+
+optionx::market_data::MarketDataStatusUpdate make_ready_status() {
+    optionx::market_data::MarketDataStatusUpdate update;
+    update.provider_id = 1;
+    update.type = optionx::market_data::MarketDataType::TICKS;
+    update.symbol = "BTCUSDT";
+    update.transport = optionx::market_data::MarketDataTransport::WEBSOCKET;
+    update.status = optionx::market_data::MarketDataStreamStatus::READY;
+    return update;
+}
+
+std::unique_ptr<optionx::market_data::TickDataBatch> make_tick_batch() {
+    auto batch = std::make_unique<optionx::market_data::TickDataBatch>();
+    batch->type = optionx::market_data::MarketDataType::TICKS;
+    batch->symbol = "BTCUSDT";
+    batch->price_digits = 2;
+    batch->items.push_back(optionx::Tick(
+        61521.30,
+        61521.38,
+        61521.34,
+        0.00017,
+        1783028778697ULL,
+        0,
+        0));
+    batch->items.back().set_flag(optionx::MarketDataFlags::REALTIME);
+    return batch;
+}
+
+std::unique_ptr<optionx::market_data::BarDataBatch> make_bar_batch() {
+    auto batch = std::make_unique<optionx::market_data::BarDataBatch>();
+    batch->type = optionx::market_data::MarketDataType::BARS;
+    batch->symbol = "BTCUSDT";
+    batch->timeframe = 60;
+    batch->price_digits = 2;
+    batch->items.push_back(optionx::Bar(
+        61520.00,
+        61522.00,
+        61519.75,
+        61521.34,
+        10.0,
+        1783028760000ULL));
+    batch->items.back().set_flag(optionx::MarketDataFlags::REALTIME);
+    batch->items.back().set_flag(optionx::MarketDataFlags::INCOMPLETE);
+    return batch;
+}
+
+} // namespace
+
+int main() {
+    DemoMarketDataProvider provider;
+    optionx::market_data::MarketDataHub hub;
+
+    // The hub binds provider callbacks and routes them to all live subscribers.
+    // Call unbind_from() before destroying the hub if the provider can outlive it.
+    hub.bind_to(provider);
+
+    // MarketDataHub stores weak references. Keep this shared_ptr alive while
+    // the chart/bot should receive market-data events.
+    auto chart = std::make_shared<ConsoleMarketDataSubscriber>();
+    const auto subscriber_id = hub.add_subscriber(chart);
+    if (subscriber_id == optionx::market_data::MarketDataHub::INVALID_SUBSCRIBER_ID) {
+        std::cerr << "failed to add market-data subscriber\n";
+        return 1;
+    }
+
+    provider.emit_status(make_ready_status());
+    provider.emit_ticks(make_tick_batch());
+    provider.emit_bars(make_bar_batch());
+
+    // Late subscribers receive cached stream status, but not old tick/bar data.
+    auto late_chart = std::make_shared<ConsoleMarketDataSubscriber>();
+    hub.add_subscriber(late_chart);
+
+    hub.remove_subscriber(subscriber_id);
+    hub.unbind_from(provider);
+    return 0;
+}

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -97,7 +97,8 @@ Market-data APIs are split into DTO/data types and a provider role:
   `BaseMarketDataProvider`, `TickSubscriptionRequest`,
   `BarSubscriptionRequest`, `MarketDataSubscriptionBatch`,
   `MarketDataSubscriptionHandle`, `MarketDataSubscriptionResult`,
-  `MarketDataBatch<T>` and `MarketDataContinuityService`.
+  `MarketDataBatch<T>`, `MarketDataHub`, `IMarketDataSubscriber`, and
+  `MarketDataContinuityService`.
 
 Contract rules:
 
@@ -130,6 +131,11 @@ Contract rules:
   status API. Status updates are keyed by `provider_id`, payload type, symbol,
   timeframe and transport; providers are not required to replay cached `READY`
   status to subscriptions created after the source was already ready.
+- `MarketDataHub` is the optional fan-out layer for applications that need many
+  subscriber objects. It binds to the provider's single tick/bar/status
+  callbacks, forwards batches to `IMarketDataSubscriber` instances, and replays
+  cached stream statuses to late subscribers. It does not own provider
+  subscriptions and does not replay tick or bar payloads.
 - `apply_subscriptions()` applies subscription changes atomically. The old
   single-operation helpers (`subscribe_ticks`, `subscribe_bars`, `unsubscribe`)
   are wrappers around a one-operation batch.

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -134,8 +134,17 @@ Contract rules:
 - `MarketDataHub` is the optional fan-out layer for applications that need many
   subscriber objects. It binds to the provider's single tick/bar/status
   callbacks, forwards batches to `IMarketDataSubscriber` instances, and replays
-  cached stream statuses to late subscribers. It does not own provider
-  subscriptions and does not replay tick or bar payloads.
+  cached stream statuses to late subscribers. It stores subscribers as weak
+  references, so caller code must keep subscriber objects alive while they
+  should receive callbacks.
+- `MarketDataHub` does not own provider subscriptions and does not replay tick
+  or bar payloads. Its status replay happens when a subscriber object is added;
+  it is not tied to creating a new provider subscription. Per-subscription
+  status replay belongs in a future router/RAII handle layer.
+- `MarketDataHub` protects its containers and invokes callbacks outside its
+  mutex, but strict replay/live ordering is guaranteed only when add/publish
+  calls are marshalled through one owner loop, such as platform `process()`.
+  A fully concurrent ordered dispatcher is a separate design.
 - `apply_subscriptions()` applies subscription changes atomically. The old
   single-operation helpers (`subscribe_ticks`, `subscribe_bars`, `unsubscribe`)
   are wrappers around a one-operation batch.
@@ -164,6 +173,19 @@ Contract rules:
 - `MarketDataContinuityService` is the thin helper for routing recovered history
   into the same bar batch pipeline. It marks payload bars as
   `HISTORICAL` and, for gap recovery, `BACKFILL`.
+
+Future market-data routing work:
+
+- Add a `MarketDataRouter` layer that binds provider subscriptions to concrete
+  subscribers and replays cached status for newly created subscription handles.
+- Add a move-only RAII `SubscriptionHandle` that unsubscribes automatically and
+  delegates to the router by `SubscriptionId`.
+- Add `SubscriptionId` or stream-key context to routed market-data events so a
+  subscriber can distinguish which logical subscription produced a status/data
+  update.
+- Consider `MarketDataSubscriberBase` as convenience sugar for bots that want to
+  subscribe from inside their own methods while keeping `IMarketDataSubscriber`
+  as a pure receiving interface.
 
 ## Typed Broker Result Pattern
 

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -128,9 +128,13 @@ Contract rules:
 - `on_market_data_status()` is a separate stream-status callback. Data callbacks
   should carry data batches, not connection lifecycle sentinel payloads.
 - `on_market_data_status()` is a stream-level event bus, not a per-subscription
-  status API. Status updates are keyed by `provider_id`, payload type, symbol,
-  timeframe and transport; providers are not required to replay cached `READY`
+  status API. Status updates are keyed by a valid subscription handle when one
+  is present; otherwise they are keyed by `provider_id`, payload type, symbol,
+  timeframe and transport. Providers are not required to replay cached `READY`
   status to subscriptions created after the source was already ready.
+- `MarketDataStatusUpdate::subscription` carries the related subscription handle
+  when a provider or router can identify a concrete subscription. If the handle
+  is invalid, the update describes the underlying stream/source.
 - `MarketDataHub` is the optional fan-out layer for applications that need many
   subscriber objects. It binds to the provider's single tick/bar/status
   callbacks, forwards batches to `IMarketDataSubscriber` instances, and replays
@@ -180,8 +184,8 @@ Future market-data routing work:
   subscribers and replays cached status for newly created subscription handles.
 - Add a move-only RAII `SubscriptionHandle` that unsubscribes automatically and
   delegates to the router by `SubscriptionId`.
-- Add `SubscriptionId` or stream-key context to routed market-data events so a
-  subscriber can distinguish which logical subscription produced a status/data
+- Have the router fill concrete subscription context in routed status/data
+  events so a subscriber can distinguish which logical subscription produced an
   update.
 - Consider `MarketDataSubscriberBase` as convenience sugar for bots that want to
   subscribe from inside their own methods while keeping `IMarketDataSubscriber`

--- a/include/optionx_cpp/market_data.hpp
+++ b/include/optionx_cpp/market_data.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef _OPTIONX_MARKET_DATA_HPP_INCLUDED
-#define _OPTIONX_MARKET_DATA_HPP_INCLUDED
+#ifndef OPTIONX_HEADER_MARKET_DATA_HPP_INCLUDED
+#define OPTIONX_HEADER_MARKET_DATA_HPP_INCLUDED
 
 /// \file market_data.hpp
 /// \brief Includes public market-data provider contracts.
@@ -8,9 +8,11 @@
 /// intended to be included through this umbrella header.
 
 #include <atomic>
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,5 +23,6 @@
 #include "market_data/MarketDataBatch.hpp"
 #include "market_data/BaseMarketDataProvider.hpp"
 #include "market_data/MarketDataContinuityService.hpp"
+#include "market_data/MarketDataHub.hpp"
 
-#endif // _OPTIONX_MARKET_DATA_HPP_INCLUDED
+#endif // OPTIONX_HEADER_MARKET_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/market_data.hpp
+++ b/include/optionx_cpp/market_data.hpp
@@ -23,6 +23,7 @@
 #include "market_data/MarketDataBatch.hpp"
 #include "market_data/BaseMarketDataProvider.hpp"
 #include "market_data/MarketDataContinuityService.hpp"
+#include "market_data/IMarketDataSubscriber.hpp"
 #include "market_data/MarketDataHub.hpp"
 
 #endif // OPTIONX_HEADER_MARKET_DATA_HPP_INCLUDED

--- a/include/optionx_cpp/market_data/IMarketDataSubscriber.hpp
+++ b/include/optionx_cpp/market_data/IMarketDataSubscriber.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#ifndef OPTIONX_HEADER_MARKET_DATA_IMARKET_DATA_SUBSCRIBER_HPP_INCLUDED
+#define OPTIONX_HEADER_MARKET_DATA_IMARKET_DATA_SUBSCRIBER_HPP_INCLUDED
+
+/// \file IMarketDataSubscriber.hpp
+/// \brief Defines the object interface used by market-data fan-out helpers.
+
+namespace optionx::market_data {
+
+    /// \class IMarketDataSubscriber
+    /// \brief Receives routed market-data batches and stream status updates.
+    /// \details This interface is intended for bots, chart services, strategy
+    ///          services, and time-series builders that prefer one subscriber
+    ///          object over assigning global provider callbacks directly. The
+    ///          interface only receives events; subscription creation and
+    ///          lifetime are owned by router/hub objects.
+    class IMarketDataSubscriber {
+    public:
+        /// \brief Virtual destructor for subscriber implementations.
+        virtual ~IMarketDataSubscriber() = default;
+
+        /// \brief Receives a live tick-data batch.
+        /// \param batch Tick batch routed from a provider.
+        virtual void on_tick_data(const TickDataBatch& batch) {
+            (void)batch;
+        }
+
+        /// \brief Receives a live bar-data batch.
+        /// \param batch Bar batch routed from a provider.
+        virtual void on_bar_data(const BarDataBatch& batch) {
+            (void)batch;
+        }
+
+        /// \brief Receives a live market-data stream status update.
+        /// \param update Stream status routed from a provider.
+        virtual void on_market_data_status(const MarketDataStatusUpdate& update) {
+            (void)update;
+        }
+    };
+
+} // namespace optionx::market_data
+
+#endif // OPTIONX_HEADER_MARKET_DATA_IMARKET_DATA_SUBSCRIBER_HPP_INCLUDED

--- a/include/optionx_cpp/market_data/MarketDataHub.hpp
+++ b/include/optionx_cpp/market_data/MarketDataHub.hpp
@@ -1,0 +1,297 @@
+#pragma once
+#ifndef OPTIONX_HEADER_MARKET_DATA_MARKET_DATA_HUB_HPP_INCLUDED
+#define OPTIONX_HEADER_MARKET_DATA_MARKET_DATA_HUB_HPP_INCLUDED
+
+/// \file MarketDataHub.hpp
+/// \brief Defines subscriber fan-out utilities for market-data providers.
+
+namespace optionx::market_data {
+
+    /// \class IMarketDataSubscriber
+    /// \brief Receives routed market-data batches and stream status updates.
+    /// \details This interface is intended for bots, strategy services, and
+    ///          time-series builders that prefer one subscriber object over
+    ///          assigning global provider callbacks directly.
+    class IMarketDataSubscriber {
+    public:
+        /// \brief Virtual destructor for subscriber implementations.
+        virtual ~IMarketDataSubscriber() = default;
+
+        /// \brief Receives a live tick-data batch.
+        /// \param batch Tick batch routed from a provider.
+        virtual void on_tick_data(const TickDataBatch& batch) {
+            (void)batch;
+        }
+
+        /// \brief Receives a live bar-data batch.
+        /// \param batch Bar batch routed from a provider.
+        virtual void on_bar_data(const BarDataBatch& batch) {
+            (void)batch;
+        }
+
+        /// \brief Receives a live market-data stream status update.
+        /// \param update Stream status routed from a provider.
+        virtual void on_market_data_status(const MarketDataStatusUpdate& update) {
+            (void)update;
+        }
+    };
+
+    /// \struct MarketDataSubscriberOptions
+    /// \brief Options used when adding a subscriber to MarketDataHub.
+    struct MarketDataSubscriberOptions {
+        bool replay_last_status = true; ///< Replay cached stream statuses to the new subscriber.
+    };
+
+    /// \class MarketDataHub
+    /// \brief Fan-out adapter from provider callbacks to many subscribers.
+    /// \details The hub is intentionally thin: it does not own provider
+    ///          subscriptions and does not replay ticks or bars. It only routes
+    ///          live batches to current subscribers and caches the last status
+    ///          per stream key so late subscribers can learn current readiness.
+    class MarketDataHub {
+    public:
+        /// \brief Runtime identifier of a subscriber slot in the hub.
+        using SubscriberId = std::uint64_t;
+
+        /// \brief Invalid subscriber slot identifier.
+        static constexpr SubscriberId INVALID_SUBSCRIBER_ID = 0;
+
+        /// \brief Adds a weak subscriber and optionally replays cached status updates.
+        /// \param subscriber Subscriber object. The hub stores the weak reference.
+        /// \param options Subscriber delivery options.
+        /// \return Non-zero subscriber ID, or INVALID_SUBSCRIBER_ID for null/expired input.
+        SubscriberId add_weak_subscriber(
+                std::weak_ptr<IMarketDataSubscriber> subscriber,
+                MarketDataSubscriberOptions options = {});
+
+        /// \brief Adds a subscriber and optionally replays cached status updates.
+        /// \param subscriber Subscriber object.
+        /// \param options Subscriber delivery options.
+        /// \return Non-zero subscriber ID, or INVALID_SUBSCRIBER_ID for null input.
+        SubscriberId add_subscriber(
+                const std::shared_ptr<IMarketDataSubscriber>& subscriber,
+                MarketDataSubscriberOptions options = {}) {
+            return add_weak_subscriber(std::weak_ptr<IMarketDataSubscriber>(subscriber), options);
+        }
+
+        /// \brief Removes a subscriber by ID.
+        /// \param id Subscriber ID returned by add_subscriber().
+        /// \return True if a slot was removed.
+        bool remove_subscriber(SubscriberId id);
+
+        /// \brief Removes all subscriber slots.
+        void clear_subscribers();
+
+        /// \brief Returns number of live subscriber slots after pruning expired ones.
+        [[nodiscard]] std::size_t subscriber_count() const;
+
+        /// \brief Binds provider callbacks to this hub.
+        /// \details The provider must not outlive the hub unless unbind_from()
+        ///          is called first; callbacks capture this hub by pointer.
+        /// \param provider Provider whose callbacks should route into the hub.
+        void bind_to(BaseMarketDataProvider& provider);
+
+        /// \brief Clears provider callbacks previously bound to a hub.
+        /// \param provider Provider whose callbacks should be reset.
+        void unbind_from(BaseMarketDataProvider& provider) const;
+
+        /// \brief Routes a tick batch to current subscribers.
+        /// \param batch Tick batch owned by the provider callback.
+        void publish_ticks(std::unique_ptr<TickDataBatch> batch);
+
+        /// \brief Routes a bar batch to current subscribers.
+        /// \param batch Bar batch owned by the provider callback.
+        void publish_bars(std::unique_ptr<BarDataBatch> batch);
+
+        /// \brief Caches and routes a status update to current subscribers.
+        /// \param update Stream status update.
+        void publish_status(MarketDataStatusUpdate update);
+
+    private:
+        struct SubscriberSlot {
+            SubscriberId id = INVALID_SUBSCRIBER_ID;
+            std::weak_ptr<IMarketDataSubscriber> subscriber;
+            MarketDataSubscriberOptions options;
+        };
+
+        mutable std::mutex m_mutex; ///< Protects subscribers and status cache.
+        mutable std::vector<SubscriberSlot> m_subscribers; ///< Registered subscribers.
+        std::vector<MarketDataStatusUpdate> m_last_statuses; ///< Last status per stream key.
+        SubscriberId m_next_subscriber_id = 1; ///< Next subscriber ID.
+
+        /// \brief Returns true when two status updates describe the same stream.
+        static bool same_status_key(
+                const MarketDataStatusUpdate& lhs,
+                const MarketDataStatusUpdate& rhs) noexcept;
+
+        /// \brief Returns current live subscribers and prunes expired slots.
+        std::vector<std::shared_ptr<IMarketDataSubscriber>> live_subscribers();
+
+        /// \brief Stores a status update in the last-status cache.
+        void cache_status_no_lock(MarketDataStatusUpdate update);
+    };
+
+    inline MarketDataHub::SubscriberId MarketDataHub::add_weak_subscriber(
+            std::weak_ptr<IMarketDataSubscriber> subscriber,
+            MarketDataSubscriberOptions options) {
+        auto live = subscriber.lock();
+        if (!live) return INVALID_SUBSCRIBER_ID;
+
+        SubscriberId id = INVALID_SUBSCRIBER_ID;
+        std::vector<MarketDataStatusUpdate> replay;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            id = m_next_subscriber_id++;
+            if (id == INVALID_SUBSCRIBER_ID) {
+                id = m_next_subscriber_id++;
+            }
+
+            m_subscribers.push_back(SubscriberSlot{id, std::move(subscriber), options});
+            if (options.replay_last_status) {
+                replay = m_last_statuses;
+            }
+        }
+
+        for (const auto& update : replay) {
+            live->on_market_data_status(update);
+        }
+        return id;
+    }
+
+    inline bool MarketDataHub::remove_subscriber(SubscriberId id) {
+        if (id == INVALID_SUBSCRIBER_ID) return false;
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto old_size = m_subscribers.size();
+        m_subscribers.erase(
+            std::remove_if(
+                m_subscribers.begin(),
+                m_subscribers.end(),
+                [id](const SubscriberSlot& slot) {
+                    return slot.id == id;
+                }),
+            m_subscribers.end());
+        return m_subscribers.size() != old_size;
+    }
+
+    inline void MarketDataHub::clear_subscribers() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_subscribers.clear();
+    }
+
+    inline std::size_t MarketDataHub::subscriber_count() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_subscribers.erase(
+            std::remove_if(
+                m_subscribers.begin(),
+                m_subscribers.end(),
+                [](const SubscriberSlot& slot) {
+                    return slot.subscriber.expired();
+                }),
+            m_subscribers.end());
+        return m_subscribers.size();
+    }
+
+    inline void MarketDataHub::bind_to(BaseMarketDataProvider& provider) {
+        provider.on_tick_data() =
+            [this](std::unique_ptr<TickDataBatch> batch) {
+                publish_ticks(std::move(batch));
+            };
+        provider.on_bar_data() =
+            [this](std::unique_ptr<BarDataBatch> batch) {
+                publish_bars(std::move(batch));
+            };
+        provider.on_market_data_status() =
+            [this](MarketDataStatusUpdate update) {
+                publish_status(std::move(update));
+            };
+    }
+
+    inline void MarketDataHub::unbind_from(BaseMarketDataProvider& provider) const {
+        provider.on_tick_data() = BaseMarketDataProvider::ticks_callback_t{};
+        provider.on_bar_data() = BaseMarketDataProvider::bars_callback_t{};
+        provider.on_market_data_status() = BaseMarketDataProvider::status_callback_t{};
+    }
+
+    inline void MarketDataHub::publish_ticks(std::unique_ptr<TickDataBatch> batch) {
+        if (!batch) return;
+        const auto subscribers = live_subscribers();
+        for (const auto& subscriber : subscribers) {
+            subscriber->on_tick_data(*batch);
+        }
+    }
+
+    inline void MarketDataHub::publish_bars(std::unique_ptr<BarDataBatch> batch) {
+        if (!batch) return;
+        const auto subscribers = live_subscribers();
+        for (const auto& subscriber : subscribers) {
+            subscriber->on_bar_data(*batch);
+        }
+    }
+
+    inline void MarketDataHub::publish_status(MarketDataStatusUpdate update) {
+        auto subscribers = std::vector<std::shared_ptr<IMarketDataSubscriber>>{};
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            cache_status_no_lock(update);
+            subscribers.reserve(m_subscribers.size());
+            m_subscribers.erase(
+                std::remove_if(
+                    m_subscribers.begin(),
+                    m_subscribers.end(),
+                    [&subscribers](const SubscriberSlot& slot) {
+                        auto subscriber = slot.subscriber.lock();
+                        if (!subscriber) return true;
+                        subscribers.push_back(std::move(subscriber));
+                        return false;
+                    }),
+                m_subscribers.end());
+        }
+
+        for (const auto& subscriber : subscribers) {
+            subscriber->on_market_data_status(update);
+        }
+    }
+
+    inline bool MarketDataHub::same_status_key(
+            const MarketDataStatusUpdate& lhs,
+            const MarketDataStatusUpdate& rhs) noexcept {
+        return lhs.provider_id == rhs.provider_id &&
+               lhs.type == rhs.type &&
+               lhs.symbol == rhs.symbol &&
+               lhs.timeframe == rhs.timeframe &&
+               lhs.transport == rhs.transport;
+    }
+
+    inline std::vector<std::shared_ptr<IMarketDataSubscriber>>
+    MarketDataHub::live_subscribers() {
+        std::vector<std::shared_ptr<IMarketDataSubscriber>> subscribers;
+        std::lock_guard<std::mutex> lock(m_mutex);
+        subscribers.reserve(m_subscribers.size());
+        m_subscribers.erase(
+            std::remove_if(
+                m_subscribers.begin(),
+                m_subscribers.end(),
+                [&subscribers](const SubscriberSlot& slot) {
+                    auto subscriber = slot.subscriber.lock();
+                    if (!subscriber) return true;
+                    subscribers.push_back(std::move(subscriber));
+                    return false;
+                }),
+            m_subscribers.end());
+        return subscribers;
+    }
+
+    inline void MarketDataHub::cache_status_no_lock(MarketDataStatusUpdate update) {
+        for (auto& cached : m_last_statuses) {
+            if (same_status_key(cached, update)) {
+                cached = std::move(update);
+                return;
+            }
+        }
+        m_last_statuses.push_back(std::move(update));
+    }
+
+} // namespace optionx::market_data
+
+#endif // OPTIONX_HEADER_MARKET_DATA_MARKET_DATA_HUB_HPP_INCLUDED

--- a/include/optionx_cpp/market_data/MarketDataHub.hpp
+++ b/include/optionx_cpp/market_data/MarketDataHub.hpp
@@ -26,6 +26,10 @@ namespace optionx::market_data {
     ///          API; a future router layer should replay status for newly
     ///          created subscription handles.
     ///
+    ///          When MarketDataStatusUpdate::subscription is valid, status
+    ///          caching keeps that subscription context distinct from other
+    ///          subscriptions that may share the same physical stream.
+    ///
     ///          The hub synchronizes subscriber and status-cache containers and
     ///          never invokes subscriber callbacks while holding its mutex. For
     ///          deterministic replay/live ordering, marshal add/publish calls
@@ -242,6 +246,13 @@ namespace optionx::market_data {
     inline bool MarketDataHub::same_status_key(
             const MarketDataStatusUpdate& lhs,
             const MarketDataStatusUpdate& rhs) noexcept {
+        if (lhs.subscription.valid() || rhs.subscription.valid()) {
+            return lhs.subscription.valid() &&
+                   rhs.subscription.valid() &&
+                   lhs.subscription.provider_id == rhs.subscription.provider_id &&
+                   lhs.subscription.id == rhs.subscription.id;
+        }
+
         return lhs.provider_id == rhs.provider_id &&
                lhs.type == rhs.type &&
                lhs.symbol == rhs.symbol &&

--- a/include/optionx_cpp/market_data/MarketDataHub.hpp
+++ b/include/optionx_cpp/market_data/MarketDataHub.hpp
@@ -7,35 +7,6 @@
 
 namespace optionx::market_data {
 
-    /// \class IMarketDataSubscriber
-    /// \brief Receives routed market-data batches and stream status updates.
-    /// \details This interface is intended for bots, strategy services, and
-    ///          time-series builders that prefer one subscriber object over
-    ///          assigning global provider callbacks directly.
-    class IMarketDataSubscriber {
-    public:
-        /// \brief Virtual destructor for subscriber implementations.
-        virtual ~IMarketDataSubscriber() = default;
-
-        /// \brief Receives a live tick-data batch.
-        /// \param batch Tick batch routed from a provider.
-        virtual void on_tick_data(const TickDataBatch& batch) {
-            (void)batch;
-        }
-
-        /// \brief Receives a live bar-data batch.
-        /// \param batch Bar batch routed from a provider.
-        virtual void on_bar_data(const BarDataBatch& batch) {
-            (void)batch;
-        }
-
-        /// \brief Receives a live market-data stream status update.
-        /// \param update Stream status routed from a provider.
-        virtual void on_market_data_status(const MarketDataStatusUpdate& update) {
-            (void)update;
-        }
-    };
-
     /// \struct MarketDataSubscriberOptions
     /// \brief Options used when adding a subscriber to MarketDataHub.
     struct MarketDataSubscriberOptions {
@@ -45,9 +16,21 @@ namespace optionx::market_data {
     /// \class MarketDataHub
     /// \brief Fan-out adapter from provider callbacks to many subscribers.
     /// \details The hub is intentionally thin: it does not own provider
-    ///          subscriptions and does not replay ticks or bars. It only routes
-    ///          live batches to current subscribers and caches the last status
-    ///          per stream key so late subscribers can learn current readiness.
+    ///          subscriptions and does not replay ticks or bars. It stores
+    ///          subscriber slots as weak references, routes live batches to
+    ///          current subscribers, and caches the last status per stream key
+    ///          so late subscriber objects can learn current stream readiness.
+    ///
+    ///          Status replay is stream-level and happens when a subscriber
+    ///          slot is added to the hub. It is not a per-subscription status
+    ///          API; a future router layer should replay status for newly
+    ///          created subscription handles.
+    ///
+    ///          The hub synchronizes subscriber and status-cache containers and
+    ///          never invokes subscriber callbacks while holding its mutex. For
+    ///          deterministic replay/live ordering, marshal add/publish calls
+    ///          through the provider owner loop, such as platform process().
+    ///          Concurrent add/publish calls may interleave callback delivery.
     class MarketDataHub {
     public:
         /// \brief Runtime identifier of a subscriber slot in the hub.
@@ -57,7 +40,7 @@ namespace optionx::market_data {
         static constexpr SubscriberId INVALID_SUBSCRIBER_ID = 0;
 
         /// \brief Adds a weak subscriber and optionally replays cached status updates.
-        /// \param subscriber Subscriber object. The hub stores the weak reference.
+        /// \param subscriber Subscriber object. The hub stores this weak reference only.
         /// \param options Subscriber delivery options.
         /// \return Non-zero subscriber ID, or INVALID_SUBSCRIBER_ID for null/expired input.
         SubscriberId add_weak_subscriber(
@@ -65,6 +48,9 @@ namespace optionx::market_data {
                 MarketDataSubscriberOptions options = {});
 
         /// \brief Adds a subscriber and optionally replays cached status updates.
+        /// \details The hub still stores only a weak reference; the caller must
+        ///          keep the shared subscriber alive while it should receive
+        ///          market-data callbacks.
         /// \param subscriber Subscriber object.
         /// \param options Subscriber delivery options.
         /// \return Non-zero subscriber ID, or INVALID_SUBSCRIBER_ID for null input.

--- a/include/optionx_cpp/market_data/MarketDataSubscription.hpp
+++ b/include/optionx_cpp/market_data/MarketDataSubscription.hpp
@@ -363,6 +363,7 @@ namespace optionx::market_data {
     /// \brief Status update for a live market-data stream.
     struct MarketDataStatusUpdate {
         ProviderInstanceId provider_id = kInvalidProviderInstanceId; ///< Provider that owns the stream.
+        MarketDataSubscriptionHandle subscription; ///< Related subscription, if the provider can identify one.
         MarketDataType type = MarketDataType::UNKNOWN; ///< Stream payload type.
         std::string symbol; ///< Stream symbol.
         BarTimeframe timeframe = 0; ///< Bar timeframe in seconds, or 0 for ticks.

--- a/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
+++ b/include/optionx_cpp/platforms/IntradeBarPlatform/MarketDataSubscriptionManager.hpp
@@ -914,6 +914,7 @@ namespace optionx::platforms::intrade_bar {
                 }
 
                 auto bar_update = update;
+                bar_update.subscription = subscription;
                 bar_update.type = market_data::MarketDataType::BARS;
                 bar_update.symbol = subscription.symbol;
                 bar_update.timeframe = subscription.timeframe;

--- a/tests/market_data_hub_test.cpp
+++ b/tests/market_data_hub_test.cpp
@@ -1,0 +1,173 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include <optionx_cpp/market_data.hpp>
+
+using namespace optionx;
+using namespace optionx::market_data;
+
+namespace {
+
+class FakeMarketDataProvider final : public BaseMarketDataProvider {
+public:
+    bars_callback_t bars_callback;
+    ticks_callback_t ticks_callback;
+    status_callback_t status_callback;
+
+    bars_callback_t& on_bar_data() override {
+        return bars_callback;
+    }
+
+    ticks_callback_t& on_tick_data() override {
+        return ticks_callback;
+    }
+
+    status_callback_t& on_market_data_status() override {
+        return status_callback;
+    }
+};
+
+class RecordingMarketDataSubscriber final : public IMarketDataSubscriber {
+public:
+    std::vector<TickDataBatch> ticks;
+    std::vector<BarDataBatch> bars;
+    std::vector<MarketDataStatusUpdate> statuses;
+
+    void on_tick_data(const TickDataBatch& batch) override {
+        ticks.push_back(batch);
+    }
+
+    void on_bar_data(const BarDataBatch& batch) override {
+        bars.push_back(batch);
+    }
+
+    void on_market_data_status(const MarketDataStatusUpdate& update) override {
+        statuses.push_back(update);
+    }
+};
+
+TickDataBatch make_tick_batch() {
+    TickDataBatch batch;
+    batch.type = MarketDataType::TICKS;
+    batch.symbol = "BTCUSDT";
+    batch.price_digits = 2;
+    batch.items.push_back(Tick(0.0, 0.0, 61521.34, 0.00017, 1783028778697ULL, 0, 0));
+    batch.items.front().set_flag(MarketDataFlags::REALTIME);
+    return batch;
+}
+
+BarDataBatch make_bar_batch() {
+    BarDataBatch batch;
+    batch.type = MarketDataType::BARS;
+    batch.symbol = "EURUSD";
+    batch.timeframe = 60;
+    batch.price_digits = 5;
+    batch.items.push_back(Bar(1.1, 1.2, 1.0, 1.15, 10.0, 1783028760000ULL));
+    batch.items.front().set_flag(MarketDataFlags::REALTIME);
+    return batch;
+}
+
+MarketDataStatusUpdate make_ready_status() {
+    MarketDataStatusUpdate update;
+    update.provider_id = 17;
+    update.type = MarketDataType::TICKS;
+    update.symbol = "BTCUSDT";
+    update.transport = MarketDataTransport::WEBSOCKET;
+    update.status = MarketDataStreamStatus::READY;
+    return update;
+}
+
+} // namespace
+
+TEST(MarketDataHub, RoutesProviderCallbacksToSubscribers) {
+    FakeMarketDataProvider provider;
+    MarketDataHub hub;
+    hub.bind_to(provider);
+
+    auto first = std::make_shared<RecordingMarketDataSubscriber>();
+    auto second = std::make_shared<RecordingMarketDataSubscriber>();
+    const auto first_id = hub.add_subscriber(first);
+    const auto second_id = hub.add_subscriber(second);
+
+    ASSERT_NE(first_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
+    ASSERT_NE(second_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
+    EXPECT_EQ(hub.subscriber_count(), 2u);
+
+    provider.on_market_data_status()(make_ready_status());
+    provider.on_tick_data()(std::make_unique<TickDataBatch>(make_tick_batch()));
+    provider.on_bar_data()(std::make_unique<BarDataBatch>(make_bar_batch()));
+
+    ASSERT_EQ(first->statuses.size(), 1u);
+    ASSERT_EQ(second->statuses.size(), 1u);
+    EXPECT_EQ(first->statuses[0].status, MarketDataStreamStatus::READY);
+    EXPECT_EQ(second->statuses[0].symbol, "BTCUSDT");
+
+    ASSERT_EQ(first->ticks.size(), 1u);
+    ASSERT_EQ(second->ticks.size(), 1u);
+    EXPECT_EQ(first->ticks[0].symbol, "BTCUSDT");
+    ASSERT_EQ(second->ticks[0].items.size(), 1u);
+    EXPECT_DOUBLE_EQ(second->ticks[0].items[0].last, 61521.34);
+
+    ASSERT_EQ(first->bars.size(), 1u);
+    ASSERT_EQ(second->bars.size(), 1u);
+    EXPECT_EQ(first->bars[0].symbol, "EURUSD");
+    EXPECT_EQ(second->bars[0].timeframe, 60);
+
+    EXPECT_TRUE(hub.remove_subscriber(first_id));
+    EXPECT_EQ(hub.subscriber_count(), 1u);
+
+    provider.on_tick_data()(std::make_unique<TickDataBatch>(make_tick_batch()));
+    EXPECT_EQ(first->ticks.size(), 1u);
+    EXPECT_EQ(second->ticks.size(), 2u);
+}
+
+TEST(MarketDataHub, ReplaysCachedStatusToLateSubscribers) {
+    MarketDataHub hub;
+    hub.publish_status(make_ready_status());
+
+    auto replayed = std::make_shared<RecordingMarketDataSubscriber>();
+    const auto replayed_id = hub.add_subscriber(replayed);
+
+    ASSERT_NE(replayed_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
+    ASSERT_EQ(replayed->statuses.size(), 1u);
+    EXPECT_EQ(replayed->statuses[0].status, MarketDataStreamStatus::READY);
+    EXPECT_EQ(replayed->statuses[0].symbol, "BTCUSDT");
+
+    auto quiet = std::make_shared<RecordingMarketDataSubscriber>();
+    MarketDataSubscriberOptions options;
+    options.replay_last_status = false;
+    const auto quiet_id = hub.add_subscriber(quiet, options);
+
+    ASSERT_NE(quiet_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
+    EXPECT_TRUE(quiet->statuses.empty());
+}
+
+TEST(MarketDataHub, PrunesExpiredSubscribersAndUnbindsProviderCallbacks) {
+    FakeMarketDataProvider provider;
+    MarketDataHub hub;
+    hub.bind_to(provider);
+
+    auto subscriber = std::make_shared<RecordingMarketDataSubscriber>();
+    ASSERT_NE(hub.add_subscriber(subscriber), MarketDataHub::INVALID_SUBSCRIBER_ID);
+    EXPECT_EQ(hub.subscriber_count(), 1u);
+
+    subscriber.reset();
+    EXPECT_EQ(hub.subscriber_count(), 0u);
+
+    ASSERT_TRUE(static_cast<bool>(provider.on_tick_data()));
+    ASSERT_TRUE(static_cast<bool>(provider.on_bar_data()));
+    ASSERT_TRUE(static_cast<bool>(provider.on_market_data_status()));
+
+    hub.unbind_from(provider);
+
+    EXPECT_FALSE(static_cast<bool>(provider.on_tick_data()));
+    EXPECT_FALSE(static_cast<bool>(provider.on_bar_data()));
+    EXPECT_FALSE(static_cast<bool>(provider.on_market_data_status()));
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/market_data_hub_test.cpp
+++ b/tests/market_data_hub_test.cpp
@@ -69,12 +69,20 @@ BarDataBatch make_bar_batch() {
     return batch;
 }
 
-MarketDataStatusUpdate make_ready_status() {
+MarketDataStatusUpdate make_ready_status(SubscriptionId subscription_id = 42) {
+    const TickSubscriptionRequest request(
+        "BTCUSDT",
+        MarketDataTransport::WEBSOCKET);
+
     MarketDataStatusUpdate update;
     update.provider_id = 17;
+    update.subscription = MarketDataSubscriptionHandle::from_tick_request(
+        update.provider_id,
+        subscription_id,
+        request);
     update.type = MarketDataType::TICKS;
-    update.symbol = "BTCUSDT";
-    update.transport = MarketDataTransport::WEBSOCKET;
+    update.symbol = request.symbol;
+    update.transport = request.transport;
     update.status = MarketDataStreamStatus::READY;
     return update;
 }
@@ -102,6 +110,8 @@ TEST(MarketDataHub, RoutesProviderCallbacksToSubscribers) {
     ASSERT_EQ(first->statuses.size(), 1u);
     ASSERT_EQ(second->statuses.size(), 1u);
     EXPECT_EQ(first->statuses[0].status, MarketDataStreamStatus::READY);
+    ASSERT_TRUE(first->statuses[0].subscription.valid());
+    EXPECT_EQ(first->statuses[0].subscription.id, 42u);
     EXPECT_EQ(second->statuses[0].symbol, "BTCUSDT");
 
     ASSERT_EQ(first->ticks.size(), 1u);
@@ -142,6 +152,22 @@ TEST(MarketDataHub, ReplaysCachedStatusToLateSubscribers) {
 
     ASSERT_NE(quiet_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
     EXPECT_TRUE(quiet->statuses.empty());
+}
+
+TEST(MarketDataHub, ReplaysSubscriptionScopedStatusesWithoutCollapsingStreamKey) {
+    MarketDataHub hub;
+    hub.publish_status(make_ready_status(42));
+    hub.publish_status(make_ready_status(43));
+
+    auto replayed = std::make_shared<RecordingMarketDataSubscriber>();
+    const auto replayed_id = hub.add_subscriber(replayed);
+
+    ASSERT_NE(replayed_id, MarketDataHub::INVALID_SUBSCRIBER_ID);
+    ASSERT_EQ(replayed->statuses.size(), 2u);
+    EXPECT_EQ(replayed->statuses[0].subscription.id, 42u);
+    EXPECT_EQ(replayed->statuses[1].subscription.id, 43u);
+    EXPECT_EQ(replayed->statuses[0].symbol, "BTCUSDT");
+    EXPECT_EQ(replayed->statuses[1].symbol, "BTCUSDT");
 }
 
 TEST(MarketDataHub, PrunesExpiredSubscribersAndUnbindsProviderCallbacks) {


### PR DESCRIPTION
## Summary
- add `IMarketDataSubscriber` and `MarketDataHub` as an optional fan-out layer over provider callbacks
- cache and replay last stream status updates to late subscribers without replaying tick/bar payloads
- expose the hub through `market_data.hpp`, document the contract, and add CI coverage

## Checks
- cmake -S . -B build-codex
- cmake --build build-codex --target market_data_hub_test -- -j1
- .\build-codex\market_data_hub_test.exe --gtest_brief=1
- .\build-codex\market_data_subscription_contract_test.exe --gtest_brief=1
- git diff --check