### PR TITLE
[codex] Add account info subscriber hub

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Run market_data_hub_test
         run: ./build-linux/market_data_hub_test --gtest_brief=1
 
+      - name: Build account_info_hub_test
+        run: cmake --build build-linux --target account_info_hub_test -j
+
+      - name: Run account_info_hub_test
+        run: ./build-linux/account_info_hub_test --gtest_brief=1
+
       - name: Build trade_manager_test
         run: cmake --build build-linux --target trade_manager_test -j
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,41 @@ if(OPTIONX_BUILD_EXAMPLES)
         )
     endif()
 
+    add_executable(account_info_hub_example examples/account_info_hub_example.cpp)
+
+    target_include_directories(account_info_hub_example PRIVATE
+        ${EXAMPLE_INCLUDE_DIRS}
+        ${EXAMPLE_DEPS_INCLUDE_DIRS}
+    )
+
+    target_link_directories(account_info_hub_example PRIVATE ${EXAMPLE_LIBRARY_DIRS})
+    target_compile_definitions(
+        account_info_hub_example PRIVATE
+        ${EXAMPLE_DEFINES}
+        LOGIT_BASE_PATH="${LOGIT_BASE_PATH_FWD}"
+    )
+    target_link_libraries(account_info_hub_example PRIVATE ${EXAMPLE_LIBS} optionx_cpp)
+
+    if(OPTIONX_BUILD_DEPS)
+        add_dependencies(account_info_hub_example mdbx-static AES)
+    endif()
+
+    foreach(dll ${EXAMPLE_DLL_FILES})
+        add_custom_command(TARGET account_info_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${dll}" "$<TARGET_FILE_DIR:account_info_hub_example>"
+        )
+    endforeach()
+
+    if(WIN32)
+        add_custom_command(TARGET account_info_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND}
+                -DOPTIONX_RUNTIME_DLL_DIR="${EXAMPLE_BUILD_LIBS_DIR}/bin"
+                -DOPTIONX_RUNTIME_TARGET_DIR="$<TARGET_FILE_DIR:account_info_hub_example>"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_runtime_dlls.cmake"
+        )
+    endif()
+
     add_executable(market_data_hub_example examples/market_data_hub_example.cpp)
 
     target_include_directories(market_data_hub_example PRIVATE

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,9 @@ against the current public aggregate headers.
 
 Currently maintained examples:
 
+- `account_info_hub_example.cpp` demonstrates routing account information
+  updates through `AccountInfoHub` into an `IAccountInfoSubscriber`
+  implementation.
 - `intrade_market_data_example.cpp` demonstrates Intrade Bar market-data
   subscriptions, stream status callbacks, direct bar history, and history routed
   through `MarketDataContinuityService`. Live authenticated lifecycle reads

--- a/examples/account_info_hub_example.cpp
+++ b/examples/account_info_hub_example.cpp
@@ -1,0 +1,164 @@
+#include <optionx_cpp/components.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+
+class DemoAccountInfo final : public optionx::BaseAccountInfoData {
+public:
+    double balance = 0.0;
+    optionx::CurrencyType currency = optionx::CurrencyType::USD;
+    optionx::AccountType account_type = optionx::AccountType::DEMO;
+    bool connected = false;
+    std::int64_t open_trades = 0;
+
+    std::unique_ptr<optionx::BaseAccountInfoData> clone_unique() const override {
+        return std::make_unique<DemoAccountInfo>(*this);
+    }
+
+    std::shared_ptr<optionx::BaseAccountInfoData> clone_shared() const override {
+        return std::make_shared<DemoAccountInfo>(*this);
+    }
+
+protected:
+    bool get_info_bool(const optionx::AccountInfoRequest& request) const override {
+        if (request.type == optionx::AccountInfoType::CONNECTION_STATUS) {
+            return connected;
+        }
+        return false;
+    }
+
+    std::int64_t get_info_int64(const optionx::AccountInfoRequest& request) const override {
+        switch (request.type) {
+        case optionx::AccountInfoType::CONNECTION_STATUS:
+            return connected ? 1 : 0;
+        case optionx::AccountInfoType::OPEN_TRADES:
+            return open_trades;
+        case optionx::AccountInfoType::ACCOUNT_TYPE:
+            return static_cast<std::int64_t>(account_type);
+        case optionx::AccountInfoType::CURRENCY:
+            return static_cast<std::int64_t>(currency);
+        case optionx::AccountInfoType::BALANCE:
+            return static_cast<std::int64_t>(balance);
+        default:
+            return 0;
+        }
+    }
+
+    double get_info_f64(const optionx::AccountInfoRequest& request) const override {
+        if (request.type == optionx::AccountInfoType::BALANCE) {
+            return balance;
+        }
+        return 0.0;
+    }
+
+    std::string get_info_str(const optionx::AccountInfoRequest& request) const override {
+        switch (request.type) {
+        case optionx::AccountInfoType::BALANCE:
+            return std::to_string(balance);
+        case optionx::AccountInfoType::ACCOUNT_TYPE:
+            return optionx::to_str(account_type);
+        case optionx::AccountInfoType::CURRENCY:
+            return optionx::to_str(currency);
+        default:
+            return {};
+        }
+    }
+
+    optionx::AccountType get_info_account_type(
+            const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return account_type;
+    }
+
+    optionx::CurrencyType get_info_currency(
+            const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return currency;
+    }
+};
+
+class ConsoleAccountSubscriber final : public optionx::components::IAccountInfoSubscriber {
+public:
+    void on_account_info(const optionx::AccountInfoUpdate& update) override {
+        std::cout << "[account] " << optionx::to_str(update.status);
+        if (!update.message.empty()) {
+            std::cout << " message=\"" << update.message << "\"";
+        }
+
+        // AccountUpdateStatus identifies what changed; account_info carries the
+        // current snapshot where the new value can be queried.
+        if (update.account_info) {
+            switch (update.status) {
+            case optionx::AccountUpdateStatus::BALANCE_UPDATED:
+                std::cout << " balance="
+                          << update.account_info->get_info<double>(
+                                 optionx::AccountInfoType::BALANCE);
+                break;
+            case optionx::AccountUpdateStatus::CURRENCY_CHANGED:
+                std::cout << " currency="
+                          << optionx::to_str(update.account_info->get_info<optionx::CurrencyType>(
+                                 optionx::AccountInfoType::CURRENCY));
+                break;
+            case optionx::AccountUpdateStatus::ACCOUNT_TYPE_CHANGED:
+                std::cout << " account_type="
+                          << optionx::to_str(update.account_info->get_info<optionx::AccountType>(
+                                 optionx::AccountInfoType::ACCOUNT_TYPE));
+                break;
+            case optionx::AccountUpdateStatus::OPEN_TRADES_CHANGED:
+                std::cout << " open_trades="
+                          << update.account_info->get_info<std::int64_t>(
+                                 optionx::AccountInfoType::OPEN_TRADES);
+                break;
+            case optionx::AccountUpdateStatus::CONNECTED:
+            case optionx::AccountUpdateStatus::DISCONNECTED:
+                std::cout << " connected="
+                          << update.account_info->get_info<bool>(
+                                 optionx::AccountInfoType::CONNECTION_STATUS);
+                break;
+            default:
+                break;
+            }
+        }
+
+        std::cout << '\n';
+    }
+};
+
+optionx::AccountInfoUpdate make_update(
+        std::shared_ptr<DemoAccountInfo> account,
+        optionx::AccountUpdateStatus status,
+        std::string message = {}) {
+    return optionx::AccountInfoUpdate(std::move(account), status, std::move(message));
+}
+
+} // namespace
+
+int main() {
+    optionx::components::AccountInfoHub hub;
+
+    // The hub stores weak references. Keep this shared_ptr alive while the
+    // subscriber should receive account events.
+    auto subscriber = std::make_shared<ConsoleAccountSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    auto account = std::make_shared<DemoAccountInfo>();
+    account->connected = true;
+    hub.publish(make_update(account, optionx::AccountUpdateStatus::CONNECTED));
+
+    account->balance = 1250.75;
+    hub.publish(make_update(account, optionx::AccountUpdateStatus::BALANCE_UPDATED));
+
+    account->open_trades = 2;
+    hub.publish(make_update(account, optionx::AccountUpdateStatus::OPEN_TRADES_CHANGED));
+
+    // Late subscribers receive the latest cached update immediately.
+    auto late_subscriber = std::make_shared<ConsoleAccountSubscriber>();
+    hub.add_subscriber(late_subscriber);
+
+    return 0;
+}

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -86,6 +86,27 @@ etc.) являются implementation detail конкретной платфор
 метод сначала должен появиться на facade/base contract, а затем делегироваться
 в manager.
 
+## Account Info Subscriber Contract
+
+`components::AccountInfoHub` is an optional fan-out adapter for the single
+platform `on_account_info()` callback. It routes immutable `AccountInfoUpdate`
+payloads to `IAccountInfoSubscriber` instances and may replay the latest cached
+update to late subscribers.
+
+Rules:
+
+- The hub does not own account storage, authorization state, platform lifecycle
+  or broker sessions.
+- `bind_to(platform.on_account_info())` replaces the platform callback with the
+  hub dispatcher. Call `unbind_from()` if the callback owner can outlive the
+  hub object.
+- Subscribers receive account lifecycle and account metadata updates such as
+  `CONNECTING`, `CONNECTED`, `DISCONNECTED`, `BALANCE_UPDATED`,
+  `ACCOUNT_TYPE_CHANGED`, `CURRENCY_CHANGED` and `OPEN_TRADES_CHANGED`.
+- Broker-specific trading-condition streams, payout changes and symbol session
+  changes should use their own DTO/subscriber contract instead of overloading
+  `AccountInfoUpdate`.
+
 ## Market Data Contract
 
 Market-data APIs are split into DTO/data types and a provider role:

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -91,7 +91,8 @@ etc.) являются implementation detail конкретной платфор
 `components::AccountInfoHub` is an optional fan-out adapter for the single
 platform `on_account_info()` callback. It routes immutable `AccountInfoUpdate`
 payloads to `IAccountInfoSubscriber` instances and may replay the latest cached
-update to late subscribers.
+update to late subscribers. It stores subscribers as weak references, so caller
+code must keep subscriber objects alive while they should receive callbacks.
 
 Rules:
 
@@ -103,6 +104,9 @@ Rules:
 - Subscribers receive account lifecycle and account metadata updates such as
   `CONNECTING`, `CONNECTED`, `DISCONNECTED`, `BALANCE_UPDATED`,
   `ACCOUNT_TYPE_CHANGED`, `CURRENCY_CHANGED` and `OPEN_TRADES_CHANGED`.
+- `AccountInfoUpdate::status` identifies the account aspect that changed.
+  `AccountInfoUpdate::account_info` carries the current account snapshot, where
+  subscribers can query the new value. The update is not an old/new diff object.
 - Broker-specific trading-condition streams, payout changes and symbol session
   changes should use their own DTO/subscriber contract instead of overloading
   `AccountInfoUpdate`.

--- a/include/optionx_cpp/components.hpp
+++ b/include/optionx_cpp/components.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef _OPTIONX_COMPONENTS_HPP_INCLUDED
-#define _OPTIONX_COMPONENTS_HPP_INCLUDED
+#ifndef OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED
 
 /// \file components.hpp
 /// \brief Public aggregate header for broker platform building blocks.
@@ -10,7 +10,12 @@
 /// trade execution queues. Application-level code normally uses
 /// `platforms.hpp` or a concrete platform facade instead.
 
+#include <algorithm>
+#include <cstddef>
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
 
 #include "utils.hpp"
 #include "data.hpp"
@@ -19,5 +24,6 @@
 #include "components/BaseTradeExecutionComponent.hpp"
 #include "components/BaseHttpClientComponent.hpp"
 #include "components/BaseAccountInfoHandler.hpp"
+#include "components/AccountInfoHub.hpp"
 
-#endif // _OPTIONX_COMPONENTS_HPP_INCLUDED
+#endif // OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED

--- a/include/optionx_cpp/components.hpp
+++ b/include/optionx_cpp/components.hpp
@@ -24,6 +24,7 @@
 #include "components/BaseTradeExecutionComponent.hpp"
 #include "components/BaseHttpClientComponent.hpp"
 #include "components/BaseAccountInfoHandler.hpp"
+#include "components/IAccountInfoSubscriber.hpp"
 #include "components/AccountInfoHub.hpp"
 
 #endif // OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED

--- a/include/optionx_cpp/components/AccountInfoHub.hpp
+++ b/include/optionx_cpp/components/AccountInfoHub.hpp
@@ -50,10 +50,14 @@ namespace optionx::components {
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 prune_expired_no_lock();
+                bool inserted = false;
                 if (!contains_subscriber_no_lock(locked.get())) {
                     m_subscribers.push_back(std::move(subscriber));
+                    inserted = true;
                 }
-                if (m_replay_last_update_to_new_subscribers && m_last_update) {
+                if (inserted &&
+                    m_replay_last_update_to_new_subscribers &&
+                    m_last_update) {
                     replay_update = m_last_update;
                 }
             }

--- a/include/optionx_cpp/components/AccountInfoHub.hpp
+++ b/include/optionx_cpp/components/AccountInfoHub.hpp
@@ -7,25 +7,15 @@
 
 namespace optionx::components {
 
-    /// \class IAccountInfoSubscriber
-    /// \brief Interface for consumers that receive account information updates.
-    class IAccountInfoSubscriber {
-    public:
-        /// \brief Virtual destructor.
-        virtual ~IAccountInfoSubscriber() = default;
-
-        /// \brief Handles an account information update.
-        /// \param update Account update payload.
-        virtual void on_account_info(const AccountInfoUpdate& update) = 0;
-    };
-
     /// \class AccountInfoHub
     /// \brief Routes a single account-info callback to multiple subscribers.
     ///
     /// The hub is a lightweight adapter for platform-level `on_account_info()`.
     /// It does not own platform lifecycle or account storage; it only fans out
     /// immutable `AccountInfoUpdate` payloads and optionally replays the latest
-    /// update to late subscribers.
+    /// update to late subscribers. Subscribers are stored as weak references,
+    /// so caller code must keep subscriber objects alive while they should
+    /// receive callbacks.
     class AccountInfoHub {
     public:
         /// \brief Constructs an account-info hub.
@@ -41,6 +31,9 @@ namespace optionx::components {
         AccountInfoHub& operator=(AccountInfoHub&&) = delete;
 
         /// \brief Adds a shared subscriber.
+        /// \details The hub stores only a weak reference; the caller must keep
+        ///          the shared subscriber alive while it should receive account
+        ///          callbacks.
         /// \param subscriber Subscriber object; ignored when null.
         void add_subscriber(std::shared_ptr<IAccountInfoSubscriber> subscriber) {
             if (!subscriber) return;

--- a/include/optionx_cpp/components/AccountInfoHub.hpp
+++ b/include/optionx_cpp/components/AccountInfoHub.hpp
@@ -1,0 +1,203 @@
+#pragma once
+#ifndef OPTIONX_HEADER_COMPONENTS_ACCOUNT_INFO_HUB_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_ACCOUNT_INFO_HUB_HPP_INCLUDED
+
+/// \file AccountInfoHub.hpp
+/// \brief Defines subscriber fan-out helpers for account information updates.
+
+namespace optionx::components {
+
+    /// \class IAccountInfoSubscriber
+    /// \brief Interface for consumers that receive account information updates.
+    class IAccountInfoSubscriber {
+    public:
+        /// \brief Virtual destructor.
+        virtual ~IAccountInfoSubscriber() = default;
+
+        /// \brief Handles an account information update.
+        /// \param update Account update payload.
+        virtual void on_account_info(const AccountInfoUpdate& update) = 0;
+    };
+
+    /// \class AccountInfoHub
+    /// \brief Routes a single account-info callback to multiple subscribers.
+    ///
+    /// The hub is a lightweight adapter for platform-level `on_account_info()`.
+    /// It does not own platform lifecycle or account storage; it only fans out
+    /// immutable `AccountInfoUpdate` payloads and optionally replays the latest
+    /// update to late subscribers.
+    class AccountInfoHub {
+    public:
+        /// \brief Constructs an account-info hub.
+        /// \param replay_last_update_to_new_subscribers Whether late subscribers
+        ///        should receive the latest cached account update immediately.
+        explicit AccountInfoHub(bool replay_last_update_to_new_subscribers = true)
+            : m_replay_last_update_to_new_subscribers(
+                  replay_last_update_to_new_subscribers) {}
+
+        AccountInfoHub(const AccountInfoHub&) = delete;
+        AccountInfoHub& operator=(const AccountInfoHub&) = delete;
+        AccountInfoHub(AccountInfoHub&&) = delete;
+        AccountInfoHub& operator=(AccountInfoHub&&) = delete;
+
+        /// \brief Adds a shared subscriber.
+        /// \param subscriber Subscriber object; ignored when null.
+        void add_subscriber(std::shared_ptr<IAccountInfoSubscriber> subscriber) {
+            if (!subscriber) return;
+            add_weak_subscriber(std::weak_ptr<IAccountInfoSubscriber>(subscriber));
+        }
+
+        /// \brief Adds a weak subscriber.
+        /// \param subscriber Weak subscriber reference; ignored when expired.
+        void add_weak_subscriber(std::weak_ptr<IAccountInfoSubscriber> subscriber) {
+            const auto locked = subscriber.lock();
+            if (!locked) return;
+
+            std::optional<AccountInfoUpdate> replay_update;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                prune_expired_no_lock();
+                if (!contains_subscriber_no_lock(locked.get())) {
+                    m_subscribers.push_back(std::move(subscriber));
+                }
+                if (m_replay_last_update_to_new_subscribers && m_last_update) {
+                    replay_update = m_last_update;
+                }
+            }
+
+            if (replay_update) {
+                locked->on_account_info(*replay_update);
+            }
+        }
+
+        /// \brief Removes a subscriber by object address.
+        /// \param subscriber Subscriber object address.
+        void remove_subscriber(const IAccountInfoSubscriber* subscriber) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_subscribers.erase(
+                std::remove_if(
+                    m_subscribers.begin(),
+                    m_subscribers.end(),
+                    [subscriber](const std::weak_ptr<IAccountInfoSubscriber>& item) {
+                        const auto locked = item.lock();
+                        return !locked || locked.get() == subscriber;
+                    }),
+                m_subscribers.end());
+        }
+
+        /// \brief Removes all subscribers.
+        void clear_subscribers() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_subscribers.clear();
+        }
+
+        /// \brief Returns the number of live subscribers.
+        /// \return Count of non-expired subscribers.
+        std::size_t subscriber_count() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::size_t count = 0;
+            for (const auto& subscriber : m_subscribers) {
+                if (!subscriber.expired()) {
+                    ++count;
+                }
+            }
+            return count;
+        }
+
+        /// \brief Binds the hub to a platform/account callback.
+        /// \details Replaces the callback with a dispatcher that calls
+        ///          `publish()`. Call `unbind_from()` before destroying the hub
+        ///          if the callback owner may outlive it.
+        /// \param callback Platform account-info callback.
+        void bind_to(account_info_callback_t& callback) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_bound_callback && m_bound_callback != &callback) {
+                *m_bound_callback = {};
+            }
+            callback = [this](const AccountInfoUpdate& update) {
+                publish(update);
+            };
+            m_bound_callback = &callback;
+        }
+
+        /// \brief Unbinds the hub from a callback if it is the current binding.
+        /// \param callback Platform account-info callback.
+        void unbind_from(account_info_callback_t& callback) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_bound_callback == &callback) {
+                callback = {};
+                m_bound_callback = nullptr;
+            }
+        }
+
+        /// \brief Publishes an account update to all live subscribers.
+        /// \param update Account update payload.
+        void publish(AccountInfoUpdate update) {
+            std::vector<std::shared_ptr<IAccountInfoSubscriber>> subscribers;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                m_last_update = update;
+                prune_expired_no_lock();
+                subscribers.reserve(m_subscribers.size());
+                for (const auto& subscriber : m_subscribers) {
+                    if (auto locked = subscriber.lock()) {
+                        subscribers.push_back(std::move(locked));
+                    }
+                }
+            }
+
+            for (const auto& subscriber : subscribers) {
+                subscriber->on_account_info(update);
+            }
+        }
+
+        /// \brief Returns the latest cached update when one exists.
+        /// \return Last account update, or `std::nullopt`.
+        std::optional<AccountInfoUpdate> last_update() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_last_update;
+        }
+
+        /// \brief Clears the cached latest update.
+        void clear_last_update() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_last_update.reset();
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::vector<std::weak_ptr<IAccountInfoSubscriber>> m_subscribers;
+        std::optional<AccountInfoUpdate> m_last_update;
+        account_info_callback_t* m_bound_callback = nullptr;
+        bool m_replay_last_update_to_new_subscribers = true;
+
+        /// \brief Removes expired weak subscribers.
+        void prune_expired_no_lock() {
+            m_subscribers.erase(
+                std::remove_if(
+                    m_subscribers.begin(),
+                    m_subscribers.end(),
+                    [](const std::weak_ptr<IAccountInfoSubscriber>& item) {
+                        return item.expired();
+                    }),
+                m_subscribers.end());
+        }
+
+        /// \brief Checks whether a subscriber is already registered.
+        /// \param subscriber Subscriber object address.
+        /// \return True if the subscriber is already present.
+        bool contains_subscriber_no_lock(
+                const IAccountInfoSubscriber* subscriber) const {
+            return std::any_of(
+                m_subscribers.begin(),
+                m_subscribers.end(),
+                [subscriber](const std::weak_ptr<IAccountInfoSubscriber>& item) {
+                    const auto locked = item.lock();
+                    return locked && locked.get() == subscriber;
+                });
+        }
+    };
+
+} // namespace optionx::components
+
+#endif // OPTIONX_HEADER_COMPONENTS_ACCOUNT_INFO_HUB_HPP_INCLUDED

--- a/include/optionx_cpp/components/IAccountInfoSubscriber.hpp
+++ b/include/optionx_cpp/components/IAccountInfoSubscriber.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef OPTIONX_HEADER_COMPONENTS_IACCOUNT_INFO_SUBSCRIBER_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_IACCOUNT_INFO_SUBSCRIBER_HPP_INCLUDED
+
+/// \file IAccountInfoSubscriber.hpp
+/// \brief Defines the object interface used by account-info fan-out helpers.
+
+namespace optionx::components {
+
+    /// \class IAccountInfoSubscriber
+    /// \brief Interface for consumers that receive account information updates.
+    /// \details AccountInfoUpdate::status tells which account aspect changed,
+    ///          while AccountInfoUpdate::account_info carries the current
+    ///          account snapshot that can be queried for the new value.
+    class IAccountInfoSubscriber {
+    public:
+        /// \brief Virtual destructor.
+        virtual ~IAccountInfoSubscriber() = default;
+
+        /// \brief Handles an account information update.
+        /// \param update Account update payload.
+        virtual void on_account_info(const AccountInfoUpdate& update) = 0;
+    };
+
+} // namespace optionx::components
+
+#endif // OPTIONX_HEADER_COMPONENTS_IACCOUNT_INFO_SUBSCRIBER_HPP_INCLUDED

--- a/tests/account_info_hub_test.cpp
+++ b/tests/account_info_hub_test.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/components.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class RecordingAccountSubscriber final
+        : public optionx::components::IAccountInfoSubscriber {
+public:
+    void on_account_info(const optionx::AccountInfoUpdate& update) override {
+        statuses.push_back(update.status);
+        messages.push_back(update.message);
+    }
+
+    std::vector<optionx::AccountUpdateStatus> statuses;
+    std::vector<std::string> messages;
+};
+
+optionx::AccountInfoUpdate make_update(
+        optionx::AccountUpdateStatus status,
+        std::string message = {}) {
+    return optionx::AccountInfoUpdate(nullptr, status, std::move(message));
+}
+
+} // namespace
+
+TEST(AccountInfoHub, RoutesUpdatesAndReplaysLastUpdate) {
+    optionx::components::AccountInfoHub hub;
+
+    const auto first = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(first);
+
+    hub.publish(make_update(optionx::AccountUpdateStatus::CONNECTING, "start"));
+
+    ASSERT_EQ(first->statuses.size(), 1u);
+    EXPECT_EQ(first->statuses[0], optionx::AccountUpdateStatus::CONNECTING);
+    EXPECT_EQ(first->messages[0], "start");
+
+    const auto late = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(late);
+
+    ASSERT_EQ(late->statuses.size(), 1u);
+    EXPECT_EQ(late->statuses[0], optionx::AccountUpdateStatus::CONNECTING);
+    EXPECT_EQ(late->messages[0], "start");
+
+    hub.publish(make_update(optionx::AccountUpdateStatus::CONNECTED, "ready"));
+
+    ASSERT_EQ(first->statuses.size(), 2u);
+    EXPECT_EQ(first->statuses[1], optionx::AccountUpdateStatus::CONNECTED);
+
+    ASSERT_EQ(late->statuses.size(), 2u);
+    EXPECT_EQ(late->statuses[1], optionx::AccountUpdateStatus::CONNECTED);
+}
+
+TEST(AccountInfoHub, RemovesSubscribersAndIgnoresDuplicateAdds) {
+    optionx::components::AccountInfoHub hub(false);
+
+    const auto first = std::make_shared<RecordingAccountSubscriber>();
+    const auto second = std::make_shared<RecordingAccountSubscriber>();
+
+    hub.add_subscriber(first);
+    hub.add_subscriber(first);
+    hub.add_subscriber(second);
+
+    EXPECT_EQ(hub.subscriber_count(), 2u);
+
+    hub.remove_subscriber(first.get());
+    hub.publish(make_update(optionx::AccountUpdateStatus::BALANCE_UPDATED));
+
+    EXPECT_TRUE(first->statuses.empty());
+
+    ASSERT_EQ(second->statuses.size(), 1u);
+    EXPECT_EQ(second->statuses[0], optionx::AccountUpdateStatus::BALANCE_UPDATED);
+}
+
+TEST(AccountInfoHub, BindsToAccountInfoCallback) {
+    optionx::components::AccountInfoHub hub;
+    optionx::account_info_callback_t callback;
+
+    const auto subscriber = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.bind_to(callback);
+    ASSERT_TRUE(static_cast<bool>(callback));
+
+    callback(make_update(optionx::AccountUpdateStatus::DISCONNECTED, "stop"));
+
+    ASSERT_EQ(subscriber->statuses.size(), 1u);
+    EXPECT_EQ(subscriber->statuses[0], optionx::AccountUpdateStatus::DISCONNECTED);
+    EXPECT_EQ(subscriber->messages[0], "stop");
+
+    const auto last_update = hub.last_update();
+    ASSERT_TRUE(last_update.has_value());
+    EXPECT_EQ(last_update->status, optionx::AccountUpdateStatus::DISCONNECTED);
+
+    hub.unbind_from(callback);
+    EXPECT_FALSE(static_cast<bool>(callback));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/account_info_hub_test.cpp
+++ b/tests/account_info_hub_test.cpp
@@ -8,16 +8,71 @@
 
 namespace {
 
+class TestAccountInfo final : public optionx::BaseAccountInfoData {
+public:
+    double balance = 0.0;
+
+    std::unique_ptr<optionx::BaseAccountInfoData> clone_unique() const override {
+        return std::make_unique<TestAccountInfo>(*this);
+    }
+
+    std::shared_ptr<optionx::BaseAccountInfoData> clone_shared() const override {
+        return std::make_shared<TestAccountInfo>(*this);
+    }
+
+protected:
+    bool get_info_bool(const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return false;
+    }
+
+    std::int64_t get_info_int64(const optionx::AccountInfoRequest& request) const override {
+        if (request.type == optionx::AccountInfoType::BALANCE) {
+            return static_cast<std::int64_t>(balance);
+        }
+        return 0;
+    }
+
+    double get_info_f64(const optionx::AccountInfoRequest& request) const override {
+        if (request.type == optionx::AccountInfoType::BALANCE) {
+            return balance;
+        }
+        return 0.0;
+    }
+
+    std::string get_info_str(const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return {};
+    }
+
+    optionx::AccountType get_info_account_type(
+            const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return optionx::AccountType::UNKNOWN;
+    }
+
+    optionx::CurrencyType get_info_currency(
+            const optionx::AccountInfoRequest& request) const override {
+        (void)request;
+        return optionx::CurrencyType::UNKNOWN;
+    }
+};
+
 class RecordingAccountSubscriber final
         : public optionx::components::IAccountInfoSubscriber {
 public:
     void on_account_info(const optionx::AccountInfoUpdate& update) override {
         statuses.push_back(update.status);
         messages.push_back(update.message);
+        if (update.account_info) {
+            balances.push_back(update.account_info->get_info<double>(
+                optionx::AccountInfoType::BALANCE));
+        }
     }
 
     std::vector<optionx::AccountUpdateStatus> statuses;
     std::vector<std::string> messages;
+    std::vector<double> balances;
 };
 
 optionx::AccountInfoUpdate make_update(
@@ -54,6 +109,25 @@ TEST(AccountInfoHub, RoutesUpdatesAndReplaysLastUpdate) {
 
     ASSERT_EQ(late->statuses.size(), 2u);
     EXPECT_EQ(late->statuses[1], optionx::AccountUpdateStatus::CONNECTED);
+}
+
+TEST(AccountInfoHub, RoutesStatusAndCurrentAccountSnapshot) {
+    optionx::components::AccountInfoHub hub;
+
+    auto account = std::make_shared<TestAccountInfo>();
+    account->balance = 1250.75;
+
+    const auto subscriber = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.publish(optionx::AccountInfoUpdate(
+        account,
+        optionx::AccountUpdateStatus::BALANCE_UPDATED));
+
+    ASSERT_EQ(subscriber->statuses.size(), 1u);
+    EXPECT_EQ(subscriber->statuses[0], optionx::AccountUpdateStatus::BALANCE_UPDATED);
+    ASSERT_EQ(subscriber->balances.size(), 1u);
+    EXPECT_DOUBLE_EQ(subscriber->balances[0], 1250.75);
 }
 
 TEST(AccountInfoHub, RemovesSubscribersAndIgnoresDuplicateAdds) {

--- a/tests/account_info_hub_test.cpp
+++ b/tests/account_info_hub_test.cpp
@@ -151,6 +151,31 @@ TEST(AccountInfoHub, RemovesSubscribersAndIgnoresDuplicateAdds) {
     EXPECT_EQ(second->statuses[0], optionx::AccountUpdateStatus::BALANCE_UPDATED);
 }
 
+TEST(AccountInfoHub, DuplicateAddDoesNotReplayLastUpdateAgain) {
+    optionx::components::AccountInfoHub hub;
+
+    const auto subscriber = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.publish(make_update(optionx::AccountUpdateStatus::CONNECTED, "ready"));
+
+    ASSERT_EQ(subscriber->statuses.size(), 1u);
+    EXPECT_EQ(subscriber->statuses[0], optionx::AccountUpdateStatus::CONNECTED);
+
+    hub.add_subscriber(subscriber);
+
+    EXPECT_EQ(hub.subscriber_count(), 1u);
+    ASSERT_EQ(subscriber->statuses.size(), 1u);
+    EXPECT_EQ(subscriber->messages[0], "ready");
+
+    const auto late = std::make_shared<RecordingAccountSubscriber>();
+    hub.add_subscriber(late);
+
+    ASSERT_EQ(late->statuses.size(), 1u);
+    EXPECT_EQ(late->statuses[0], optionx::AccountUpdateStatus::CONNECTED);
+    EXPECT_EQ(late->messages[0], "ready");
+}
+
 TEST(AccountInfoHub, BindsToAccountInfoCallback) {
     optionx::components::AccountInfoHub hub;
     optionx::account_info_callback_t callback;


### PR DESCRIPTION
﻿## Summary
- add `components::IAccountInfoSubscriber` and `components::AccountInfoHub` for fan-out from the platform `on_account_info()` callback
- document the account-info subscriber contract and keep broker-specific trading-condition streams out of this DTO path
- cover routing, replay, removal, callback binding, and add the test to Ubuntu Smoke

## Checks
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target account_info_hub_test -- -j1`
- `build-codex/account_info_hub_test.exe --gtest_brief=1`
- `cmake --build build-codex --target market_data_subscription_contract_test -- -j1`
- `build-codex/market_data_subscription_contract_test.exe --gtest_brief=1`
- `git diff --check`
