### PR TITLE
[codex] Add trading condition subscriber hub

### DIFF
--- a/.github/workflows/ubuntu-smoke.yml
+++ b/.github/workflows/ubuntu-smoke.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Run account_info_hub_test
         run: ./build-linux/account_info_hub_test --gtest_brief=1
 
+      - name: Build trading_condition_hub_test
+        run: cmake --build build-linux --target trading_condition_hub_test -j
+
+      - name: Run trading_condition_hub_test
+        run: ./build-linux/trading_condition_hub_test --gtest_brief=1
+
       - name: Build trade_manager_test
         run: cmake --build build-linux --target trade_manager_test -j
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,41 @@ if(OPTIONX_BUILD_EXAMPLES)
         )
     endif()
 
+    add_executable(trading_condition_hub_example examples/trading_condition_hub_example.cpp)
+
+    target_include_directories(trading_condition_hub_example PRIVATE
+        ${EXAMPLE_INCLUDE_DIRS}
+        ${EXAMPLE_DEPS_INCLUDE_DIRS}
+    )
+
+    target_link_directories(trading_condition_hub_example PRIVATE ${EXAMPLE_LIBRARY_DIRS})
+    target_compile_definitions(
+        trading_condition_hub_example PRIVATE
+        ${EXAMPLE_DEFINES}
+        LOGIT_BASE_PATH="${LOGIT_BASE_PATH_FWD}"
+    )
+    target_link_libraries(trading_condition_hub_example PRIVATE ${EXAMPLE_LIBS} optionx_cpp)
+
+    if(OPTIONX_BUILD_DEPS)
+        add_dependencies(trading_condition_hub_example mdbx-static AES)
+    endif()
+
+    foreach(dll ${EXAMPLE_DLL_FILES})
+        add_custom_command(TARGET trading_condition_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${dll}" "$<TARGET_FILE_DIR:trading_condition_hub_example>"
+        )
+    endforeach()
+
+    if(WIN32)
+        add_custom_command(TARGET trading_condition_hub_example POST_BUILD
+            COMMAND ${CMAKE_COMMAND}
+                -DOPTIONX_RUNTIME_DLL_DIR="${EXAMPLE_BUILD_LIBS_DIR}/bin"
+                -DOPTIONX_RUNTIME_TARGET_DIR="$<TARGET_FILE_DIR:trading_condition_hub_example>"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/copy_runtime_dlls.cmake"
+        )
+    endif()
+
     add_executable(market_data_hub_example examples/market_data_hub_example.cpp)
 
     target_include_directories(market_data_hub_example PRIVATE

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,9 @@ Currently maintained examples:
   `OPTIONX_INTRADE_EMAIL` and `OPTIONX_INTRADE_PASSWORD` from the environment.
 - `market_data_hub_example.cpp` demonstrates routing provider callbacks through
   `MarketDataHub` into an `IMarketDataSubscriber` implementation.
+- `trading_condition_hub_example.cpp` demonstrates routing payout, session and
+  expiration-limit changes through `TradingConditionHub`, plus querying the
+  merged current condition snapshot for a concrete symbol.
 - `trade_record_db_example.cpp` demonstrates basic `TradeRecordDB` usage.
 
 Old exploratory broker and component probes were removed because they referenced

--- a/examples/trading_condition_hub_example.cpp
+++ b/examples/trading_condition_hub_example.cpp
@@ -1,0 +1,118 @@
+#include <optionx_cpp/components.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+optionx::TradingConditionUpdate make_scope(std::string symbol) {
+    optionx::TradingConditionUpdate scope;
+    scope.symbol = std::move(symbol);
+    scope.platform_type = optionx::PlatformType::INTRADE_BAR;
+    scope.account_type = optionx::AccountType::DEMO;
+    scope.currency = optionx::CurrencyType::USD;
+    scope.option_type = optionx::OptionType::SPRINT;
+    return scope;
+}
+
+optionx::TradingConditionUpdate make_initial_condition(
+        std::string symbol,
+        double payout,
+        std::uint32_t min_duration,
+        std::uint32_t max_duration) {
+    auto update = make_scope(std::move(symbol));
+    update.market_open = true;
+    update.tradable = true;
+    update.payout = payout;
+    update.min_duration = min_duration;
+    update.max_duration = max_duration;
+    return update;
+}
+
+void print_optional_bool(const char* name, const std::optional<bool>& value) {
+    if (value) {
+        std::cout << ' ' << name << '=' << (*value ? "true" : "false");
+    }
+}
+
+template<class T>
+void print_optional_value(const char* name, const std::optional<T>& value) {
+    if (value) {
+        std::cout << ' ' << name << '=' << *value;
+    }
+}
+
+void print_condition(const char* prefix, const optionx::TradingConditionUpdate& update) {
+    std::cout << prefix
+              << " symbol=" << update.symbol
+              << " option=" << optionx::to_str(update.option_type);
+    print_optional_bool("market_open", update.market_open);
+    print_optional_bool("tradable", update.tradable);
+    print_optional_value("payout", update.payout);
+    print_optional_value("min_duration", update.min_duration);
+    print_optional_value("max_duration", update.max_duration);
+    print_optional_value("max_open_trades", update.max_open_trades);
+    if (!update.message.empty()) {
+        std::cout << " message=\"" << update.message << '"';
+    }
+    std::cout << '\n';
+}
+
+class ConditionRecorder final
+        : public optionx::components::ITradingConditionSubscriber {
+public:
+    explicit ConditionRecorder(std::string name)
+        : m_name(std::move(name)) {}
+
+    void on_trading_condition(
+            const optionx::TradingConditionUpdate& update) override {
+        updates.push_back(update);
+        const std::string prefix = "[" + m_name + "] update";
+        print_condition(prefix.c_str(), update);
+    }
+
+    std::vector<optionx::TradingConditionUpdate> updates;
+
+private:
+    std::string m_name;
+};
+
+} // namespace
+
+int main() {
+    optionx::components::TradingConditionHub hub;
+
+    // The hub stores weak references. Keep the subscriber alive while it should
+    // receive condition changes such as payout, session and expiration updates.
+    auto recorder = std::make_shared<ConditionRecorder>("bot");
+    hub.add_subscriber(recorder);
+
+    hub.publish(make_initial_condition("EUR/USD", 0.82, 60, 180));
+    hub.publish(make_initial_condition("BTCUSDT", 0.70, 60, 300));
+
+    // Broker updates can be partial. This event says that EUR/USD is closed and
+    // its max expiration changed; it intentionally does not repeat the payout.
+    auto eur_session_update = make_scope("EUR/USD");
+    eur_session_update.market_open = false;
+    eur_session_update.tradable = false;
+    eur_session_update.max_duration = 300u;
+    eur_session_update.message = "evening limits";
+    hub.publish(eur_session_update);
+
+    // Direct current-state query: the hub merged independent partial updates
+    // into one snapshot for this exact broker/symbol/account/option scope.
+    if (const auto state = hub.current_condition(make_scope("EUR/USD"))) {
+        print_condition("[query] current", *state);
+    }
+
+    // Late subscribers receive merged current snapshots, not the whole old log.
+    auto late_recorder = std::make_shared<ConditionRecorder>("late");
+    hub.add_subscriber(late_recorder);
+
+    return 0;
+}

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -220,23 +220,30 @@ Future market-data routing work:
 
 `TradingConditionUpdate` is the payload for broker trading conditions: payouts,
 symbol tradability, market open/closed state, amount limits, duration limits,
-refund limits and max open trades. All condition fields are optional because
-brokers can update them independently.
+refund limits and max open trades. Condition fields are optional because live
+broker messages can update them independently.
 
 `components::BaseTradingConditionHandler` bridges
 `events::TradingConditionUpdateEvent` into the platform callback exposed as
 `BaseTradingPlatform::on_trading_condition()`.
 
 `components::TradingConditionHub` is an optional fan-out adapter for that
-callback. It caches the latest update per `(platform_type, account_type,
-currency, option_type, symbol)` scope and may replay cached updates to late
-subscribers.
+callback. Live subscribers receive incoming updates as-is, while the hub cache
+merges optional fields into the current condition snapshot per
+`(platform_type, account_type, currency, option_type, symbol)` scope. Late
+subscribers may receive those merged snapshots immediately.
 
 Rules:
 
 - Use `AccountInfoUpdate` for account lifecycle and account metadata changes.
 - Use `TradingConditionUpdate` for broker trading constraints and payout/session
   changes.
+- `TradingConditionUpdate::merge_patch()` is snapshot merge logic, not event
+  history. A patch with only `market_open=false` must not erase cached payout or
+  expiration limits for the same scope.
+- `TradingConditionHub::current_condition(scope)` is the direct read path for a
+  concrete current condition state, for example the latest payout and expiration
+  limits for one symbol.
 - Do not encode trading-condition changes as fake ticks, bars or market-data
   status events. Market-data subscriptions report prices; condition subscribers
   report whether and how a trade can currently be opened.

--- a/guides/api-and-header-contracts.md
+++ b/guides/api-and-header-contracts.md
@@ -216,6 +216,31 @@ Future market-data routing work:
   subscribe from inside their own methods while keeping `IMarketDataSubscriber`
   as a pure receiving interface.
 
+## Trading Condition Subscriber Contract
+
+`TradingConditionUpdate` is the payload for broker trading conditions: payouts,
+symbol tradability, market open/closed state, amount limits, duration limits,
+refund limits and max open trades. All condition fields are optional because
+brokers can update them independently.
+
+`components::BaseTradingConditionHandler` bridges
+`events::TradingConditionUpdateEvent` into the platform callback exposed as
+`BaseTradingPlatform::on_trading_condition()`.
+
+`components::TradingConditionHub` is an optional fan-out adapter for that
+callback. It caches the latest update per `(platform_type, account_type,
+currency, option_type, symbol)` scope and may replay cached updates to late
+subscribers.
+
+Rules:
+
+- Use `AccountInfoUpdate` for account lifecycle and account metadata changes.
+- Use `TradingConditionUpdate` for broker trading constraints and payout/session
+  changes.
+- Do not encode trading-condition changes as fake ticks, bars or market-data
+  status events. Market-data subscriptions report prices; condition subscribers
+  report whether and how a trade can currently be opened.
+
 ## Typed Broker Result Pattern
 
 Broker HTTP adapters используют typed result wrappers, чтобы не смешивать

--- a/guides/platform-api-guide.md
+++ b/guides/platform-api-guide.md
@@ -39,6 +39,7 @@
 | `disconnect(callback)` | Публикует `DisconnectRequestEvent` | Реальное отключение делает manager |
 | `is_connected()` | Читает `AccountInfoType::CONNECTION_STATUS` | Источник правды - account info provider |
 | `get_info<T>(...)` | Typed read из account info | Нужен корректный ожидаемый тип |
+| `on_trading_condition()` | Подписаться на изменения payout/лимитов/доступности торговли | Возвращает `TradingConditionUpdate` |
 | `run(bool start_worker_thread = true)` | Добавляет initialize и loop tasks | `run(false)` требует ручного `process()` |
 | `process()` | Один тик task manager | Используй при внешнем event loop |
 | `shutdown()` | Остановить tasks/components и drain events | Idempotent; вызывается в destructor |

--- a/include/optionx_cpp/components.hpp
+++ b/include/optionx_cpp/components.hpp
@@ -26,5 +26,7 @@
 #include "components/BaseAccountInfoHandler.hpp"
 #include "components/IAccountInfoSubscriber.hpp"
 #include "components/AccountInfoHub.hpp"
+#include "components/BaseTradingConditionHandler.hpp"
+#include "components/TradingConditionHub.hpp"
 
 #endif // OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED

--- a/include/optionx_cpp/components.hpp
+++ b/include/optionx_cpp/components.hpp
@@ -27,6 +27,7 @@
 #include "components/IAccountInfoSubscriber.hpp"
 #include "components/AccountInfoHub.hpp"
 #include "components/BaseTradingConditionHandler.hpp"
+#include "components/ITradingConditionSubscriber.hpp"
 #include "components/TradingConditionHub.hpp"
 
 #endif // OPTIONX_HEADER_COMPONENTS_HPP_INCLUDED

--- a/include/optionx_cpp/components/BaseTradingConditionHandler.hpp
+++ b/include/optionx_cpp/components/BaseTradingConditionHandler.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#ifndef OPTIONX_HEADER_COMPONENTS_BASE_TRADING_CONDITION_HANDLER_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_BASE_TRADING_CONDITION_HANDLER_HPP_INCLUDED
+
+/// \file BaseTradingConditionHandler.hpp
+/// \brief Defines an event-to-callback handler for trading-condition updates.
+
+namespace optionx::components {
+
+    /// \class BaseTradingConditionHandler
+    /// \brief Subscribes to trading-condition events and invokes a callback.
+    class BaseTradingConditionHandler : public BaseComponent {
+    public:
+        /// \brief Constructs the handler and subscribes to condition updates.
+        /// \param bus Event bus used by the owning platform/component.
+        explicit BaseTradingConditionHandler(utils::EventBus& bus)
+            : BaseComponent(bus) {
+            subscribe<events::TradingConditionUpdateEvent>();
+        }
+
+        /// \brief Virtual destructor.
+        virtual ~BaseTradingConditionHandler() = default;
+
+        /// \brief Handles incoming events.
+        /// \param event Received event.
+        void on_event(const utils::Event* const event) override {
+            if (const auto* msg =
+                    dynamic_cast<const events::TradingConditionUpdateEvent*>(event)) {
+                handle_event(*msg);
+            }
+        }
+
+        /// \brief Returns a reference to the condition callback.
+        /// \return Callback invoked for trading-condition updates.
+        trading_condition_callback_t& on_trading_condition() {
+            return m_callback;
+        }
+
+    private:
+        trading_condition_callback_t m_callback; ///< Trading-condition callback.
+
+        /// \brief Processes an update event and invokes the callback.
+        /// \param event Trading-condition update event.
+        void handle_event(const events::TradingConditionUpdateEvent& event) {
+            TradingConditionUpdate update = event;
+            if (m_callback) m_callback(update);
+        }
+    };
+
+} // namespace optionx::components
+
+#endif // OPTIONX_HEADER_COMPONENTS_BASE_TRADING_CONDITION_HANDLER_HPP_INCLUDED

--- a/include/optionx_cpp/components/ITradingConditionSubscriber.hpp
+++ b/include/optionx_cpp/components/ITradingConditionSubscriber.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef OPTIONX_HEADER_COMPONENTS_ITRADING_CONDITION_SUBSCRIBER_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_ITRADING_CONDITION_SUBSCRIBER_HPP_INCLUDED
+
+/// \file ITradingConditionSubscriber.hpp
+/// \brief Defines the subscriber interface for broker trading-condition updates.
+
+namespace optionx::components {
+
+    /// \class ITradingConditionSubscriber
+    /// \brief Interface for consumers that receive broker trading-condition updates.
+    class ITradingConditionSubscriber {
+    public:
+        /// \brief Virtual destructor.
+        virtual ~ITradingConditionSubscriber() = default;
+
+        /// \brief Handles a trading-condition update.
+        /// \param update Trading-condition payload.
+        virtual void on_trading_condition(const TradingConditionUpdate& update) = 0;
+    };
+
+} // namespace optionx::components
+
+#endif // OPTIONX_HEADER_COMPONENTS_ITRADING_CONDITION_SUBSCRIBER_HPP_INCLUDED

--- a/include/optionx_cpp/components/TradingConditionHub.hpp
+++ b/include/optionx_cpp/components/TradingConditionHub.hpp
@@ -1,0 +1,222 @@
+#pragma once
+#ifndef OPTIONX_HEADER_COMPONENTS_TRADING_CONDITION_HUB_HPP_INCLUDED
+#define OPTIONX_HEADER_COMPONENTS_TRADING_CONDITION_HUB_HPP_INCLUDED
+
+/// \file TradingConditionHub.hpp
+/// \brief Defines subscriber fan-out helpers for trading-condition updates.
+
+namespace optionx::components {
+
+    /// \class ITradingConditionSubscriber
+    /// \brief Interface for consumers that receive broker trading-condition updates.
+    class ITradingConditionSubscriber {
+    public:
+        /// \brief Virtual destructor.
+        virtual ~ITradingConditionSubscriber() = default;
+
+        /// \brief Handles a trading-condition update.
+        /// \param update Trading-condition payload.
+        virtual void on_trading_condition(const TradingConditionUpdate& update) = 0;
+    };
+
+    /// \class TradingConditionHub
+    /// \brief Routes trading-condition updates to multiple subscribers.
+    class TradingConditionHub {
+    public:
+        /// \brief Constructs a trading-condition hub.
+        /// \param replay_cached_updates_to_new_subscribers Whether late
+        ///        subscribers receive cached latest updates immediately.
+        explicit TradingConditionHub(
+                bool replay_cached_updates_to_new_subscribers = true)
+            : m_replay_cached_updates_to_new_subscribers(
+                  replay_cached_updates_to_new_subscribers) {}
+
+        TradingConditionHub(const TradingConditionHub&) = delete;
+        TradingConditionHub& operator=(const TradingConditionHub&) = delete;
+        TradingConditionHub(TradingConditionHub&&) = delete;
+        TradingConditionHub& operator=(TradingConditionHub&&) = delete;
+
+        /// \brief Adds a shared subscriber.
+        /// \param subscriber Subscriber object; ignored when null.
+        void add_subscriber(
+                std::shared_ptr<ITradingConditionSubscriber> subscriber) {
+            if (!subscriber) return;
+            add_weak_subscriber(
+                std::weak_ptr<ITradingConditionSubscriber>(subscriber));
+        }
+
+        /// \brief Adds a weak subscriber.
+        /// \param subscriber Weak subscriber reference; ignored when expired.
+        void add_weak_subscriber(
+                std::weak_ptr<ITradingConditionSubscriber> subscriber) {
+            const auto locked = subscriber.lock();
+            if (!locked) return;
+
+            std::vector<TradingConditionUpdate> replay_updates;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                prune_expired_no_lock();
+                if (!contains_subscriber_no_lock(locked.get())) {
+                    m_subscribers.push_back(std::move(subscriber));
+                }
+                if (m_replay_cached_updates_to_new_subscribers) {
+                    replay_updates = m_cached_updates;
+                }
+            }
+
+            for (const auto& update : replay_updates) {
+                locked->on_trading_condition(update);
+            }
+        }
+
+        /// \brief Removes a subscriber by object address.
+        /// \param subscriber Subscriber object address.
+        void remove_subscriber(const ITradingConditionSubscriber* subscriber) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_subscribers.erase(
+                std::remove_if(
+                    m_subscribers.begin(),
+                    m_subscribers.end(),
+                    [subscriber](const std::weak_ptr<ITradingConditionSubscriber>& item) {
+                        const auto locked = item.lock();
+                        return !locked || locked.get() == subscriber;
+                    }),
+                m_subscribers.end());
+        }
+
+        /// \brief Removes all subscribers.
+        void clear_subscribers() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_subscribers.clear();
+        }
+
+        /// \brief Returns the number of live subscribers.
+        /// \return Count of non-expired subscribers.
+        std::size_t subscriber_count() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            std::size_t count = 0;
+            for (const auto& subscriber : m_subscribers) {
+                if (!subscriber.expired()) {
+                    ++count;
+                }
+            }
+            return count;
+        }
+
+        /// \brief Binds the hub to a trading-condition callback.
+        /// \param callback Callback to replace with this hub dispatcher.
+        void bind_to(trading_condition_callback_t& callback) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            callback = [this](const TradingConditionUpdate& update) {
+                publish(update);
+            };
+            m_bound_callback = &callback;
+        }
+
+        /// \brief Unbinds the hub from a callback if it is the current binding.
+        /// \param callback Callback to unbind.
+        void unbind_from(trading_condition_callback_t& callback) {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_bound_callback == &callback) {
+                callback = {};
+                m_bound_callback = nullptr;
+            }
+        }
+
+        /// \brief Publishes a trading-condition update.
+        /// \param update Trading-condition update payload.
+        void publish(TradingConditionUpdate update) {
+            std::vector<std::shared_ptr<ITradingConditionSubscriber>> subscribers;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                upsert_cached_update_no_lock(update);
+                prune_expired_no_lock();
+                subscribers.reserve(m_subscribers.size());
+                for (const auto& subscriber : m_subscribers) {
+                    if (auto locked = subscriber.lock()) {
+                        subscribers.push_back(std::move(locked));
+                    }
+                }
+            }
+
+            for (const auto& subscriber : subscribers) {
+                subscriber->on_trading_condition(update);
+            }
+        }
+
+        /// \brief Returns cached latest updates by condition key.
+        /// \return Copy of cached updates.
+        std::vector<TradingConditionUpdate> cached_updates() const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            return m_cached_updates;
+        }
+
+        /// \brief Clears cached updates.
+        void clear_cached_updates() {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_cached_updates.clear();
+        }
+
+    private:
+        mutable std::mutex m_mutex;
+        std::vector<std::weak_ptr<ITradingConditionSubscriber>> m_subscribers;
+        std::vector<TradingConditionUpdate> m_cached_updates;
+        trading_condition_callback_t* m_bound_callback = nullptr;
+        bool m_replay_cached_updates_to_new_subscribers = true;
+
+        /// \brief Checks whether two updates describe the same condition scope.
+        static bool same_condition_key(
+                const TradingConditionUpdate& left,
+                const TradingConditionUpdate& right) {
+            return left.symbol == right.symbol &&
+                   left.platform_type == right.platform_type &&
+                   left.account_type == right.account_type &&
+                   left.currency == right.currency &&
+                   left.option_type == right.option_type;
+        }
+
+        /// \brief Inserts or replaces a cached update by condition key.
+        void upsert_cached_update_no_lock(const TradingConditionUpdate& update) {
+            const auto it = std::find_if(
+                m_cached_updates.begin(),
+                m_cached_updates.end(),
+                [&update](const TradingConditionUpdate& cached) {
+                    return same_condition_key(cached, update);
+                });
+
+            if (it == m_cached_updates.end()) {
+                m_cached_updates.push_back(update);
+                return;
+            }
+
+            *it = update;
+        }
+
+        /// \brief Removes expired weak subscribers.
+        void prune_expired_no_lock() {
+            m_subscribers.erase(
+                std::remove_if(
+                    m_subscribers.begin(),
+                    m_subscribers.end(),
+                    [](const std::weak_ptr<ITradingConditionSubscriber>& item) {
+                        return item.expired();
+                    }),
+                m_subscribers.end());
+        }
+
+        /// \brief Checks whether a subscriber is already registered.
+        bool contains_subscriber_no_lock(
+                const ITradingConditionSubscriber* subscriber) const {
+            return std::any_of(
+                m_subscribers.begin(),
+                m_subscribers.end(),
+                [subscriber](const std::weak_ptr<ITradingConditionSubscriber>& item) {
+                    const auto locked = item.lock();
+                    return locked && locked.get() == subscriber;
+                });
+        }
+    };
+
+} // namespace optionx::components
+
+#endif // OPTIONX_HEADER_COMPONENTS_TRADING_CONDITION_HUB_HPP_INCLUDED

--- a/include/optionx_cpp/components/TradingConditionHub.hpp
+++ b/include/optionx_cpp/components/TradingConditionHub.hpp
@@ -7,20 +7,8 @@
 
 namespace optionx::components {
 
-    /// \class ITradingConditionSubscriber
-    /// \brief Interface for consumers that receive broker trading-condition updates.
-    class ITradingConditionSubscriber {
-    public:
-        /// \brief Virtual destructor.
-        virtual ~ITradingConditionSubscriber() = default;
-
-        /// \brief Handles a trading-condition update.
-        /// \param update Trading-condition payload.
-        virtual void on_trading_condition(const TradingConditionUpdate& update) = 0;
-    };
-
     /// \class TradingConditionHub
-    /// \brief Routes trading-condition updates to multiple subscribers.
+    /// \brief Routes trading-condition deltas and keeps merged condition snapshots.
     class TradingConditionHub {
     public:
         /// \brief Constructs a trading-condition hub.
@@ -37,6 +25,9 @@ namespace optionx::components {
         TradingConditionHub& operator=(TradingConditionHub&&) = delete;
 
         /// \brief Adds a shared subscriber.
+        /// \details The hub stores only a weak reference; the caller must keep
+        ///          the shared subscriber alive while it should receive trading
+        ///          condition callbacks.
         /// \param subscriber Subscriber object; ignored when null.
         void add_subscriber(
                 std::shared_ptr<ITradingConditionSubscriber> subscriber) {
@@ -56,10 +47,12 @@ namespace optionx::components {
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
                 prune_expired_no_lock();
+                bool inserted = false;
                 if (!contains_subscriber_no_lock(locked.get())) {
                     m_subscribers.push_back(std::move(subscriber));
+                    inserted = true;
                 }
-                if (m_replay_cached_updates_to_new_subscribers) {
+                if (inserted && m_replay_cached_updates_to_new_subscribers) {
                     replay_updates = m_cached_updates;
                 }
             }
@@ -124,6 +117,9 @@ namespace optionx::components {
         }
 
         /// \brief Publishes a trading-condition update.
+        /// \details Live subscribers receive the update as-is. The internal
+        ///          cache merges optional fields by condition scope and can be
+        ///          queried as the current condition snapshot.
         /// \param update Trading-condition update payload.
         void publish(TradingConditionUpdate update) {
             std::vector<std::shared_ptr<ITradingConditionSubscriber>> subscribers;
@@ -144,11 +140,29 @@ namespace optionx::components {
             }
         }
 
-        /// \brief Returns cached latest updates by condition key.
-        /// \return Copy of cached updates.
+        /// \brief Returns cached current condition snapshots.
+        /// \return Copy of merged cached snapshots.
         std::vector<TradingConditionUpdate> cached_updates() const {
             std::lock_guard<std::mutex> lock(m_mutex);
             return m_cached_updates;
+        }
+
+        /// \brief Returns the cached current condition for an exact scope.
+        /// \param scope Identity fields describing the requested condition scope.
+        /// \return Cached merged snapshot, or `std::nullopt`.
+        std::optional<TradingConditionUpdate> current_condition(
+                const TradingConditionUpdate& scope) const {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            const auto it = std::find_if(
+                m_cached_updates.begin(),
+                m_cached_updates.end(),
+                [&scope](const TradingConditionUpdate& cached) {
+                    return cached.same_scope(scope);
+                });
+            if (it == m_cached_updates.end()) {
+                return std::nullopt;
+            }
+            return *it;
         }
 
         /// \brief Clears cached updates.
@@ -164,24 +178,13 @@ namespace optionx::components {
         trading_condition_callback_t* m_bound_callback = nullptr;
         bool m_replay_cached_updates_to_new_subscribers = true;
 
-        /// \brief Checks whether two updates describe the same condition scope.
-        static bool same_condition_key(
-                const TradingConditionUpdate& left,
-                const TradingConditionUpdate& right) {
-            return left.symbol == right.symbol &&
-                   left.platform_type == right.platform_type &&
-                   left.account_type == right.account_type &&
-                   left.currency == right.currency &&
-                   left.option_type == right.option_type;
-        }
-
-        /// \brief Inserts or replaces a cached update by condition key.
+        /// \brief Inserts or merges a cached update by condition scope.
         void upsert_cached_update_no_lock(const TradingConditionUpdate& update) {
             const auto it = std::find_if(
                 m_cached_updates.begin(),
                 m_cached_updates.end(),
                 [&update](const TradingConditionUpdate& cached) {
-                    return same_condition_key(cached, update);
+                    return cached.same_scope(update);
                 });
 
             if (it == m_cached_updates.end()) {
@@ -189,7 +192,7 @@ namespace optionx::components {
                 return;
             }
 
-            *it = update;
+            it->merge_patch(update);
         }
 
         /// \brief Removes expired weak subscribers.

--- a/include/optionx_cpp/components/TradingConditionHub.hpp
+++ b/include/optionx_cpp/components/TradingConditionHub.hpp
@@ -100,6 +100,9 @@ namespace optionx::components {
         /// \param callback Callback to replace with this hub dispatcher.
         void bind_to(trading_condition_callback_t& callback) {
             std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_bound_callback && m_bound_callback != &callback) {
+                *m_bound_callback = {};
+            }
             callback = [this](const TradingConditionUpdate& update) {
                 publish(update);
             };

--- a/include/optionx_cpp/data/account.hpp
+++ b/include/optionx_cpp/data/account.hpp
@@ -1,11 +1,15 @@
 #pragma once
-#ifndef _OPTIONX_ACCOUNT_HPP_INCLUDED
-#define _OPTIONX_ACCOUNT_HPP_INCLUDED
+#ifndef OPTIONX_HEADER_DATA_ACCOUNT_HPP_INCLUDED
+#define OPTIONX_HEADER_DATA_ACCOUNT_HPP_INCLUDED
 
 /// \file account.hpp
 /// \brief Core components for account management and data querying.
 
 #include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 #include <kurlyk/types.hpp>
 
@@ -16,6 +20,7 @@
 #include "account/IAuthData.hpp"
 #include "account/BaseAccountInfoData.hpp"
 #include "account/AccountInfoUpdate.hpp"
+#include "account/TradingConditionUpdate.hpp"
 #include "account/ConnectionResult.hpp"
 
-#endif // _OPTIONX_ACCOUNT_HPP_INCLUDED
+#endif // OPTIONX_HEADER_DATA_ACCOUNT_HPP_INCLUDED

--- a/include/optionx_cpp/data/account/TradingConditionUpdate.hpp
+++ b/include/optionx_cpp/data/account/TradingConditionUpdate.hpp
@@ -1,0 +1,64 @@
+#pragma once
+#ifndef OPTIONX_HEADER_DATA_ACCOUNT_TRADING_CONDITION_UPDATE_HPP_INCLUDED
+#define OPTIONX_HEADER_DATA_ACCOUNT_TRADING_CONDITION_UPDATE_HPP_INCLUDED
+
+/// \file TradingConditionUpdate.hpp
+/// \brief Defines broker trading-condition update payloads.
+
+namespace optionx {
+
+    /// \struct TradingConditionUpdate
+    /// \brief Describes changed broker trading conditions for a symbol or account scope.
+    ///
+    /// Fields are optional because brokers often update payouts, market state,
+    /// limits and sessions independently. Empty identity fields mean that the
+    /// update applies to the provider/account scope rather than a concrete
+    /// symbol or option type.
+    struct TradingConditionUpdate {
+        std::string symbol; ///< Broker/provider symbol, or empty for account-wide updates.
+        PlatformType platform_type = PlatformType::UNKNOWN; ///< Source platform type.
+        AccountType account_type = AccountType::UNKNOWN; ///< Account type, if relevant.
+        CurrencyType currency = CurrencyType::UNKNOWN; ///< Account currency, if relevant.
+        OptionType option_type = OptionType::UNKNOWN; ///< Option type, if relevant.
+        std::int64_t timestamp = 0; ///< Update timestamp as Unix seconds; 0 means unknown.
+
+        std::optional<bool> market_open; ///< Whether the symbol/session is open.
+        std::optional<bool> tradable; ///< Whether new trades are currently accepted.
+        std::optional<double> payout; ///< Current payout ratio, 0.0-1.0.
+        std::optional<double> min_amount; ///< Minimum allowed trade amount.
+        std::optional<double> max_amount; ///< Maximum allowed trade amount.
+        std::optional<double> min_refund; ///< Minimum refund ratio, 0.0-1.0.
+        std::optional<double> max_refund; ///< Maximum refund ratio, 0.0-1.0.
+        std::optional<std::uint32_t> min_duration; ///< Minimum duration in seconds.
+        std::optional<std::uint32_t> max_duration; ///< Maximum duration in seconds.
+        std::optional<std::uint32_t> max_open_trades; ///< Maximum concurrent trades.
+        std::optional<std::int64_t> session_start; ///< Session start, seconds since midnight.
+        std::optional<std::int64_t> session_end; ///< Session end, seconds since midnight.
+        std::string message; ///< Optional diagnostic or broker-provided note.
+
+        /// \brief Returns true when no condition field is populated.
+        /// \return True if the update contains only identity/context fields.
+        bool empty() const noexcept {
+            return !market_open &&
+                   !tradable &&
+                   !payout &&
+                   !min_amount &&
+                   !max_amount &&
+                   !min_refund &&
+                   !max_refund &&
+                   !min_duration &&
+                   !max_duration &&
+                   !max_open_trades &&
+                   !session_start &&
+                   !session_end &&
+                   message.empty();
+        }
+    };
+
+    /// \brief Callback type for broker trading-condition updates.
+    using trading_condition_callback_t =
+        std::function<void(const TradingConditionUpdate&)>;
+
+} // namespace optionx
+
+#endif // OPTIONX_HEADER_DATA_ACCOUNT_TRADING_CONDITION_UPDATE_HPP_INCLUDED

--- a/include/optionx_cpp/data/account/TradingConditionUpdate.hpp
+++ b/include/optionx_cpp/data/account/TradingConditionUpdate.hpp
@@ -36,6 +36,39 @@ namespace optionx {
         std::optional<std::int64_t> session_end; ///< Session end, seconds since midnight.
         std::string message; ///< Optional diagnostic or broker-provided note.
 
+        /// \brief Checks whether another update belongs to the same condition scope.
+        /// \param other Update to compare with.
+        /// \return True when both updates address the same broker/symbol scope.
+        bool same_scope(const TradingConditionUpdate& other) const {
+            return symbol == other.symbol &&
+                   platform_type == other.platform_type &&
+                   account_type == other.account_type &&
+                   currency == other.currency &&
+                   option_type == other.option_type;
+        }
+
+        /// \brief Merges an incremental condition update into this snapshot.
+        /// \details Optional fields in `patch` replace this snapshot only when
+        ///          they are present, so independent payout/session/limit updates
+        ///          accumulate into one current condition state.
+        /// \param patch Incremental update for the same condition scope.
+        void merge_patch(const TradingConditionUpdate& patch) {
+            if (patch.timestamp != 0) timestamp = patch.timestamp;
+            if (patch.market_open) market_open = patch.market_open;
+            if (patch.tradable) tradable = patch.tradable;
+            if (patch.payout) payout = patch.payout;
+            if (patch.min_amount) min_amount = patch.min_amount;
+            if (patch.max_amount) max_amount = patch.max_amount;
+            if (patch.min_refund) min_refund = patch.min_refund;
+            if (patch.max_refund) max_refund = patch.max_refund;
+            if (patch.min_duration) min_duration = patch.min_duration;
+            if (patch.max_duration) max_duration = patch.max_duration;
+            if (patch.max_open_trades) max_open_trades = patch.max_open_trades;
+            if (patch.session_start) session_start = patch.session_start;
+            if (patch.session_end) session_end = patch.session_end;
+            if (!patch.message.empty()) message = patch.message;
+        }
+
         /// \brief Returns true when no condition field is populated.
         /// \return True if the update contains only identity/context fields.
         bool empty() const noexcept {

--- a/include/optionx_cpp/data/events.hpp
+++ b/include/optionx_cpp/data/events.hpp
@@ -17,6 +17,7 @@
 #include "events/WebSocketResultEvent.hpp"
 #include "events/AutoDomainSelectedEvent.hpp"
 #include "events/AccountInfoUpdateEvent.hpp"
+#include "events/TradingConditionUpdateEvent.hpp"
 #include "events/BalanceRequestEvent.hpp"
 #include "events/PriceUpdateEvent.hpp"
 #include "events/ConnectRequestEvent.hpp"

--- a/include/optionx_cpp/data/events/TradingConditionUpdateEvent.hpp
+++ b/include/optionx_cpp/data/events/TradingConditionUpdateEvent.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef OPTIONX_HEADER_DATA_EVENTS_TRADING_CONDITION_UPDATE_EVENT_HPP_INCLUDED
+#define OPTIONX_HEADER_DATA_EVENTS_TRADING_CONDITION_UPDATE_EVENT_HPP_INCLUDED
+
+/// \file TradingConditionUpdateEvent.hpp
+/// \brief Defines the event carrying broker trading-condition updates.
+
+namespace optionx::events {
+
+    /// \class TradingConditionUpdateEvent
+    /// \brief Event containing updated broker trading conditions.
+    class TradingConditionUpdateEvent : public utils::Event, public TradingConditionUpdate {
+    public:
+        /// \brief Constructs an event from a trading-condition update.
+        /// \param update Trading-condition update payload.
+        explicit TradingConditionUpdateEvent(TradingConditionUpdate update)
+            : TradingConditionUpdate(std::move(update)) {}
+
+        /// \brief Default virtual destructor.
+        virtual ~TradingConditionUpdateEvent() = default;
+
+        /// \brief Returns the runtime event type.
+        std::type_index type() const override {
+            return typeid(TradingConditionUpdateEvent);
+        }
+
+        /// \brief Returns the diagnostic event name.
+        const char* name() const override {
+            return "TradingConditionUpdateEvent";
+        }
+    };
+
+} // namespace optionx::events
+
+#endif // OPTIONX_HEADER_DATA_EVENTS_TRADING_CONDITION_UPDATE_EVENT_HPP_INCLUDED

--- a/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
+++ b/include/optionx_cpp/platforms/common/BaseTradingPlatform.hpp
@@ -15,7 +15,8 @@ namespace optionx::platforms {
             : m_account_info(std::move(account_info)),
               m_account_provider(m_account_info),
               m_event_bus(), m_task_manager(),
-              m_account_info_handler(m_event_bus) {
+              m_account_info_handler(m_event_bus),
+              m_trading_condition_handler(m_event_bus) {
         }
 
         virtual ~BaseTradingPlatform() noexcept {
@@ -25,6 +26,11 @@ namespace optionx::platforms {
         /// \brief Returns a reference to the account info callback.
         virtual account_info_callback_t& on_account_info() {
             return m_account_info_handler.on_account_info();
+        }
+
+        /// \brief Returns a reference to the trading-condition callback.
+        virtual trading_condition_callback_t& on_trading_condition() {
+            return m_trading_condition_handler.on_trading_condition();
         }
 
         /// \brief Configures the endpoint with a supported platform configuration DTO.
@@ -229,6 +235,7 @@ namespace optionx::platforms {
         utils::EventBus                      m_event_bus;
         utils::TaskManager                   m_task_manager;
         components::BaseAccountInfoHandler        m_account_info_handler;
+        components::BaseTradingConditionHandler    m_trading_condition_handler;
         std::vector<components::BaseComponent*>    m_components;
         std::mutex                           m_lifecycle_mutex;
         std::atomic<bool>                    m_running{false};

--- a/tests/trading_condition_hub_test.cpp
+++ b/tests/trading_condition_hub_test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <optionx_cpp/components.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+class RecordingTradingConditionSubscriber final
+        : public optionx::components::ITradingConditionSubscriber {
+public:
+    void on_trading_condition(
+            const optionx::TradingConditionUpdate& update) override {
+        updates.push_back(update);
+    }
+
+    std::vector<optionx::TradingConditionUpdate> updates;
+};
+
+optionx::TradingConditionUpdate make_condition(
+        std::string symbol,
+        double payout) {
+    optionx::TradingConditionUpdate update;
+    update.symbol = std::move(symbol);
+    update.platform_type = optionx::PlatformType::INTRADE_BAR;
+    update.option_type = optionx::OptionType::SPRINT;
+    update.payout = payout;
+    update.market_open = true;
+    return update;
+}
+
+} // namespace
+
+TEST(TradingConditionUpdate, ReportsWhetherConditionFieldsArePresent) {
+    optionx::TradingConditionUpdate update;
+    update.symbol = "EUR/USD";
+    EXPECT_TRUE(update.empty());
+
+    update.payout = 0.82;
+    EXPECT_FALSE(update.empty());
+}
+
+TEST(TradingConditionHub, RoutesUpdatesAndReplaysLatestCachedConditions) {
+    optionx::components::TradingConditionHub hub;
+
+    const auto first = std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(first);
+
+    hub.publish(make_condition("EUR/USD", 0.80));
+    hub.publish(make_condition("EUR/USD", 0.82));
+    hub.publish(make_condition("BTCUSDT", 0.70));
+
+    ASSERT_EQ(first->updates.size(), 3u);
+    EXPECT_DOUBLE_EQ(*first->updates[1].payout, 0.82);
+
+    const auto late = std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(late);
+
+    ASSERT_EQ(late->updates.size(), 2u);
+    EXPECT_EQ(late->updates[0].symbol, "EUR/USD");
+    EXPECT_DOUBLE_EQ(*late->updates[0].payout, 0.82);
+    EXPECT_EQ(late->updates[1].symbol, "BTCUSDT");
+    EXPECT_DOUBLE_EQ(*late->updates[1].payout, 0.70);
+}
+
+TEST(TradingConditionHub, BindsToTradingConditionCallback) {
+    optionx::components::TradingConditionHub hub;
+    optionx::trading_condition_callback_t callback;
+
+    const auto subscriber =
+        std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.bind_to(callback);
+    ASSERT_TRUE(static_cast<bool>(callback));
+
+    callback(make_condition("EUR/USD", 0.83));
+
+    ASSERT_EQ(subscriber->updates.size(), 1u);
+    EXPECT_EQ(subscriber->updates[0].symbol, "EUR/USD");
+    EXPECT_DOUBLE_EQ(*subscriber->updates[0].payout, 0.83);
+
+    hub.unbind_from(callback);
+    EXPECT_FALSE(static_cast<bool>(callback));
+}
+
+TEST(BaseTradingConditionHandler, RoutesEventBusUpdatesToCallback) {
+    optionx::utils::EventBus bus;
+    optionx::components::BaseTradingConditionHandler handler(bus);
+    std::vector<optionx::TradingConditionUpdate> received;
+
+    handler.on_trading_condition() =
+        [&received](const optionx::TradingConditionUpdate& update) {
+            received.push_back(update);
+        };
+
+    bus.notify_async(std::make_unique<optionx::events::TradingConditionUpdateEvent>(
+        make_condition("BTCUSDT", 0.71)));
+    bus.process();
+
+    ASSERT_EQ(received.size(), 1u);
+    EXPECT_EQ(received[0].symbol, "BTCUSDT");
+    EXPECT_DOUBLE_EQ(*received[0].payout, 0.71);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/trading_condition_hub_test.cpp
+++ b/tests/trading_condition_hub_test.cpp
@@ -172,6 +172,30 @@ TEST(TradingConditionHub, BindsToTradingConditionCallback) {
     EXPECT_FALSE(static_cast<bool>(callback));
 }
 
+TEST(TradingConditionHub, RebindingClearsPreviousCallback) {
+    optionx::components::TradingConditionHub hub;
+    optionx::trading_condition_callback_t first_callback;
+    optionx::trading_condition_callback_t second_callback;
+
+    const auto subscriber =
+        std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.bind_to(first_callback);
+    ASSERT_TRUE(static_cast<bool>(first_callback));
+
+    hub.bind_to(second_callback);
+
+    EXPECT_FALSE(static_cast<bool>(first_callback));
+    ASSERT_TRUE(static_cast<bool>(second_callback));
+
+    second_callback(make_condition("BTCUSDT", 0.71));
+
+    ASSERT_EQ(subscriber->updates.size(), 1u);
+    EXPECT_EQ(subscriber->updates[0].symbol, "BTCUSDT");
+    EXPECT_DOUBLE_EQ(*subscriber->updates[0].payout, 0.71);
+}
+
 TEST(BaseTradingConditionHandler, RoutesEventBusUpdatesToCallback) {
     optionx::utils::EventBus bus;
     optionx::components::BaseTradingConditionHandler handler(bus);

--- a/tests/trading_condition_hub_test.cpp
+++ b/tests/trading_condition_hub_test.cpp
@@ -25,10 +25,22 @@ optionx::TradingConditionUpdate make_condition(
     optionx::TradingConditionUpdate update;
     update.symbol = std::move(symbol);
     update.platform_type = optionx::PlatformType::INTRADE_BAR;
+    update.account_type = optionx::AccountType::DEMO;
+    update.currency = optionx::CurrencyType::USD;
     update.option_type = optionx::OptionType::SPRINT;
     update.payout = payout;
     update.market_open = true;
     return update;
+}
+
+optionx::TradingConditionUpdate make_scope(std::string symbol) {
+    optionx::TradingConditionUpdate scope;
+    scope.symbol = std::move(symbol);
+    scope.platform_type = optionx::PlatformType::INTRADE_BAR;
+    scope.account_type = optionx::AccountType::DEMO;
+    scope.currency = optionx::CurrencyType::USD;
+    scope.option_type = optionx::OptionType::SPRINT;
+    return scope;
 }
 
 } // namespace
@@ -40,6 +52,22 @@ TEST(TradingConditionUpdate, ReportsWhetherConditionFieldsArePresent) {
 
     update.payout = 0.82;
     EXPECT_FALSE(update.empty());
+}
+
+TEST(TradingConditionUpdate, MergesIndependentOptionalFields) {
+    auto snapshot = make_condition("EUR/USD", 0.82);
+
+    auto patch = make_scope("EUR/USD");
+    patch.market_open = false;
+    patch.max_duration = 300u;
+    snapshot.merge_patch(patch);
+
+    ASSERT_TRUE(snapshot.payout.has_value());
+    EXPECT_DOUBLE_EQ(*snapshot.payout, 0.82);
+    ASSERT_TRUE(snapshot.market_open.has_value());
+    EXPECT_FALSE(*snapshot.market_open);
+    ASSERT_TRUE(snapshot.max_duration.has_value());
+    EXPECT_EQ(*snapshot.max_duration, 300u);
 }
 
 TEST(TradingConditionHub, RoutesUpdatesAndReplaysLatestCachedConditions) {
@@ -63,6 +91,64 @@ TEST(TradingConditionHub, RoutesUpdatesAndReplaysLatestCachedConditions) {
     EXPECT_DOUBLE_EQ(*late->updates[0].payout, 0.82);
     EXPECT_EQ(late->updates[1].symbol, "BTCUSDT");
     EXPECT_DOUBLE_EQ(*late->updates[1].payout, 0.70);
+}
+
+TEST(TradingConditionHub, MergesCachedConditionSnapshotsByScope) {
+    optionx::components::TradingConditionHub hub;
+
+    const auto subscriber =
+        std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.publish(make_condition("EUR/USD", 0.82));
+
+    auto patch = make_scope("EUR/USD");
+    patch.market_open = false;
+    patch.min_duration = 60u;
+    patch.max_duration = 300u;
+    hub.publish(patch);
+
+    ASSERT_EQ(subscriber->updates.size(), 2u);
+    EXPECT_TRUE(subscriber->updates[0].payout.has_value());
+    EXPECT_FALSE(subscriber->updates[1].payout.has_value());
+    ASSERT_TRUE(subscriber->updates[1].market_open.has_value());
+    EXPECT_FALSE(*subscriber->updates[1].market_open);
+
+    const auto cached = hub.current_condition(make_scope("EUR/USD"));
+    ASSERT_TRUE(cached.has_value());
+    ASSERT_TRUE(cached->payout.has_value());
+    EXPECT_DOUBLE_EQ(*cached->payout, 0.82);
+    ASSERT_TRUE(cached->market_open.has_value());
+    EXPECT_FALSE(*cached->market_open);
+    ASSERT_TRUE(cached->min_duration.has_value());
+    EXPECT_EQ(*cached->min_duration, 60u);
+    ASSERT_TRUE(cached->max_duration.has_value());
+    EXPECT_EQ(*cached->max_duration, 300u);
+
+    const auto late = std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(late);
+
+    ASSERT_EQ(late->updates.size(), 1u);
+    ASSERT_TRUE(late->updates[0].payout.has_value());
+    EXPECT_DOUBLE_EQ(*late->updates[0].payout, 0.82);
+    ASSERT_TRUE(late->updates[0].market_open.has_value());
+    EXPECT_FALSE(*late->updates[0].market_open);
+}
+
+TEST(TradingConditionHub, DuplicateAddDoesNotReplayCachedSnapshotsAgain) {
+    optionx::components::TradingConditionHub hub;
+
+    const auto subscriber =
+        std::make_shared<RecordingTradingConditionSubscriber>();
+    hub.add_subscriber(subscriber);
+
+    hub.publish(make_condition("EUR/USD", 0.82));
+    ASSERT_EQ(subscriber->updates.size(), 1u);
+
+    hub.add_subscriber(subscriber);
+
+    EXPECT_EQ(hub.subscriber_count(), 1u);
+    EXPECT_EQ(subscriber->updates.size(), 1u);
 }
 
 TEST(TradingConditionHub, BindsToTradingConditionCallback) {


### PR DESCRIPTION
﻿## Summary
- add `TradingConditionUpdate` for payout, tradability, market/session, amount, duration, refund, and open-trade limit updates
- add `TradingConditionUpdateEvent`, `BaseTradingConditionHandler`, `BaseTradingPlatform::on_trading_condition()`, and `TradingConditionHub`
- document the account-vs-trading-condition split and cover hub/event routing in tests

## Checks
- `cmake -S . -B build-codex`
- `cmake --build build-codex --target trading_condition_hub_test -- -j1`
- `build-codex/trading_condition_hub_test.exe --gtest_brief=1`
- `cmake --build build-codex --target lifecycle_event_safety_test -- -j1`
- `build-codex/lifecycle_event_safety_test.exe --gtest_brief=1`
- `build-codex/market_data_subscription_contract_test.exe --gtest_brief=1`
- `git diff --check`
